### PR TITLE
Add srun-direct SLURM wrappers and 8-GPU MoE stress config

### DIFF
--- a/configs/train/moe_8gpu_stress.toml
+++ b/configs/train/moe_8gpu_stress.toml
@@ -1,0 +1,66 @@
+# 8-GPU MoE stress test: saturate 2 nodes × 4 H200 141GB.
+#
+# ~4B total params, ~1.8B active per token. TP=4 intra-node, DP_shard=2
+# across nodes (FSDP). All layers MoE, real FineWeb-Edu dataset, bf16.
+# Activation checkpointing on and large batch to saturate compute.
+
+[model]
+dim = 2048
+n_layers = 24
+n_heads = 16
+n_kv_heads = 4
+vocab_size = 128256
+ffn_dim_multiplier = 1.3
+max_seq_len = 4096
+rope_theta = 500000.0
+num_experts = 8
+moe_top_k = 2
+moe_frequency = 1
+moe_router = "softmax_topk"
+moe_aux_loss_weight = 0.01
+moe_capacity_factor = 0.0
+
+[train]
+batch_size = 10
+seq_len = 4096
+max_steps = 20
+grad_accum_steps = 1
+grad_clip_norm = 1.0
+compile_model = false
+mixed_precision = "bf16"
+activation_checkpointing = "full"
+
+[optimizer]
+name = "adamw"
+lr = 3e-4
+weight_decay = 0.1
+betas = [0.9, 0.95]
+eps = 1e-8
+fused = true
+
+[scheduler]
+name = "cosine"
+warmup_steps = 5
+min_lr_ratio = 0.1
+
+[data]
+dataset_path = "/n/holylfs06/LABS/kempner_shared/Everyone/testbed/text/fineweb-edu/tokenized/meta-llama-3/default"
+file_pattern = "tokenized_*.bin"
+num_workers = 4
+pin_memory = true
+prefetch_factor = 2
+
+[distributed]
+tp = 4
+dp_shard = 2
+nccl_timeout_sec = 600
+
+[checkpoint]
+dir = "checkpoints/moe_8gpu_stress"
+interval = 1000
+keep_last_n = 1
+
+[metrics]
+log_interval = 1
+enable_wandb = false
+enable_tensorboard = false

--- a/scripts/slurm/_dcgm_monitor.sh
+++ b/scripts/slurm/_dcgm_monitor.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Per-node GPU utilization monitor using dcgmi dmon.
+# Run one instance per node (srun --ntasks-per-node=1) alongside training.
+#
+# Fields (DCGM field IDs, see /usr/include/dcgm_fields.h or `dcgmi dmon -l`):
+#   203  = DCGM_FI_DEV_GPU_UTIL              (GPUTL, %)  — GPU active (coarse)
+#   1002 = DCGM_FI_PROF_SM_ACTIVE            (SMACT, 0..1) — fraction of SMs active
+#   1003 = DCGM_FI_PROF_SM_OCCUPANCY         (SMOCC, 0..1) — warp occupancy per SM
+#   1004 = DCGM_FI_PROF_PIPE_TENSOR_ACTIVE   (TENSO, 0..1) — tensor pipe active (MFU signal)
+#   1005 = DCGM_FI_PROF_DRAM_ACTIVE          (DRAMA, 0..1) — HBM bandwidth use
+#   252  = DCGM_FI_DEV_FB_USED               (FBUSD, MiB)
+#   155  = DCGM_FI_DEV_POWER_USAGE           (POWER, W)
+#   150  = DCGM_FI_DEV_GPU_TEMP              (TMPTR, C)
+#
+# Output: ${KEMPNERFORGE_LOG_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/logs/distributed}/dcgm_job${JOB}_${HOSTNAME}.log
+
+set -eo pipefail
+
+LOG_DIR="${KEMPNERFORGE_LOG_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/logs/distributed}"
+mkdir -p "$LOG_DIR"
+OUT="$LOG_DIR/dcgm_job${SLURM_JOB_ID}_$(hostname -s).log"
+
+echo "[$(hostname -s)] dcgmi dmon -> $OUT"
+
+# -d 1000ms sampling; runs until killed by the caller (training finishes)
+exec dcgmi dmon \
+    -e 203,1002,1003,1004,1005,252,155,150 \
+    -d 1000 \
+    > "$OUT" 2>&1

