### PR TITLE
MoE: pack expert weights into single tensor per projection

### DIFF
--- a/kempnerforge/config/model.py
+++ b/kempnerforge/config/model.py
@@ -50,6 +50,7 @@ class ModelConfig:
     moe_sequence_aux_loss_weight: float = 0.0  # Sequence-level balance loss (0=off)
     moe_gradient_scale: bool = False  # Per-expert gradient normalization
     moe_bias_schedule: str = "constant"  # "constant", "cosine_decay", "linear_warmup"
+    moe_packed_experts: bool = False  # Pack expert weights into one tensor per projection
 
     def __post_init__(self) -> None:
         if self.n_kv_heads is None:

--- a/kempnerforge/distributed/expert_parallel.py
+++ b/kempnerforge/distributed/expert_parallel.py
@@ -351,19 +351,20 @@ def apply_expert_parallel(model: torch.nn.Module, device_mesh: DeviceMesh | None
         start = ep_rank * experts_per_rank
         end = start + experts_per_rank
 
-        # Prune to local experts only
-        local_experts = torch.nn.ModuleList([module.experts[i] for i in range(start, end)])
-        module.experts = local_experts
-
-        # Packed path: slice the stacked weight tensors along the expert dim.
-        # Replace the Parameter (can't resize in-place) with the sliced view.
         if module.packed_experts:
+            # Packed path: slice the stacked weight tensors along the expert dim.
+            # Replace the Parameter (can't resize in-place) with the sliced view.
+            # The unpacked ModuleList is already absent in packed mode.
             module.up_w = torch.nn.Parameter(module.up_w.data[start:end].clone().contiguous())
             module.down_w = torch.nn.Parameter(module.down_w.data[start:end].clone().contiguous())
             if module._is_swiglu:
                 module.gate_w = torch.nn.Parameter(
                     module.gate_w.data[start:end].clone().contiguous()
                 )
+        else:
+            # Unpacked path: prune the ModuleList to the local experts only.
+            local_experts = torch.nn.ModuleList([module.experts[i] for i in range(start, end)])
+            module.experts = local_experts
 
         # Store EP metadata
         module.ep_world_size = ep_size

--- a/kempnerforge/distributed/expert_parallel.py
+++ b/kempnerforge/distributed/expert_parallel.py
@@ -94,7 +94,7 @@ def ep_dispatch_and_compute(
     x: torch.Tensor,
     weights: torch.Tensor,
     indices: torch.Tensor,
-    experts: torch.nn.ModuleList,
+    moe: MoEMLP,
     ep_group: dist.ProcessGroup,
     local_expert_start: int,
     num_local_experts: int,
@@ -107,7 +107,8 @@ def ep_dispatch_and_compute(
         x: (num_tokens, dim) flattened token representations.
         weights: (num_tokens, top_k) routing weights.
         indices: (num_tokens, top_k) global expert indices.
-        experts: Local expert ModuleList (length = num_local_experts).
+        moe: The MoEMLP module. Holds either an nn.ModuleList of local experts
+            (unpacked) or packed expert tensors already sliced to the local range.
         ep_group: EP process group.
         local_expert_start: First global expert index on this rank.
         num_local_experts: Number of experts on this rank.
@@ -171,6 +172,7 @@ def ep_dispatch_and_compute(
         _GROUPED_MM_DTYPES,
         _HAS_GROUPED_MM,
         grouped_expert_forward,
+        grouped_expert_forward_packed,
     )
 
     use_grouped = _HAS_GROUPED_MM and received_tokens.dtype in _GROUPED_MM_DTYPES
@@ -183,40 +185,79 @@ def ep_dispatch_and_compute(
         local_ids = sorted_ids - local_expert_start
         tokens_per_expert = torch.bincount(local_ids, minlength=num_local_experts).tolist()
 
-        local_output_sorted = grouped_expert_forward(
-            sorted_recv,
-            tokens_per_expert,
-            experts,
-        )
+        if moe.packed_experts:
+            local_output_sorted = grouped_expert_forward_packed(
+                sorted_recv,
+                tokens_per_expert,
+                moe.up_w,
+                moe.down_w,
+                moe.gate_w if moe._is_swiglu else None,
+                moe._packed_activation,
+            )
+        else:
+            local_output_sorted = grouped_expert_forward(
+                sorted_recv,
+                tokens_per_expert,
+                moe.experts,
+            )
 
         # Unsort back to received order.
         unsort_by_expert = torch.argsort(sort_by_expert)
         local_output = local_output_sorted[unsort_by_expert]
 
-        # Ensure all expert params are in the autograd graph for FSDP2.
-        # grouped_expert_forward touches all expert weights via stacked matmul,
-        # but experts with zero tokens contribute only padding zeros. Add an
-        # explicit zero-valued contribution to guarantee AccumulateGrad fires.
-        for i in range(num_local_experts):
-            if tokens_per_expert[i] == 0:
-                for p in experts[i].parameters():
-                    local_output = local_output + p.sum() * 0
+        if moe.packed_experts:
+            # grouped_mm over the full packed tensor touches every expert row →
+            # AccumulateGrad on up_w/down_w/gate_w always fires when there is
+            # at least one token. If zero tokens arrived locally, grouped_mm
+            # short-circuits; add an explicit zero contribution to keep the
+            # packed params in the autograd graph for FSDP2.
+            if sum(tokens_per_expert) == 0:
+                _zero = moe.up_w.sum() * 0 + moe.down_w.sum() * 0
+                if moe._is_swiglu:
+                    _zero = _zero + moe.gate_w.sum() * 0
+                local_output = local_output + _zero
+        else:
+            # Unpacked: grouped_expert_forward stacks per-expert Linear weights
+            # into a temporary — experts with zero tokens never appear in the
+            # graph. Force AccumulateGrad to fire on each unused expert.
+            for i in range(num_local_experts):
+                if tokens_per_expert[i] == 0:
+                    for p in moe.experts[i].parameters():
+                        local_output = local_output + p.sum() * 0
     else:
         local_output = torch.zeros_like(received_tokens)
-        unused_expert_params: list[torch.nn.Parameter] = []
-        for i in range(num_local_experts):
-            global_expert_id = local_expert_start + i
-            mask = received_expert_ids == global_expert_id
-            if not mask.any():
-                unused_expert_params.extend(experts[i].parameters())
-                continue
-            local_output[mask] = experts[i](received_tokens[mask])
+        if moe.packed_experts:
+            any_computed = False
+            for i in range(num_local_experts):
+                global_expert_id = local_expert_start + i
+                mask = received_expert_ids == global_expert_id
+                if not mask.any():
+                    continue
+                local_output[mask] = moe._apply_packed_expert(received_tokens[mask], i)
+                any_computed = True
 
-        # FSDP2 requires every parameter's AccumulateGrad hook to fire during
-        # backward for reduce-scatter to complete.
-        if unused_expert_params:
-            _zero = sum(p.sum() for p in unused_expert_params) * 0
-            local_output = local_output + _zero
+            # If no local expert ran, packed params never entered the graph.
+            # Add zero contribution so FSDP2 reduce-scatter fires.
+            if not any_computed:
+                _zero = moe.up_w.sum() * 0 + moe.down_w.sum() * 0
+                if moe._is_swiglu:
+                    _zero = _zero + moe.gate_w.sum() * 0
+                local_output = local_output + _zero
+        else:
+            unused_expert_params: list[torch.nn.Parameter] = []
+            for i in range(num_local_experts):
+                global_expert_id = local_expert_start + i
+                mask = received_expert_ids == global_expert_id
+                if not mask.any():
+                    unused_expert_params.extend(moe.experts[i].parameters())
+                    continue
+                local_output[mask] = moe.experts[i](received_tokens[mask])
+
+            # FSDP2 requires every parameter's AccumulateGrad hook to fire during
+            # backward for reduce-scatter to complete.
+            if unused_expert_params:
+                _zero = sum(p.sum() for p in unused_expert_params) * 0
+                local_output = local_output + _zero
 
     # Per-expert gradient scaling: normalize by utilization ratio so
     # high-traffic experts don't dominate learning (DeepSeek-V3 Sec 3.2).
@@ -313,6 +354,16 @@ def apply_expert_parallel(model: torch.nn.Module, device_mesh: DeviceMesh | None
         # Prune to local experts only
         local_experts = torch.nn.ModuleList([module.experts[i] for i in range(start, end)])
         module.experts = local_experts
+
+        # Packed path: slice the stacked weight tensors along the expert dim.
+        # Replace the Parameter (can't resize in-place) with the sliced view.
+        if module.packed_experts:
+            module.up_w = torch.nn.Parameter(module.up_w.data[start:end].clone().contiguous())
+            module.down_w = torch.nn.Parameter(module.down_w.data[start:end].clone().contiguous())
+            if module._is_swiglu:
+                module.gate_w = torch.nn.Parameter(
+                    module.gate_w.data[start:end].clone().contiguous()
+                )
 
         # Store EP metadata
         module.ep_world_size = ep_size

--- a/kempnerforge/model/moe.py
+++ b/kempnerforge/model/moe.py
@@ -83,6 +83,68 @@ def grouped_expert_forward(
     return output
 
 
+def grouped_expert_forward_packed(
+    x_sorted: torch.Tensor,
+    tokens_per_expert: list[int],
+    up_w: torch.Tensor,
+    down_w: torch.Tensor,
+    gate_w: torch.Tensor | None,
+    activation,
+) -> torch.Tensor:
+    """Batched expert computation over pre-packed weights.
+
+    Same as ``grouped_expert_forward`` but consumes packed weight tensors
+    directly — no per-step ``torch.stack`` over an ``nn.ModuleList``.
+
+    Args:
+        x_sorted: (total_tokens, dim) token features sorted by expert index.
+        tokens_per_expert: Number of tokens assigned to each expert, in order.
+        up_w: (E, dim, hidden) packed up-projection weights.
+        down_w: (E, hidden, dim) packed down-projection weights.
+        gate_w: (E, dim, hidden) packed gate weights for SwiGLU, else None.
+        activation: Activation function applied to the up-projection output
+            when ``gate_w`` is None. SwiGLU hardcodes silu.
+
+    Returns:
+        (total_tokens, dim) expert outputs in the same sorted order as input.
+    """
+    num_experts = up_w.shape[0]
+    total_tokens, dim = x_sorted.shape
+    max_tokens = max(tokens_per_expert)
+
+    if max_tokens == 0 or total_tokens == 0:
+        return torch.zeros_like(x_sorted)
+
+    # Pad token groups into (E, max_tokens, dim) for uniform batch size.
+    x_padded = x_sorted.new_zeros(num_experts, max_tokens, dim)
+    offset = 0
+    for i, count in enumerate(tokens_per_expert):
+        if count > 0:
+            x_padded[i, :count] = x_sorted[offset : offset + count]
+        offset += count
+
+    # Grouped matmuls — 3 for SwiGLU, 2 for StandardMLP.
+    if gate_w is not None:
+        gate = torch._grouped_mm(x_padded, gate_w)  # (E, M, H)
+        up = torch._grouped_mm(x_padded, up_w)  # (E, M, H)
+        hidden = F.silu(gate) * up  # (E, M, H)
+    else:
+        hidden = torch._grouped_mm(x_padded, up_w)  # (E, M, H)
+        hidden = activation(hidden)
+
+    out_padded = torch._grouped_mm(hidden, down_w)  # (E, M, dim)
+
+    # Unpad back to flat sorted order.
+    output = torch.zeros_like(x_sorted)
+    offset = 0
+    for i, count in enumerate(tokens_per_expert):
+        if count > 0:
+            output[offset : offset + count] = out_padded[i, :count]
+        offset += count
+
+    return output
+
+
 def _apply_capacity(
     weights: torch.Tensor,
     indices: torch.Tensor,
@@ -176,6 +238,20 @@ class MoEMLP(nn.Module):
             else:
                 self._packed_activation = experts[0]._activation
 
+    def _apply_packed_expert(self, x: torch.Tensor, i: int) -> torch.Tensor:
+        """Apply packed expert ``i`` to ``x`` without grouped GEMM.
+
+        Used by the sequential fallback path. Matches the unpacked
+        SwiGLU/StandardMLP forward exactly (no bias, same matmul order).
+        """
+        up = x @ self.up_w[i]
+        if self._is_swiglu:
+            gate = x @ self.gate_w[i]
+            hidden = F.silu(gate) * up
+        else:
+            hidden = self._packed_activation(up)  # type: ignore[reportCallIssue]
+        return hidden @ self.down_w[i]
+
     def _local_forward(
         self,
         x_flat: torch.Tensor,
@@ -212,7 +288,17 @@ class MoEMLP(nn.Module):
                 sorted_expert_ids, minlength=self.num_experts
             ).tolist()
 
-            expert_out = grouped_expert_forward(x_sorted, tokens_per_expert, self.experts)
+            if self.packed_experts:
+                expert_out = grouped_expert_forward_packed(
+                    x_sorted,
+                    tokens_per_expert,
+                    self.up_w,
+                    self.down_w,
+                    self.gate_w if self._is_swiglu else None,
+                    self._packed_activation,
+                )
+            else:
+                expert_out = grouped_expert_forward(x_sorted, tokens_per_expert, self.experts)
 
             # Per-expert gradient scaling: normalize by utilization ratio so
             # high-traffic experts don't dominate learning (DeepSeek-V3 Sec 3.2).
@@ -246,7 +332,11 @@ class MoEMLP(nn.Module):
                 if not mask.any():
                     continue
                 expert_input = x_flat[mask]
-                expert_output = self.experts[i](expert_input)
+                expert_output = (
+                    self._apply_packed_expert(expert_input, i)
+                    if self.packed_experts
+                    else self.experts[i](expert_input)
+                )
                 # Per-expert gradient scaling (DeepSeek-V3 Sec 3.2)
                 if self.gradient_scale and self.training:
                     tokens_i = (indices == i).sum().detach().float()

--- a/kempnerforge/model/moe.py
+++ b/kempnerforge/model/moe.py
@@ -388,7 +388,7 @@ class MoEMLP(nn.Module):
                 x_flat,
                 weights,
                 indices,
-                self.experts,
+                self,
                 self.ep_group,  # type: ignore[reportArgumentType]
                 self.local_expert_start,
                 self.num_local_experts,

--- a/kempnerforge/model/moe.py
+++ b/kempnerforge/model/moe.py
@@ -205,7 +205,6 @@ class MoEMLP(nn.Module):
     ) -> None:
         super().__init__()
         self.router = router
-        self.experts = experts
         self.shared_expert = shared_expert
         self.num_experts = len(experts)
         self.capacity_factor = capacity_factor
@@ -218,11 +217,11 @@ class MoEMLP(nn.Module):
         self.local_expert_start: int = 0
         self.num_local_experts: int = len(experts)
 
-        # Packed expert weights: stack per-expert (out, in) Linear weights into
-        # (E, in, out) tensors at init so grouped GEMM can consume them zero-copy.
-        # Consumers (_local_forward, EP) still use self.experts; switch happens in
-        # subsequent steps. Activation function is captured here for the same reason.
         if packed_experts:
+            # Packed expert weights: stack per-expert (out, in) Linear weights into
+            # (E, in, out) tensors so grouped GEMM can consume them zero-copy.
+            # Drop the per-expert nn.ModuleList — the packed tensors are the
+            # sole source of truth. Tests / EP / FSDP2 read `self.up_w` etc.
             self._is_swiglu = hasattr(experts[0], "gate_proj")
             self.up_w = nn.Parameter(
                 torch.stack([e.up_proj.weight.t().contiguous() for e in experts])  # type: ignore[reportCallIssue, reportAttributeAccessIssue]
@@ -237,6 +236,8 @@ class MoEMLP(nn.Module):
                 self._packed_activation = F.silu
             else:
                 self._packed_activation = experts[0]._activation
+        else:
+            self.experts = experts
 
     def _apply_packed_expert(self, x: torch.Tensor, i: int) -> torch.Tensor:
         """Apply packed expert ``i`` to ``x`` without grouped GEMM.

--- a/kempnerforge/model/moe.py
+++ b/kempnerforge/model/moe.py
@@ -139,6 +139,7 @@ class MoEMLP(nn.Module):
         shared_expert: nn.Module | None = None,
         capacity_factor: float = 0.0,
         gradient_scale: bool = False,
+        packed_experts: bool = False,
     ) -> None:
         super().__init__()
         self.router = router
@@ -147,12 +148,33 @@ class MoEMLP(nn.Module):
         self.num_experts = len(experts)
         self.capacity_factor = capacity_factor
         self.gradient_scale = gradient_scale
+        self.packed_experts = packed_experts
 
         # EP attributes — set by apply_expert_parallel(); defaults = no EP
         self.ep_world_size: int = 1
         self.ep_group = None
         self.local_expert_start: int = 0
         self.num_local_experts: int = len(experts)
+
+        # Packed expert weights: stack per-expert (out, in) Linear weights into
+        # (E, in, out) tensors at init so grouped GEMM can consume them zero-copy.
+        # Consumers (_local_forward, EP) still use self.experts; switch happens in
+        # subsequent steps. Activation function is captured here for the same reason.
+        if packed_experts:
+            self._is_swiglu = hasattr(experts[0], "gate_proj")
+            self.up_w = nn.Parameter(
+                torch.stack([e.up_proj.weight.t().contiguous() for e in experts])  # type: ignore[reportCallIssue, reportAttributeAccessIssue]
+            )
+            self.down_w = nn.Parameter(
+                torch.stack([e.down_proj.weight.t().contiguous() for e in experts])  # type: ignore[reportCallIssue, reportAttributeAccessIssue]
+            )
+            if self._is_swiglu:
+                self.gate_w = nn.Parameter(
+                    torch.stack([e.gate_proj.weight.t().contiguous() for e in experts])  # type: ignore[reportCallIssue, reportAttributeAccessIssue]
+                )
+                self._packed_activation = F.silu
+            else:
+                self._packed_activation = experts[0]._activation
 
     def _local_forward(
         self,
@@ -304,6 +326,7 @@ def build_moe(
     gradient_scale: bool = False,
     sequence_aux_loss_weight: float = 0.0,
     bias_schedule: str = "constant",
+    packed_experts: bool = False,
 ) -> MoEMLP:
     """Build an MoE layer, composing router + experts from Registry.
 
@@ -319,6 +342,7 @@ def build_moe(
         gradient_scale: Per-expert gradient normalization.
         sequence_aux_loss_weight: Sequence-level balance loss weight (sigmoid router only).
         bias_schedule: Bias update rate schedule (sigmoid router only).
+        packed_experts: Pack expert weights into one tensor per projection.
     """
     router_builder = registry.get("router", router_type)
     router_kwargs: dict[str, object] = {}
@@ -341,4 +365,5 @@ def build_moe(
         shared_expert,
         capacity_factor=capacity_factor,
         gradient_scale=gradient_scale,
+        packed_experts=packed_experts,
     )

--- a/kempnerforge/model/transformer.py
+++ b/kempnerforge/model/transformer.py
@@ -62,6 +62,7 @@ class TransformerBlock(nn.Module):
                 gradient_scale=config.moe_gradient_scale,
                 sequence_aux_loss_weight=config.moe_sequence_aux_loss_weight,
                 bias_schedule=config.moe_bias_schedule,
+                packed_experts=config.moe_packed_experts,
             )
         else:
             self.mlp = build_mlp(

--- a/tests/distributed/test_ep.py
+++ b/tests/distributed/test_ep.py
@@ -216,7 +216,7 @@ class TestEPPacked:
                 assert p.grad is not None, f"No gradient for {name}"
 
     def test_ep_packed_grads_on_packed_params(self, ep_only_mesh):
-        """Backward fills grads on packed params, not on the local ModuleList experts."""
+        """Backward fills grads on packed params; packed MoE has no ModuleList."""
         model = Transformer(EP_CONFIG_PACKED).cuda()
         apply_expert_parallel(model, ep_only_mesh)
 
@@ -228,10 +228,7 @@ class TestEPPacked:
                 assert layer.mlp.up_w.grad is not None
                 assert layer.mlp.down_w.grad is not None
                 assert layer.mlp.gate_w.grad is not None
-                for expert in layer.mlp.experts:
-                    assert expert.up_proj.weight.grad is None
-                    assert expert.down_proj.weight.grad is None
-                    assert expert.gate_proj.weight.grad is None
+                assert not hasattr(layer.mlp, "experts")
 
     @pytest.mark.skipif(
         int(os.environ.get("WORLD_SIZE", "1")) < 4,

--- a/tests/distributed/test_ep.py
+++ b/tests/distributed/test_ep.py
@@ -27,6 +27,7 @@ pytestmark = pytest.mark.skipif(
 
 _BASE = dict(dim=128, n_layers=2, n_heads=4, n_kv_heads=2, vocab_size=512, max_seq_len=32)
 EP_CONFIG = ModelConfig(**_BASE, num_experts=4, moe_top_k=2)
+EP_CONFIG_PACKED = ModelConfig(**_BASE, num_experts=4, moe_top_k=2, moe_packed_experts=True)
 
 
 @pytest.fixture
@@ -177,3 +178,78 @@ class TestEPPlusFSDP:
         # All losses should be finite
         for i, v in enumerate(all_losses):
             assert torch.isfinite(v), f"Rank {i} loss not finite: {v.item()}"
+
+
+class TestEPPacked:
+    """Phase 17c: EP sharding with packed expert weights."""
+
+    def test_apply_slices_packed_tensors(self, ep_only_mesh):
+        """apply_expert_parallel slices up_w/down_w/gate_w along the expert dim."""
+        model = Transformer(EP_CONFIG_PACKED).cuda()
+        apply_expert_parallel(model, ep_only_mesh)
+
+        ep_size = ep_only_mesh["ep"].size()
+        experts_per_rank = EP_CONFIG_PACKED.num_experts // ep_size
+
+        for layer in model.layers.values():
+            if isinstance(layer.mlp, MoEMLP):
+                assert layer.mlp.up_w.shape[0] == experts_per_rank
+                assert layer.mlp.down_w.shape[0] == experts_per_rank
+                assert layer.mlp.gate_w.shape[0] == experts_per_rank  # SwiGLU
+                assert isinstance(layer.mlp.up_w, torch.nn.Parameter)
+                assert isinstance(layer.mlp.down_w, torch.nn.Parameter)
+                assert isinstance(layer.mlp.gate_w, torch.nn.Parameter)
+
+    def test_ep_forward_backward_packed(self, ep_only_mesh):
+        """Packed EP model forward + backward produces finite output and grads."""
+        model = Transformer(EP_CONFIG_PACKED).cuda()
+        apply_expert_parallel(model, ep_only_mesh)
+
+        tokens = torch.randint(0, 512, (1, 16), device="cuda")
+        out = model(tokens)
+        loss = out.sum()
+        assert torch.isfinite(torch.tensor(loss.item())), f"Loss not finite: {loss.item()}"
+        loss.backward()
+
+        for name, p in model.named_parameters():
+            if p.requires_grad:
+                assert p.grad is not None, f"No gradient for {name}"
+
+    def test_ep_packed_grads_on_packed_params(self, ep_only_mesh):
+        """Backward fills grads on packed params, not on the local ModuleList experts."""
+        model = Transformer(EP_CONFIG_PACKED).cuda()
+        apply_expert_parallel(model, ep_only_mesh)
+
+        tokens = torch.randint(0, 512, (2, 32), device="cuda")
+        model(tokens).sum().backward()
+
+        for layer in model.layers.values():
+            if isinstance(layer.mlp, MoEMLP):
+                assert layer.mlp.up_w.grad is not None
+                assert layer.mlp.down_w.grad is not None
+                assert layer.mlp.gate_w.grad is not None
+                for expert in layer.mlp.experts:
+                    assert expert.up_proj.weight.grad is None
+                    assert expert.down_proj.weight.grad is None
+                    assert expert.gate_proj.weight.grad is None
+
+    @pytest.mark.skipif(
+        int(os.environ.get("WORLD_SIZE", "1")) < 4,
+        reason="EP+FSDP requires >= 4 GPUs (dp=2, ep=2)",
+    )
+    def test_ep_plus_fsdp2_packed(self):
+        """Packed EP composes with FSDP2 on a 2D mesh."""
+        world_size = dist.get_world_size()
+        ep_size = 2
+        dp_size = world_size // ep_size
+        mesh = init_device_mesh("cuda", (dp_size, ep_size), mesh_dim_names=("dp_shard", "ep"))
+
+        model = Transformer(EP_CONFIG_PACKED).cuda()
+        apply_expert_parallel(model, mesh)
+        apply_fsdp2(model, mesh)
+
+        tokens = torch.randint(0, 512, (1, 16), device="cuda")
+        out = model(tokens)
+        loss = out.sum()
+        assert torch.isfinite(torch.tensor(loss.item()))
+        loss.backward()

--- a/tests/distributed/test_moe_distributed.py
+++ b/tests/distributed/test_moe_distributed.py
@@ -27,6 +27,7 @@ pytestmark = pytest.mark.skipif(
 # n_heads=8, n_kv_heads=4 divisible by TP=2 and TP=4
 _BASE = dict(dim=256, n_layers=4, n_heads=8, n_kv_heads=4, vocab_size=1000, max_seq_len=64)
 MOE_CONFIG = ModelConfig(**_BASE, num_experts=4, moe_top_k=2)
+MOE_PACKED_CONFIG = ModelConfig(**_BASE, num_experts=4, moe_top_k=2, moe_packed_experts=True)
 MOE_FREQ_CONFIG = ModelConfig(**_BASE, num_experts=4, moe_top_k=2, moe_frequency=2)
 MOE_SIGMOID_CONFIG = ModelConfig(
     **_BASE,
@@ -101,6 +102,48 @@ class TestMoEFSDP:
         loss = out.sum()
         assert torch.isfinite(loss)
         loss.backward()
+
+
+class TestMoEFSDPPacked:
+    """FSDP2 over packed MoE expert weights (no EP)."""
+
+    def test_packed_fsdp_forward_backward(self, distributed_env):
+        """Packed MoE + FSDP2 produces finite loss; packed params get grads."""
+        mesh = distributed_env
+        model = Transformer(MOE_PACKED_CONFIG).cuda()
+        apply_fsdp2(model, mesh)
+
+        tokens = torch.randint(0, 1000, (2, 32), device="cuda")
+        out = model(tokens)
+        loss = out.sum()
+        assert torch.isfinite(loss), f"Loss not finite: {loss.item()}"
+        loss.backward()
+
+        for layer in model.layers.values():
+            if isinstance(layer.mlp, MoEMLP):
+                assert not hasattr(layer.mlp, "experts")
+                assert layer.mlp.up_w.grad is not None
+                assert layer.mlp.down_w.grad is not None
+                assert layer.mlp.gate_w.grad is not None
+
+    def test_packed_fsdp_gradient_sync(self, distributed_env):
+        """Losses should match across DP ranks with packed experts + FSDP2."""
+        mesh = distributed_env
+        model = Transformer(MOE_PACKED_CONFIG).cuda()
+        apply_fsdp2(model, mesh)
+
+        torch.manual_seed(0)
+        tokens = torch.randint(0, 1000, (2, 32), device="cuda")
+        out = model(tokens)
+        loss = out.sum()
+
+        loss_val = loss.detach().clone()
+        all_losses = [torch.zeros_like(loss_val) for _ in range(dist.get_world_size())]
+        dist.all_gather(all_losses, loss_val)
+        for other in all_losses[1:]:
+            assert torch.allclose(all_losses[0], other, atol=1e-3), (
+                f"Packed MoE losses differ across ranks: {[v.item() for v in all_losses]}"
+            )
 
 
 class TestMoETP:

--- a/tests/unit/test_moe.py
+++ b/tests/unit/test_moe.py
@@ -902,6 +902,9 @@ class TestPackedExperts:
         assert isinstance(moe.up_w, torch.nn.Parameter)
         assert isinstance(moe.down_w, torch.nn.Parameter)
         assert isinstance(moe.gate_w, torch.nn.Parameter)
+        # Packed mode drops the per-expert ModuleList — packed tensors are the
+        # sole source of truth.
+        assert not hasattr(moe, "experts")
 
     def test_packed_standard_storage_no_gate(self):
         dim, hidden_dim, E = 64, 128, 4
@@ -919,19 +922,18 @@ class TestPackedExperts:
         assert moe.down_w.shape == (E, hidden_dim, dim)
         assert not hasattr(moe, "gate_w")
 
-    def test_packed_weights_match_individual(self):
-        """Packed tensors equal stacked individual expert weights."""
-        moe = build_moe(
-            dim=64,
-            hidden_dim=128,
-            num_experts=4,
-            top_k=2,
-            activation="silu",
-            packed_experts=True,
-        )
-        expected_up = torch.stack([e.up_proj.weight.t().contiguous() for e in moe.experts])
-        expected_down = torch.stack([e.down_proj.weight.t().contiguous() for e in moe.experts])
-        expected_gate = torch.stack([e.gate_proj.weight.t().contiguous() for e in moe.experts])
+    def test_packed_weights_initialized_from_individual_experts(self):
+        """MoEMLP(packed=True) seeds packed tensors from the input ModuleList."""
+        dim, hidden, E = 64, 128, 4
+        router = SoftmaxTopKRouter(dim=dim, num_experts=E, top_k=2)
+        experts = torch.nn.ModuleList([SwiGLUMLP(dim, hidden) for _ in range(E)])
+        # Snapshot expected packed weights BEFORE handing to MoEMLP (which drops
+        # the ModuleList in packed mode).
+        expected_up = torch.stack([e.up_proj.weight.t().contiguous() for e in experts])
+        expected_down = torch.stack([e.down_proj.weight.t().contiguous() for e in experts])
+        expected_gate = torch.stack([e.gate_proj.weight.t().contiguous() for e in experts])
+
+        moe = MoEMLP(router, experts, packed_experts=True)
         torch.testing.assert_close(moe.up_w.data, expected_up)
         torch.testing.assert_close(moe.down_w.data, expected_down)
         torch.testing.assert_close(moe.gate_w.data, expected_gate)
@@ -950,7 +952,7 @@ class TestPackedExperts:
         x = torch.randn(8, 128)
         torch.testing.assert_close(moe._packed_activation(x), torch.nn.functional.silu(x))
 
-    def test_packed_activation_standard_matches_expert(self):
+    def test_packed_activation_standard_matches_gelu(self):
         moe = build_moe(
             dim=64,
             hidden_dim=128,
@@ -960,7 +962,7 @@ class TestPackedExperts:
             packed_experts=True,
         )
         x = torch.randn(8, 128)
-        torch.testing.assert_close(moe._packed_activation(x), moe.experts[0]._activation(x))
+        torch.testing.assert_close(moe._packed_activation(x), torch.nn.functional.gelu(x))
 
     def test_transformer_propagates_packed_flag(self):
         config = ModelConfig(
@@ -1056,48 +1058,44 @@ class TestPackedExperts:
 
         torch.testing.assert_close(packed_out, unpacked_out, atol=1e-5, rtol=1e-5)
 
-    def test_sequential_packed_matches_unpacked_swiglu(self):
-        """MoEMLP forward on fp32 CPU (sequential path) matches unpacked output."""
-        torch.manual_seed(42)
-        moe = build_moe(
-            dim=64,
-            hidden_dim=128,
-            num_experts=4,
-            top_k=2,
-            activation="silu",
-            packed_experts=True,
+    def _build_matched_pair(self, activation: str):
+        """Build packed/unpacked MoEMLPs with byte-identical expert weights."""
+        import copy
+
+        dim, hidden, E = 64, 128, 4
+        router = SoftmaxTopKRouter(dim=dim, num_experts=E, top_k=2)
+        mlp_cls = SwiGLUMLP if activation == "silu" else StandardMLP
+        experts = torch.nn.ModuleList(
+            [
+                mlp_cls(dim, hidden)
+                if activation == "silu"
+                else mlp_cls(dim, hidden, activation=activation)
+                for _ in range(E)
+            ]
         )
-        moe.eval()
+
+        router_unpacked = copy.deepcopy(router)
+        experts_unpacked = copy.deepcopy(experts)
+
+        moe_packed = MoEMLP(router, experts, packed_experts=True)
+        moe_unpacked = MoEMLP(router_unpacked, experts_unpacked, packed_experts=False)
+        moe_packed.eval()
+        moe_unpacked.eval()
+        return moe_packed, moe_unpacked
+
+    def test_sequential_packed_matches_unpacked_swiglu(self):
+        """Packed MoE and unpacked MoE with identical weights produce identical output."""
+        torch.manual_seed(42)
+        moe_packed, moe_unpacked = self._build_matched_pair("silu")
         x = torch.randn(2, 16, 64)
-
-        out_packed = moe(x)
-
-        # Flip flag → sequential path consults ModuleList experts.
-        # Packed and unpacked weights are mathematically equivalent (same init).
-        moe.packed_experts = False
-        out_unpacked = moe(x)
-
-        torch.testing.assert_close(out_packed, out_unpacked, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(moe_packed(x), moe_unpacked(x), atol=1e-5, rtol=1e-5)
 
     def test_sequential_packed_matches_unpacked_standard(self):
-        """MoEMLP forward matches for StandardMLP (gelu) experts on sequential path."""
+        """Same equivalence check for StandardMLP (gelu) experts."""
         torch.manual_seed(42)
-        moe = build_moe(
-            dim=64,
-            hidden_dim=128,
-            num_experts=4,
-            top_k=2,
-            activation="gelu",
-            packed_experts=True,
-        )
-        moe.eval()
+        moe_packed, moe_unpacked = self._build_matched_pair("gelu")
         x = torch.randn(2, 16, 64)
-
-        out_packed = moe(x)
-        moe.packed_experts = False
-        out_unpacked = moe(x)
-
-        torch.testing.assert_close(out_packed, out_unpacked, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(moe_packed(x), moe_unpacked(x), atol=1e-5, rtol=1e-5)
 
     def test_packed_backward_grads_flow_to_packed_weights(self):
         """Backward through packed forward fills grads on up_w/down_w/gate_w."""
@@ -1117,9 +1115,8 @@ class TestPackedExperts:
         assert moe.down_w.grad is not None and moe.down_w.grad.abs().sum() > 0
         assert moe.gate_w.grad is not None and moe.gate_w.grad.abs().sum() > 0
 
-    def test_packed_unpacked_experts_receive_no_gradient(self):
-        """When packed, forward only reads packed params; ModuleList experts get no grads."""
-        torch.manual_seed(42)
+    def test_packed_named_parameters_has_no_expert_modulelist(self):
+        """Packed MoE exposes up_w/down_w/gate_w as the only MoE weight params."""
         moe = build_moe(
             dim=64,
             hidden_dim=128,
@@ -1128,13 +1125,12 @@ class TestPackedExperts:
             activation="silu",
             packed_experts=True,
         )
-        x = torch.randn(2, 16, 64)
-        moe(x).sum().backward()
-
-        for expert in moe.experts:
-            assert expert.up_proj.weight.grad is None
-            assert expert.down_proj.weight.grad is None
-            assert expert.gate_proj.weight.grad is None
+        names = {n for n, _ in moe.named_parameters()}
+        assert "up_w" in names
+        assert "down_w" in names
+        assert "gate_w" in names
+        # No per-expert Linear params remain.
+        assert not any(n.startswith("experts.") for n in names)
 
     def test_transformer_forward_backward_packed(self):
         """End-to-end Transformer forward + backward uses packed params exclusively."""
@@ -1152,6 +1148,4 @@ class TestPackedExperts:
             assert moe.up_w.grad is not None and moe.up_w.grad.abs().sum() > 0
             assert moe.down_w.grad is not None and moe.down_w.grad.abs().sum() > 0
             assert moe.gate_w.grad is not None and moe.gate_w.grad.abs().sum() > 0
-            # ModuleList experts are not on the forward path → no grads.
-            for expert in moe.experts:
-                assert expert.up_proj.weight.grad is None
+            assert not hasattr(moe, "experts")

--- a/tests/unit/test_moe.py
+++ b/tests/unit/test_moe.py
@@ -992,3 +992,166 @@ class TestPackedExperts:
         assert id(moe.up_w) in param_ids
         assert id(moe.down_w) in param_ids
         assert id(moe.gate_w) in param_ids
+
+    # ----- Phase 17b: packed forward equivalence -----
+
+    def test_grouped_packed_matches_unpacked_swiglu(self):
+        """grouped_expert_forward_packed matches grouped_expert_forward for SwiGLU."""
+        from kempnerforge.model.moe import (
+            _HAS_GROUPED_MM,
+            grouped_expert_forward,
+            grouped_expert_forward_packed,
+        )
+
+        if not _HAS_GROUPED_MM:
+            pytest.skip("torch._grouped_mm not available")
+
+        torch.manual_seed(42)
+        dim, hidden, E = 64, 128, 4
+        experts = torch.nn.ModuleList([SwiGLUMLP(dim, hidden) for _ in range(E)])
+        experts.eval()
+
+        tokens_per_expert = [5, 7, 3, 5]
+        x_sorted = torch.randn(sum(tokens_per_expert), dim)
+
+        unpacked_out = grouped_expert_forward(x_sorted, tokens_per_expert, experts)
+
+        up_w = torch.stack([e.up_proj.weight.t().contiguous() for e in experts])
+        down_w = torch.stack([e.down_proj.weight.t().contiguous() for e in experts])
+        gate_w = torch.stack([e.gate_proj.weight.t().contiguous() for e in experts])
+        packed_out = grouped_expert_forward_packed(
+            x_sorted, tokens_per_expert, up_w, down_w, gate_w, torch.nn.functional.silu
+        )
+
+        torch.testing.assert_close(packed_out, unpacked_out, atol=1e-5, rtol=1e-5)
+
+    def test_grouped_packed_matches_unpacked_standard(self):
+        """grouped_expert_forward_packed matches grouped_expert_forward for StandardMLP."""
+        from kempnerforge.model.moe import (
+            _HAS_GROUPED_MM,
+            grouped_expert_forward,
+            grouped_expert_forward_packed,
+        )
+
+        if not _HAS_GROUPED_MM:
+            pytest.skip("torch._grouped_mm not available")
+
+        torch.manual_seed(42)
+        dim, hidden, E = 64, 128, 4
+        experts = torch.nn.ModuleList(
+            [StandardMLP(dim, hidden, activation="gelu") for _ in range(E)]
+        )
+        experts.eval()
+
+        tokens_per_expert = [6, 4, 8, 2]
+        x_sorted = torch.randn(sum(tokens_per_expert), dim)
+
+        unpacked_out = grouped_expert_forward(x_sorted, tokens_per_expert, experts)
+
+        up_w = torch.stack([e.up_proj.weight.t().contiguous() for e in experts])
+        down_w = torch.stack([e.down_proj.weight.t().contiguous() for e in experts])
+        packed_out = grouped_expert_forward_packed(
+            x_sorted, tokens_per_expert, up_w, down_w, None, experts[0]._activation
+        )
+
+        torch.testing.assert_close(packed_out, unpacked_out, atol=1e-5, rtol=1e-5)
+
+    def test_sequential_packed_matches_unpacked_swiglu(self):
+        """MoEMLP forward on fp32 CPU (sequential path) matches unpacked output."""
+        torch.manual_seed(42)
+        moe = build_moe(
+            dim=64,
+            hidden_dim=128,
+            num_experts=4,
+            top_k=2,
+            activation="silu",
+            packed_experts=True,
+        )
+        moe.eval()
+        x = torch.randn(2, 16, 64)
+
+        out_packed = moe(x)
+
+        # Flip flag → sequential path consults ModuleList experts.
+        # Packed and unpacked weights are mathematically equivalent (same init).
+        moe.packed_experts = False
+        out_unpacked = moe(x)
+
+        torch.testing.assert_close(out_packed, out_unpacked, atol=1e-5, rtol=1e-5)
+
+    def test_sequential_packed_matches_unpacked_standard(self):
+        """MoEMLP forward matches for StandardMLP (gelu) experts on sequential path."""
+        torch.manual_seed(42)
+        moe = build_moe(
+            dim=64,
+            hidden_dim=128,
+            num_experts=4,
+            top_k=2,
+            activation="gelu",
+            packed_experts=True,
+        )
+        moe.eval()
+        x = torch.randn(2, 16, 64)
+
+        out_packed = moe(x)
+        moe.packed_experts = False
+        out_unpacked = moe(x)
+
+        torch.testing.assert_close(out_packed, out_unpacked, atol=1e-5, rtol=1e-5)
+
+    def test_packed_backward_grads_flow_to_packed_weights(self):
+        """Backward through packed forward fills grads on up_w/down_w/gate_w."""
+        torch.manual_seed(42)
+        moe = build_moe(
+            dim=64,
+            hidden_dim=128,
+            num_experts=4,
+            top_k=2,
+            activation="silu",
+            packed_experts=True,
+        )
+        x = torch.randn(2, 16, 64)
+        moe(x).sum().backward()
+
+        assert moe.up_w.grad is not None and moe.up_w.grad.abs().sum() > 0
+        assert moe.down_w.grad is not None and moe.down_w.grad.abs().sum() > 0
+        assert moe.gate_w.grad is not None and moe.gate_w.grad.abs().sum() > 0
+
+    def test_packed_unpacked_experts_receive_no_gradient(self):
+        """When packed, forward only reads packed params; ModuleList experts get no grads."""
+        torch.manual_seed(42)
+        moe = build_moe(
+            dim=64,
+            hidden_dim=128,
+            num_experts=4,
+            top_k=2,
+            activation="silu",
+            packed_experts=True,
+        )
+        x = torch.randn(2, 16, 64)
+        moe(x).sum().backward()
+
+        for expert in moe.experts:
+            assert expert.up_proj.weight.grad is None
+            assert expert.down_proj.weight.grad is None
+            assert expert.gate_proj.weight.grad is None
+
+    def test_transformer_forward_backward_packed(self):
+        """End-to-end Transformer forward + backward uses packed params exclusively."""
+        config = ModelConfig(**_SMALL, num_experts=4, moe_top_k=2, moe_packed_experts=True)
+        model = Transformer(config)
+        tokens = torch.randint(0, _SMALL["vocab_size"], (2, 16))
+
+        out = model(tokens)
+        assert out.shape == (2, 16, _SMALL["vocab_size"])
+        assert torch.isfinite(out).all()
+
+        out.sum().backward()
+        moe_layers = [m for m in model.modules() if isinstance(m, MoEMLP)]
+        for moe in moe_layers:
+            assert moe.up_w.grad is not None and moe.up_w.grad.abs().sum() > 0
+            assert moe.down_w.grad is not None and moe.down_w.grad.abs().sum() > 0
+            assert moe.gate_w.grad is not None and moe.gate_w.grad.abs().sum() > 0
+            # ModuleList experts are not on the forward path → no grads.
+            for expert in moe.experts:
+                assert expert.up_proj.weight.grad is None

--- a/tests/unit/test_moe.py
+++ b/tests/unit/test_moe.py
@@ -868,3 +868,127 @@ class TestMoESigmoidConfigValidation:
         logits.sum().backward()
         for name, p in model.named_parameters():
             assert p.grad is not None, f"{name} has no gradient"
+
+
+class TestPackedExperts:
+    """Phase 17a: packed expert weight storage in MoEMLP."""
+
+    def test_config_default_is_false(self):
+        config = ModelConfig(**_SMALL, num_experts=4, moe_top_k=2)
+        assert config.moe_packed_experts is False
+
+    def test_disabled_by_default_no_packed_attrs(self):
+        moe = build_moe(dim=64, hidden_dim=128, num_experts=4, top_k=2)
+        assert moe.packed_experts is False
+        assert not hasattr(moe, "up_w")
+        assert not hasattr(moe, "down_w")
+        assert not hasattr(moe, "gate_w")
+
+    def test_packed_swiglu_storage_shapes(self):
+        dim, hidden_dim, E = 64, 128, 4
+        moe = build_moe(
+            dim=dim,
+            hidden_dim=hidden_dim,
+            num_experts=E,
+            top_k=2,
+            activation="silu",
+            packed_experts=True,
+        )
+        assert moe.packed_experts is True
+        assert moe._is_swiglu is True
+        assert moe.up_w.shape == (E, dim, hidden_dim)
+        assert moe.down_w.shape == (E, hidden_dim, dim)
+        assert moe.gate_w.shape == (E, dim, hidden_dim)
+        assert isinstance(moe.up_w, torch.nn.Parameter)
+        assert isinstance(moe.down_w, torch.nn.Parameter)
+        assert isinstance(moe.gate_w, torch.nn.Parameter)
+
+    def test_packed_standard_storage_no_gate(self):
+        dim, hidden_dim, E = 64, 128, 4
+        moe = build_moe(
+            dim=dim,
+            hidden_dim=hidden_dim,
+            num_experts=E,
+            top_k=2,
+            activation="gelu",
+            packed_experts=True,
+        )
+        assert moe.packed_experts is True
+        assert moe._is_swiglu is False
+        assert moe.up_w.shape == (E, dim, hidden_dim)
+        assert moe.down_w.shape == (E, hidden_dim, dim)
+        assert not hasattr(moe, "gate_w")
+
+    def test_packed_weights_match_individual(self):
+        """Packed tensors equal stacked individual expert weights."""
+        moe = build_moe(
+            dim=64,
+            hidden_dim=128,
+            num_experts=4,
+            top_k=2,
+            activation="silu",
+            packed_experts=True,
+        )
+        expected_up = torch.stack([e.up_proj.weight.t().contiguous() for e in moe.experts])
+        expected_down = torch.stack([e.down_proj.weight.t().contiguous() for e in moe.experts])
+        expected_gate = torch.stack([e.gate_proj.weight.t().contiguous() for e in moe.experts])
+        torch.testing.assert_close(moe.up_w.data, expected_up)
+        torch.testing.assert_close(moe.down_w.data, expected_down)
+        torch.testing.assert_close(moe.gate_w.data, expected_gate)
+
+    def test_packed_activation_swiglu_is_silu(self):
+        moe = build_moe(
+            dim=64,
+            hidden_dim=128,
+            num_experts=4,
+            top_k=2,
+            activation="silu",
+            packed_experts=True,
+        )
+        # SwiGLU: outer activation handled by silu(gate) * up — the captured
+        # function is silu so the packed forward path can apply it directly.
+        x = torch.randn(8, 128)
+        torch.testing.assert_close(moe._packed_activation(x), torch.nn.functional.silu(x))
+
+    def test_packed_activation_standard_matches_expert(self):
+        moe = build_moe(
+            dim=64,
+            hidden_dim=128,
+            num_experts=4,
+            top_k=2,
+            activation="gelu",
+            packed_experts=True,
+        )
+        x = torch.randn(8, 128)
+        torch.testing.assert_close(moe._packed_activation(x), moe.experts[0]._activation(x))
+
+    def test_transformer_propagates_packed_flag(self):
+        config = ModelConfig(
+            **_SMALL,
+            num_experts=4,
+            moe_top_k=2,
+            moe_packed_experts=True,
+        )
+        model = Transformer(config)
+        moe_layers = [m for m in model.modules() if isinstance(m, MoEMLP)]
+        assert len(moe_layers) > 0
+        for moe in moe_layers:
+            assert moe.packed_experts is True
+            assert hasattr(moe, "up_w")
+            assert hasattr(moe, "down_w")
+            assert hasattr(moe, "gate_w")  # _SMALL uses silu → SwiGLU
+
+    def test_packed_params_registered_on_module(self):
+        """Packed tensors are nn.Parameters → discoverable via .parameters()."""
+        moe = build_moe(
+            dim=64,
+            hidden_dim=128,
+            num_experts=4,
+            top_k=2,
+            activation="silu",
+            packed_experts=True,
+        )
+        param_ids = {id(p) for p in moe.parameters()}
+        assert id(moe.up_w) in param_ids
+        assert id(moe.down_w) in param_ids
+        assert id(moe.gate_w) in param_ids


### PR DESCRIPTION
Closes #15

Packs per-expert weights into stacked `nn.Parameter` tensors behind `moe_packed_experts: bool = False`. Default off, existing configs produce identical behavior.

## Changes

Five commits, each keeping the default path green:

**17a — packed storage** (`model/moe.py`)
Adds `moe_packed_experts: bool = False` config flag. When True, `MoEMLP.__init__` builds `up_w`/`down_w`/`gate_w` `nn.Parameter` tensors of shape `(E, in, out)` from the per-expert ModuleList (`gate_w` SwiGLU-only), plus captures the activation function. Storage only — no consumers switched yet.

**17b — zero-copy grouped GEMM** (`model/moe.py`)
New `grouped_expert_forward_packed()` consumes the packed tensors directly. In packed mode, `_local_forward()` dispatches to it and eliminates the per-step `torch.stack([e.up_proj.weight.t() for e in experts])`. Sequential CPU fallback routes through `_apply_packed_expert(x, i)`. Unpacked path unchanged.

**17c — EP sharding via tensor slice** (`distributed/expert_parallel.py`)
`apply_expert_parallel` in packed mode also slices `up_w`/`down_w`/`gate_w` along the expert dim (ModuleList prune still runs — it's removed in 17d). `ep_dispatch_and_compute()` takes the `MoEMLP` (was: bare `ModuleList`) and branches on `packed_experts`: grouped path calls `grouped_expert_forward_packed`, sequential fallback calls `_apply_packed_expert` per local expert. Zero-token graph hooks preserved for FSDP2 reduce-scatter.

**17d — drop ModuleList in packed mode** (`model/moe.py`, `distributed/expert_parallel.py`)
`MoEMLP.__init__` no longer assigns `self.experts` when `packed_experts=True`. `apply_expert_parallel` replaces the unconditional ModuleList prune + optional packed slice with an `if/else` on `packed_experts`. Packed tensors become the sole source of truth. FSDP2 wrapping logic is untouched.

**Packed FSDP2 coverage** (`tests/distributed/test_moe_distributed.py`)
`TestEPPacked.test_ep_plus_fsdp2_packed` already covers packed+EP+FSDP2. Added `TestMoEFSDPPacked` (2 tests) for the EP=1 case (pure DP shard): packed forward+backward + per-rank loss match.

## Tests

- **Unit** (`tests/unit/test_moe.py`): 782 passed. New `TestPackedExperts` (16 tests) covers storage shapes, init from ModuleList, grouped+sequential forward matching unpacked, backward grads on packed params, activation selection, `named_parameters` has no expert ModuleList. Equivalence tests use `copy.deepcopy` to build byte-identical packed/unpacked pairs.
- **Distributed 4×H200** (`tests/distributed/`): 63 passed, 2 skipped. `TestEPPacked` (4 tests): EP slice shapes, forward+backward, grads on packed params, EP+FSDP2 composition. `TestMoEFSDPPacked` (2 tests): pure-DP+FSDP2.
- **E2E 4×H200** (`tests/e2e/ --e2e`): 28 passed, 1 skipped (7B `--slow`).
- `ruff check`, `ruff format --check`, `pyright` clean.

## Not in this PR

- **Benchmark tok/s at 8/16/64 experts** — follow-up.
- **FSDP wrap count doesn't drop.** `fully_shard` wraps `layer.mlp` (or `layer` when no EP) as a single unit in both modes, so wrap count is per-layer either way. Packing reduces the *number of Parameters inside* that wrap from 3N Linear weights to 3 tensors, collapsing FSDP2's per-parameter all-gathers into one per projection — validated via `named_parameters` and grad-attribution checks.