### PR TITLE
Persist WandB run ID across checkpoint resume

### DIFF
--- a/kempnerforge/checkpoint/manager.py
+++ b/kempnerforge/checkpoint/manager.py
@@ -140,7 +140,7 @@ class CheckpointManager:
         scheduler: Any | None = None,
         dataloader: Any | None = None,
         exclude_keys: list[str] | None = None,
-    ) -> tuple[int, int]:
+    ) -> tuple[int, int, dict[str, Any]]:
         """Load a checkpoint and restore all state.
 
         Args:
@@ -151,12 +151,13 @@ class CheckpointManager:
             exclude_keys: DCP state keys to skip (e.g., ["optimizer"] for fine-tuning).
 
         Returns:
-            Tuple of (step, tokens_seen).
+            Tuple of (step, tokens_seen, extra) where extra contains any
+            additional keys saved via ``build_train_state(extra=...)``.
         """
         ckpt_dir = self._resolve_load_path(path)
         if ckpt_dir is None:
             logger.info("No checkpoint found — starting from scratch")
-            return 0, 0
+            return 0, 0, {}
 
         logger.info(f"Loading checkpoint: {ckpt_dir}")
 
@@ -189,15 +190,15 @@ class CheckpointManager:
                 train_state = object_list[0]
 
             assert train_state is not None, "train_state broadcast failed"
-            step, tokens_seen = restore_train_state(
+            step, tokens_seen, extra = restore_train_state(
                 train_state,
                 scheduler=scheduler,
                 dataloader=dataloader,
             )
             logger.info(f"Resumed from step {step}, {tokens_seen:,} tokens seen")
-            return step, tokens_seen
+            return step, tokens_seen, extra
 
-        return 0, 0
+        return 0, 0, {}
 
     def _resolve_load_path(self, path: str | None = None) -> Path | None:
         """Resolve the checkpoint path to load from."""

--- a/kempnerforge/checkpoint/state.py
+++ b/kempnerforge/checkpoint/state.py
@@ -86,7 +86,7 @@ def restore_train_state(
     state: dict[str, Any],
     scheduler: Any | None = None,
     dataloader: Any | None = None,
-) -> tuple[int, int]:
+) -> tuple[int, int, dict[str, Any]]:
     """Restore the non-distributed portion of the training state.
 
     Args:
@@ -95,7 +95,8 @@ def restore_train_state(
         dataloader: Stateful dataloader to restore.
 
     Returns:
-        Tuple of (step, tokens_seen).
+        Tuple of (step, tokens_seen, extra) where extra contains any
+        additional keys saved via build_train_state(extra=...).
     """
     step = state.get("step", 0)
     tokens_seen = state.get("tokens_seen", 0)
