### PR TITLE
Add model.sdpa_backend config for attention kernel override

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Key config options:
 - `distributed.pp` — pipeline parallelism degree (default 1)
 - `model.num_experts` — number of MoE experts (0 = dense model)
 - `model.moe_router` — `"softmax_topk"` or `"sigmoid_topk"` (DeepSeek-V3 style)
+- `model.sdpa_backend` — `"auto"` (default), `"flash"`, `"efficient"`, `"cudnn"`, `"math"` — force a specific SDPA kernel for benchmarking/debugging
 - `optimizer.name` — `"adamw"`, `"muon"`, `"lion"`, or `"schedule_free_adamw"` (default `"adamw"`)
 - `scheduler.name` — `"cosine"`, `"linear"`, `"wsd"`, `"constant"`, `"rex"`, or `"none"` (default `"cosine"`)
 - `scheduler.wsd_decay_type` — WSD cooldown shape: `"cosine"`, `"linear"`, or `"sqrt"` (default `"cosine"`)

--- a/kempnerforge/config/model.py
+++ b/kempnerforge/config/model.py
@@ -38,6 +38,9 @@ class ModelConfig:
     qk_norm: bool = False  # Apply RMSNorm to Q/K per-head before RoPE (Gemma, DeepSeek-V3)
     init_std: float = 0.02  # Std for weight initialization (GPT-2/Llama default)
     model_type: str = "transformer"  # Registry key for model builder
+    # SDPA backend: "auto" lets PyTorch select (recommended). Override to force
+    # a specific kernel for benchmarking or debugging.
+    sdpa_backend: str = "auto"  # "auto", "flash", "efficient", "cudnn", "math"
 
     # MoE (all defaults produce a dense model -- zero behavior change)
     num_experts: int = 0  # 0 = dense, >0 = MoE
@@ -70,6 +73,13 @@ class ModelConfig:
         if self.n_heads % self.n_kv_heads != 0:
             raise ValueError(
                 f"n_heads ({self.n_heads}) must be divisible by n_kv_heads ({self.n_kv_heads})"
+            )
+
+        # SDPA backend validation
+        if self.sdpa_backend not in ("auto", "flash", "efficient", "cudnn", "math"):
+            raise ValueError(
+                f"Unknown sdpa_backend: '{self.sdpa_backend}'. "
+                "Options: 'auto', 'flash', 'efficient', 'cudnn', 'math'"
             )
 
         # MoE validation

--- a/kempnerforge/model/attention.py
+++ b/kempnerforge/model/attention.py
@@ -8,12 +8,22 @@ GQA is the general case:
 
 from __future__ import annotations
 
+import contextlib
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from kempnerforge.model.norm import RMSNorm
 from kempnerforge.model.position import apply_rope
+
+_SDPA_BACKENDS = {
+    "flash": SDPBackend.FLASH_ATTENTION,
+    "efficient": SDPBackend.EFFICIENT_ATTENTION,
+    "cudnn": SDPBackend.CUDNN_ATTENTION,
+    "math": SDPBackend.MATH,
+}
 
 
 class KVCache:
@@ -70,12 +80,14 @@ class Attention(nn.Module):
         n_kv_heads: int,
         head_dim: int | None = None,
         qk_norm: bool = False,
