### PR TITLE
Fix Muon comment, add optimizer config validation, use public DTensor API

### DIFF
--- a/kempnerforge/config/optimizer.py
+++ b/kempnerforge/config/optimizer.py
@@ -29,3 +29,9 @@ class OptimizerConfig:
             raise ValueError("weight_decay must be non-negative")
         if not (0 <= self.betas[0] < 1 and 0 <= self.betas[1] < 1):
             raise ValueError("betas must be in [0, 1)")
+        if not (0 < self.muon_momentum < 1):
+            raise ValueError("muon_momentum must be in (0, 1)")
+        if self.muon_ns_steps <= 0:
+            raise ValueError("muon_ns_steps must be positive")
+        if self.schedule_free_warmup_steps < 0:
+            raise ValueError("schedule_free_warmup_steps must be non-negative")

--- a/kempnerforge/training/optimizer.py
+++ b/kempnerforge/training/optimizer.py
@@ -307,7 +307,7 @@ def _newton_schulz(G: torch.Tensor, steps: int = 5) -> torch.Tensor:
     assert G.ndim == 2
     a, b, c = 3.4445, -4.7750, 2.0315
 
-    # Spectral normalization to ensure convergence
+    # Frobenius normalization (matches reference Muon; sufficient for NS convergence)
     X = G / (G.norm() + 1e-7)
 
     for _ in range(steps):
@@ -329,7 +329,7 @@ def _get_local_tensor(t: torch.Tensor) -> torch.Tensor:
         from torch.distributed._tensor import DTensor
 
         if isinstance(t, DTensor):
-            return t._local_tensor
+            return t.to_local()
     except ImportError:
         pass
     return t

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -170,6 +170,18 @@ class TestOptimizerConfig:
         with pytest.raises(ValueError, match="betas"):
             OptimizerConfig(betas=(1.0, 0.95))
 
+    def test_rejects_bad_muon_momentum(self):
+        with pytest.raises(ValueError, match="muon_momentum"):
+            OptimizerConfig(muon_momentum=0.0)
+
+    def test_rejects_bad_muon_ns_steps(self):
+        with pytest.raises(ValueError, match="muon_ns_steps"):
+            OptimizerConfig(muon_ns_steps=0)
+
+    def test_rejects_negative_schedule_free_warmup(self):
+        with pytest.raises(ValueError, match="schedule_free_warmup_steps"):
+            OptimizerConfig(schedule_free_warmup_steps=-1)
+
 
 # ---------------------------------------------------------------------------
 # DistributedConfig


### PR DESCRIPTION
## Summary
- Fix misleading "Spectral normalization" comment in `_newton_schulz` — code uses Frobenius norm, which is correct per reference Muon implementation
- Add `__post_init__` validation for `muon_momentum` (must be in (0,1)), `muon_ns_steps` (must be positive), `schedule_free_warmup_steps` (must be non-negative)
- Add 3 rejection tests for the new validations
- Replace private `DTensor._local_tensor` with public `DTensor.to_local()` in Muon's `_get_local_tensor()`

## Testing
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run pytest tests/unit/test_config.py::TestOptimizerConfig -v` passes (6 tests)
- [x] `uv run pytest tests/unit/test_optimizer.py -v` passes
- [x] `uv run pytest tests/unit/test_additional_optimizers.py -v` passes

Closes #25