--- a/scripts/slurm/_run_distributed_tests.sh
+++ b/scripts/slurm/_run_distributed_tests.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Launch wrapper for running distributed tests under srun multi-node.
+# One srun task per GPU (srun-direct pattern, matching scripts/slurm/multinode.sh).
+#
+# Usage (from within a SLURM allocation):
+#   srun --jobid=<ID> --nodes=<N> --ntasks-per-node=<gpus_per_node> \
+#        --gpus-per-node=<G> --overlap \
+#        scripts/slurm/_run_distributed_tests.sh <pytest_target> [pytest args...]
+#
+# Each task sets RANK/LOCAL_RANK/WORLD_SIZE from SLURM env so pytest's
+# `RANK`-gated skip mark in tests/distributed/conftest.py does not fire.
+
+set -eo pipefail
+
+# Pytest discovers tests relative to CWD; run from the repo root (or pass a
+# target path as an argument). No hard-coded absolute path — the caller's
+# shell cwd is respected.
+
+# --- Distributed env vars (torchrun-compatible) ---
+export RANK=$SLURM_PROCID
+export LOCAL_RANK=$SLURM_LOCALID
+export WORLD_SIZE=$SLURM_NTASKS
+
+export MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+# Deterministic port from job ID; same value on every task so they rendezvous.
+export MASTER_PORT=$((15000 + SLURM_JOB_ID % 5000))
+
+# --- NCCL / Gloo: bind to IB ---
+IB_IFNAME=$(ip -br addr | awk '/^ib[0-9]+\s+UP\s+[0-9]/ {print $1; exit}')
+IB_IFNAME="${IB_IFNAME:-ib0}"
+export NCCL_SOCKET_IFNAME="$IB_IFNAME"
+export GLOO_SOCKET_IFNAME="$IB_IFNAME"
+export NCCL_IB_DISABLE=0
+export NCCL_IB_GID_INDEX=3
+export NCCL_TIMEOUT=1800
+
+# --- Per-rank logging on shared FS ---
+# All ranks (0..N-1) write to $LOG_DIR/job<JOBID>_rank<N>.log so failures on any
+# rank can be inspected. Rank 0 also streams to stdout so the terminal sees live
+# progress. LOG_DIR defaults to <cwd>/logs/distributed; override with
+# KEMPNERFORGE_LOG_DIR if you want a fixed absolute location.
+LOG_DIR="${KEMPNERFORGE_LOG_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/logs/distributed}"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/job${SLURM_JOB_ID}_rank${SLURM_PROCID}.log"
+
+if [ "$SLURM_PROCID" -eq 0 ]; then
+    echo "=== Distributed tests ==="
+    echo "Nodes:       $SLURM_JOB_NODELIST"
+    echo "World size:  $WORLD_SIZE"
+    echo "Master:      $MASTER_ADDR:$MASTER_PORT"
+    echo "IB:          $IB_IFNAME"
+    echo "Pytest args: $*"
+    echo "Log dir:     $LOG_DIR"
+    echo "Per-rank:    job${SLURM_JOB_ID}_rank<N>.log"
+    echo "========================="
+    # Rank 0: stream to stdout AND per-rank file. PIPESTATUS preserves pytest exit code.
+    uv run pytest "$@" 2>&1 | tee "$LOG_FILE"
+    exit "${PIPESTATUS[0]}"
+else
+    # Other ranks: per-rank file only.
+    exec uv run pytest "$@" > "$LOG_FILE" 2>&1
+fi