+        sdpa_backend: str = "auto",
     ) -> None:
         super().__init__()
         self.n_heads = n_heads
         self.n_kv_heads = n_kv_heads
         self.head_dim = head_dim or (dim // n_heads)
         self.n_rep = n_heads // n_kv_heads  # GQA repetition factor
+        self.sdpa_backend = sdpa_backend
 
         # Projections
         self.q_proj = nn.Linear(dim, n_heads * self.head_dim, bias=False)
@@ -90,6 +102,16 @@ class Attention(nn.Module):
         # Attention weight capture (analysis only — not for training)
         self.capture_attention_weights = False
         self._last_attention_weights: torch.Tensor | None = None
+
+    def _sdpa_context(self):
+        """Return a context manager that forces a specific SDPA backend.
+
+        When sdpa_backend="auto", returns a no-op and lets PyTorch's
+        heuristics select the backend.
+        """
+        if self.sdpa_backend == "auto":
+            return contextlib.nullcontext()
+        return sdpa_kernel(_SDPA_BACKENDS[self.sdpa_backend])
 
     def forward(
         self,
@@ -163,10 +185,12 @@ class Attention(nn.Module):
             doc_mask = doc_ids.unsqueeze(2) == doc_ids.unsqueeze(1)  # (B, S, S)
             causal = torch.ones(seq_len, seq_len_kv, dtype=torch.bool, device=q.device).tril()
             attn_mask = (doc_mask & causal).unsqueeze(1)  # (B, 1, S, S)
-            out = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
+            with self._sdpa_context():
+                out = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
         else:
             is_causal = kv_cache is None or seq_len > 1
-            out = F.scaled_dot_product_attention(q, k, v, is_causal=is_causal)
+            with self._sdpa_context():
+                out = F.scaled_dot_product_attention(q, k, v, is_causal=is_causal)
 
         # Reshape back: (batch, n_heads, seq_len, head_dim) → (batch, seq_len, dim)
         out = out.transpose(1, 2).contiguous().view(batch, seq_len, -1)

--- a/kempnerforge/model/transformer.py
+++ b/kempnerforge/model/transformer.py
@@ -42,6 +42,7 @@ class TransformerBlock(nn.Module):
             n_kv_heads=config.n_kv_heads,  # type: ignore[reportArgumentType]
             head_dim=config.head_dim,
             qk_norm=config.qk_norm,
+            sdpa_backend=config.sdpa_backend,
         )
 
         self.mlp_norm = build_norm(config.norm_type, config.dim, eps=config.norm_eps)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -130,6 +130,21 @@ class TestModelConfig:
         )
         assert 0.9 < ratio < 1.1  # close to 7x extra MLP params + small router overhead
 
+    # --- SDPA backend config ---
+
+    def test_sdpa_backend_default_is_auto(self):
+        m = ModelConfig()
+        assert m.sdpa_backend == "auto"
+
+    def test_sdpa_backend_accepts_valid_values(self):
+        for backend in ("auto", "flash", "efficient", "cudnn", "math"):
+            m = ModelConfig(sdpa_backend=backend)
+            assert m.sdpa_backend == backend
+
+    def test_sdpa_backend_rejects_unknown(self):
+        with pytest.raises(ValueError, match="Unknown sdpa_backend"):
+            ModelConfig(sdpa_backend="fa3")
+
 
 # ---------------------------------------------------------------------------
 # TrainConfig

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -177,6 +177,14 @@ class TestAttention:
         out = attn(x, cos, sin)
         assert out.shape == (1, 32, 256)
 
+    def test_sdpa_backend_defaults_to_auto(self):
+        attn = Attention(dim=128, n_heads=4, n_kv_heads=4)
+        assert attn.sdpa_backend == "auto"
+
+    def test_sdpa_backend_stored_on_module(self):
+        attn = Attention(dim=128, n_heads=4, n_kv_heads=4, sdpa_backend="math")
+        assert attn.sdpa_backend == "math"
+
 
 # ---------------------------------------------------------------------------
 # MLP


### PR DESCRIPTION
## Summary
- Add `model.sdpa_backend` field (default `"auto"`) with values `"auto"`, `"flash"`, `"efficient"`, `"cudnn"`, `"math"`
- Validate in `ModelConfig.__post_init__`
- Wrap `F.scaled_dot_product_attention` calls in `Attention._sdpa_context()` — uses `sdpa_kernel()` when forced, `contextlib.nullcontext()` when auto (zero overhead)
- Plumb through `TransformerBlock` -> `Attention`
- Add config validation tests and Attention backend-storage tests
- Document new field in README key config options

## Testing
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors)
- [x] `uv run pytest tests/unit/test_config.py::TestModelConfig tests/unit/test_model.py::TestAttention -v` passes (33 tests)

Closes #29