### PR TITLE
Fix smoke test SLURM detection regex matching ReqNodeList

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -82,7 +82,7 @@ def _detect_slurm_env(jobid: str | None) -> dict[str, str | int] | None:
         info = result.stdout
         nodes_match = re.search(r"NumNodes=(\d+)", info)
         tasks_match = re.search(r"NumTasks=(\d+)", info)
-        nodelist_match = re.search(r"NodeList=(\S+)", info)
+        nodelist_match = re.search(r"(?<!\w)NodeList=(\S+)", info)
         state_match = re.search(r"JobState=(\w+)", info)
 
         if not all([nodes_match, nodelist_match, state_match]):


### PR DESCRIPTION
## Summary
- Fixes a regex bug in `tests/smoke/conftest.py` where `_detect_slurm_env` matched `ReqNodeList=(null)` instead of `NodeList=<hosts>` from `scontrol show job` output
- Caused `master_addr='(null)'`, which broke torchrun rendezvous on every `--slurm` smoke test run

## Root cause
`scontrol show job` output contains both fields on adjacent lines:

```
ReqNodeList=(null) ExcNodeList=(null)
NodeList=holygpu8a[10301-10302]
```

The regex `NodeList=(\S+)` greedy-matched `NodeList=(null)` from inside `ReqNodeList=(null)` first, since `NodeList` is a substring of `ReqNodeList`.

## Fix
Added a negative lookbehind `(?<!\w)` so the match only succeeds when `NodeList` is at a word boundary.

## Test plan
- [x] Verified root cause by reproducing the mismatch at the Python regex level
- [x] Ran a previously-failing smoke test after the fix: `test_dense_fsdp` passes in ~54s
- [ ] CI validation