### PR TITLE
Add MIT license and update package metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ### Clone and Install
 
 ```bash
-git clone git@github.com:mmshad/KempnerForge.git
+git clone git@github.com:KempnerInstitute/KempnerForge.git
 cd KempnerForge
 
 # Install all dependencies (creates .venv automatically)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kempner Institute for the Study of Natural and Artificial Intelligence, Harvard University
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,10 @@
 name = "kempnerforge"
 version = "0.1.0"
 description = "PyTorch-native framework for fault-tolerant distributed training of foundation models on AI clusters"
+license = "MIT"
+authors = [
+    { name = "Kempner Institute", email = "kempner_hpc_cluster@harvard.edu" },
+]
 requires-python = ">=3.12"
 dependencies = [
     "torch>=2.4",


### PR DESCRIPTION
## Summary
- Add MIT LICENSE file (Kempner Institute, Harvard University)
- Add license and authors fields to pyproject.toml
- Fix CONTRIBUTING.md clone URL to KempnerInstitute/KempnerForge

Closes #27