@@ -112,4 +113,7 @@ def restore_train_state(
         dataloader.load_state_dict(state["dataloader"])
         logger.info("Restored dataloader state")
 
-    return step, tokens_seen
+    _standard_keys = {"step", "tokens_seen", "rng", "scheduler", "dataloader"}
+    extra = {k: v for k, v in state.items() if k not in _standard_keys}
+
+    return step, tokens_seen, extra

--- a/kempnerforge/config/metrics.py
+++ b/kempnerforge/config/metrics.py
@@ -14,6 +14,7 @@ class MetricsConfig:
     enable_tensorboard: bool = False
     wandb_project: str = "kempnerforge"
     wandb_run_name: str | None = None  # None -> auto-generated
+    wandb_run_id: str = ""  # Restored from checkpoint on resume; empty = new run
     tensorboard_dir: str = "tb_logs"
 
     def __post_init__(self) -> None:

--- a/kempnerforge/metrics/tracker.py
+++ b/kempnerforge/metrics/tracker.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from typing import Any
 
 from kempnerforge.config.schema import JobConfig, MetricsConfig
 from kempnerforge.metrics.logger import format_metrics, get_logger
@@ -245,11 +246,15 @@ class WandBBackend(_LoggingBackend):
         try:
             import wandb
 
-            self._run = wandb.init(
-                project=self._config.wandb_project,
-                name=self._config.wandb_run_name,
-                resume="allow",
-            )
+            init_kwargs: dict[str, Any] = {
+                "project": self._config.wandb_project,
+                "name": self._config.wandb_run_name,
+                "resume": "allow",
+            }
+            if self._config.wandb_run_id:
+                init_kwargs["id"] = self._config.wandb_run_id
+            self._run = wandb.init(**init_kwargs)
+            self._config.wandb_run_id = self._run.id
             logger.info(f"WandB initialized: {self._run.url}")
         except ImportError:
             logger.warning("wandb not installed — disabling WandB backend")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -195,10 +195,12 @@ def main() -> None:
     resume_path = resolve_resume_path(config.checkpoint.dir)
     step, tokens_seen = 0, 0
     if resume_path or config.checkpoint.load_path:
-        step, tokens_seen = ckpt_mgr.load(
+        step, tokens_seen, ckpt_extra_loaded = ckpt_mgr.load(
             path=str(resume_path) if resume_path else None,
             scheduler=scheduler,
         )
+        if ckpt_extra_loaded.get("wandb_run_id"):
+            config.metrics.wandb_run_id = ckpt_extra_loaded["wandb_run_id"]
 
     # --- Metrics ---
     tracker = MetricsTracker(config, num_gpus=world_size)
@@ -752,8 +754,10 @@ def main() -> None:
         if prof is not None:
             prof.step()
 
-        # Checkpoint (include phase index for exact resumption)
-        ckpt_extra = {"phase_idx": current_phase_idx} if active_phases else None
+        # Checkpoint (include phase index + wandb run ID for exact resumption)
+        ckpt_extra = {"phase_idx": current_phase_idx} if active_phases else {}
+        if config.metrics.wandb_run_id:
+            ckpt_extra["wandb_run_id"] = config.metrics.wandb_run_id
         if step % config.checkpoint.interval == 0:
             ckpt_mgr.save(
                 step=step,

--- a/tests/unit/test_checkpoint.py
+++ b/tests/unit/test_checkpoint.py
@@ -91,9 +91,10 @@ class TestBuildTrainState:
 class TestRestoreTrainState:
     def test_restores_step_and_tokens(self):
         state = {"step": 42, "tokens_seen": 99999}
-        step, tokens = restore_train_state(state)
+        step, tokens, extra = restore_train_state(state)
         assert step == 42
         assert tokens == 99999
+        assert extra == {}
 
     def test_restores_scheduler(self):
         # Build a scheduler, step it, save its state
@@ -133,9 +134,18 @@ class TestRestoreTrainState:
         assert torch.equal(a, b)
 
     def test_defaults_for_missing_keys(self):
-        step, tokens = restore_train_state({})
+        step, tokens, extra = restore_train_state({})
         assert step == 0
         assert tokens == 0
+        assert extra == {}
+
+    def test_extra_keys_roundtrip(self):
+        state = build_train_state(step=5, tokens_seen=100, extra={"wandb_run_id": "abc123"})
+        assert state["wandb_run_id"] == "abc123"
+        step, tokens, extra = restore_train_state(state)
+        assert step == 5
+        assert tokens == 100
+        assert extra["wandb_run_id"] == "abc123"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #19.

`wandb.init(resume="allow")` without `id=` creates a new run on every restart. Preempted jobs on `kempner_requeue` lose their WandB history.

Saves the run ID in checkpoint `train_state.pt` and passes it back to `wandb.init(id=..., resume="allow")` on resume. Only rank 0 talks to WandB (unchanged).

`restore_train_state` and `CheckpointManager.load` now return an extra dict with non-standard keys (`wandb_run_id`, `phase_idx`, etc.) so callers can access checkpoint extras without changing the save format.

## Acceptance

- [x] Resumed job logs to the same WandB run (verified on 12 GPU, 3 nodes)
- [x] Only rank 0 talks to WandB
- [x] Existing configs with `enable_wandb=false` unaffected
- [x] `ruff` and `ruff format --check` clean
- [x] Unit tests pass (786/786)

## Test plan

- [x] `uv run pytest tests/unit/ -x` (786 passed)
- [x] `uv run ruff check` on changed files
- [x] 12-GPU live test: phase 1 (5 steps, ckpt at step 3) → phase 2 (resume to step 8), same WandB run ID `6fmvbl3a` in both phases