--- a/scripts/slurm/_run_training.sh
+++ b/scripts/slurm/_run_training.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Launch wrapper for running scripts/train.py under srun multi-node,
+# srun-direct pattern (one task per GPU). Mirrors scripts/slurm/multinode.sh
+# but for use inside an existing interactive allocation.
+#
+# Invoke from the repo root (same convention as multinode.sh):
+#   srun --jobid=<ID> --nodes=<N> --ntasks-per-node=<gpus_per_node> \
+#        --gpus-per-node=<G> --overlap \
+#        scripts/slurm/_run_training.sh <config.toml> [overrides...]
+#
+# Environment overrides:
+#   KEMPNERFORGE_LOG_DIR   where per-rank logs go (default: $SLURM_SUBMIT_DIR/logs/distributed or $PWD/logs/distributed)
+#
+# Per-rank logs go to $LOG_DIR/train_job<JOB>_rank<N>.log; rank 0 also
+# streams to stdout.
+
+set -eo pipefail
+
+CONFIG="${1:?Usage: _run_training.sh <config.toml> [overrides...]}"
+shift
+
+export RANK=$SLURM_PROCID
+export LOCAL_RANK=$SLURM_LOCALID
+export WORLD_SIZE=$SLURM_NTASKS
+
+export MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
+export MASTER_PORT=$((15000 + SLURM_JOB_ID % 5000))
+
+IB_IFNAME=$(ip -br addr | awk '/^ib[0-9]+\s+UP\s+[0-9]/ {print $1; exit}')
+IB_IFNAME="${IB_IFNAME:-ib0}"
+export NCCL_SOCKET_IFNAME="$IB_IFNAME"
+export GLOO_SOCKET_IFNAME="$IB_IFNAME"
+export NCCL_IB_DISABLE=0
+export NCCL_IB_GID_INDEX=3
+export NCCL_TIMEOUT=1800
+
+LOG_DIR="${KEMPNERFORGE_LOG_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/logs/distributed}"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/train_job${SLURM_JOB_ID}_rank${SLURM_PROCID}.log"
+
+if [ "$SLURM_PROCID" -eq 0 ]; then
+    echo "=== Training (srun-direct) ==="
+    echo "Nodes:       $SLURM_JOB_NODELIST"
+    echo "World size:  $WORLD_SIZE"
+    echo "Master:      $MASTER_ADDR:$MASTER_PORT"
+    echo "IB:          $IB_IFNAME"
+    echo "Config:      $CONFIG"
+    echo "Overrides:   $*"
+    echo "Log dir:     $LOG_DIR"
+    echo "=============================="
+    uv run python scripts/train.py "$CONFIG" "$@" 2>&1 | tee "$LOG_FILE"
+    exit "${PIPESTATUS[0]}"
+else
+    exec uv run python scripts/train.py "$CONFIG" "$@" > "$LOG_FILE" 2>&1
+fi


### PR DESCRIPTION
Closes #11

## Summary
- Three srun-direct wrapper scripts (`_run_training.sh`, `_run_distributed_tests.sh`, `_dcgm_monitor.sh`) for launching training, pytest, and per-node GPU monitoring inside an existing interactive SLURM allocation.
- `configs/train/moe_8gpu_stress.toml` — 2-node × 4-GPU H200 MoE stress config (9.2B params, TP=4 + FSDP dp_shard=2, `batch_size=10`, `activation_checkpointing="full"`).
- Wrappers follow `scripts/slurm/multinode.sh` convention — no hard-coded `cd`, no package-install refactor; `uv run python scripts/train.py` relative to the caller's cwd.

## Test plan
- [x] `uv run ruff check scripts/ configs/` passes
- [x] `uv run ruff format --check scripts/ configs/train/moe_8gpu_stress.toml` passes
- [x] 20-step training run on 2× H200 nodes via `_run_training.sh` completes cleanly (job 5339095). Loss starts at ln(128256) ≈ 11.99, aux_loss 24.0 → 24.12 across steps, expert_balance 0 → ~1e-3. Peak MFU 3.9%, peak tok/s 16,786.
- [x] All 14/14 distributed MoE tests pass via `_run_distributed_tests.sh`.
- [x] `dcgmi dmon` output captured for both nodes via `_dcgm_monitor.sh`; fields render correctly.