### PR TITLE
Iss docs

### DIFF
--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -1,0 +1,256 @@
+# Data Flow
+
+The path a batch of tokens takes from the dataloader to a committed
+gradient update. Follow this page with
+[`scripts/train.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/train.py)
+open in another tab — line numbers move, but the structure below maps
+one-to-one onto the training loop body.
+
+## One-slide view
+
+```
+   ┌─ MemoryMappedDataset or MixtureDataset
+   │
+   ├─ DistributedSampler / MixtureSampler (rank-partitioned indices)
+   │
+   ├─ StatefulDataLoader ──► batch = {input_ids, labels, doc_ids?}
+   │
+   ▼
+for micro_step in range(grad_accum_steps):       ── maybe_no_sync sets
+    ├─ model.set_moe_step(step, max_steps)          DDP/FSDP grad-sync off
+    ├─ logits = model(input_ids, doc_ids=doc_ids)   on all but last micro
+    ├─ loss   = loss_fn(logits, labels)
+    ├─ [+ moe_aux_loss_weight * model.get_moe_aux_loss()]
+    └─ (loss / grad_accum_steps).backward()       ── gradient accumulation
+
+grad_norm = clip_grad_norm_(model, grad_clip_norm)
+if NaN: zero_grad, skip, maybe stop
+optimizer.step() ; scheduler.step() ; optimizer.zero_grad()
+
+tracker.end_step(step, loss, grad_norm, lr, tokens_in_step)
+hook_runner.on_step_end(StepContext(...))
+[every N steps] eval, NCCL health, profiler.step, ckpt_mgr.save
+if shutdown_handler.should_shutdown(): save + break
+```
+
+## Startup, once
+
+Before the loop starts,
+[`scripts/train.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/train.py)
+initializes the collaborators:
+
+- **`init_distributed(config.distributed, seed=...)`** from
+  [`kempnerforge.distributed.setup`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/setup.py)
+  — reads `RANK` / `LOCAL_RANK` / `WORLD_SIZE` (torchrun) or
+  `SLURM_PROCID` / `SLURM_NTASKS` (multi-node srun), calls
+  `dist.init_process_group`, builds the `DeviceMesh`, seeds torch.
+- **`ShutdownHandler`** from
+  [`kempnerforge.resilience.signal_handler`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/signal_handler.py)
+  — installs SIGTERM / SIGUSR1 handlers for cooperative SLURM
+  preemption.
+- **`NaNDetector`** from
+  [`kempnerforge.resilience.health`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/health.py)
+  — tracks consecutive NaN steps; `action="warn"` by default, escalates
+  to rollback after `max_consecutive=10`.
+- **Loss function** from the registry (`"cross_entropy"` or
+  `"chunked_cross_entropy"`).
+- **Model** via `build_parallel_model` — applies the full parallelism
+  stack (see [Parallelism order](parallelism-order.md)).
+- **Optimizer and scheduler** from their registries.
+- **`CheckpointManager`** from
+  [`kempnerforge.checkpoint.manager`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/checkpoint/manager.py)
+  — owns DCP async save/load, latest-symlink, step_N directories.
+- **`resolve_resume_path(config.checkpoint.dir)`** from
+  [`kempnerforge.resilience.elastic`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/elastic.py)
+  — follows the `latest` symlink or picks the highest `step_N`. If
+  non-`None`, `ckpt_mgr.load(resume_path)` restores model, optimizer,
+  scheduler, dataloader position, and RNG state before the loop
+  starts.
+- **`MetricsTracker`** from
+  [`kempnerforge.metrics.tracker`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/metrics/tracker.py)
+  — per-step metrics + EMA smoothing + WandB / TensorBoard backends.
+- **Data pipeline** — `MemoryMappedDataset` or `MixtureDataset` or an
+  HF streaming / eager dataset (config dispatches), wrapped by
+  `DistributedSampler` or `MixtureSampler` and then by
+  `StatefulDataLoader` from
+  [`kempnerforge.data`](https://github.com/KempnerInstitute/KempnerForge/tree/main/kempnerforge/data).
+- **Eval dataloader and `torch.profiler`** (optional).
+- **Phase schedule** (optional) — for curriculum training, rebalances
+  the mixture at `phase.start_step`.
+
+## Inside the loop: one step
+
+The step body is where the interesting routing happens.
+
+### 1 · Microbatch fetch
+
+```python
+for micro_step in range(grad_accum_steps):
+    batch = next(data_iter)
+    input_ids = batch["input_ids"].to(device)
+    labels    = batch["labels"].to(device)
+    doc_ids   = batch.get("doc_ids").to(device) if "doc_ids" in batch else None
+```
+
+When `dataloader is None`, the loop generates random integer tokens —
+useful for smoke-testing the parallelism stack without any corpus.
+
+`doc_ids` is optional: non-`None` only when the dataset packs multiple
+documents into one sequence. It triggers the block-diagonal attention
+mask path (see [Model § Three attention paths](model.md#three-attention-paths)).
+
+### 2 · `maybe_no_sync`
+
+```python
+with maybe_no_sync(model, micro_step, grad_accum_steps):
+    ...
+```
+
+Utility from
+[`kempnerforge.training.grad`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/grad.py),
+re-exported from `kempnerforge.training`. On all microbatches except
+the last, it disables gradient synchronization so the backward pass
+accumulates locally and does not fire reduce-scatter N times per
+optimizer step.
+
+### 3 · MoE step propagation
+
+```python
+if mc.is_moe:
+    model.set_moe_step(step, tc.max_steps)
+```
+
+Forwards `(step, max_steps)` to every `SigmoidTopKRouter`. Used by the
+adaptive bias schedule (see [docs/moe/](../moe/index.md)). Dense models
+skip this.
+
+### 4 · Forward
+
+```python
+logits = model(input_ids, doc_ids=doc_ids)
+loss   = loss_fn(logits, labels)
+```
+
+The forward pass follows [the model page](model.md): token embedding →
+N transformer blocks (RoPE + GQA + SwiGLU or MoE) → final RMSNorm →
+output head → `(batch, seq_len, vocab_size)` logits.
+
+Per-dataset metrics, if the dataloader is a mixture, are collected here
+before backward so the logits are still alive.
+
+### 5 · MoE auxiliary loss
+
+```python
+if mc.is_moe:
+    aux_loss = model.get_moe_aux_loss()
+    loss = loss + mc.moe_aux_loss_weight * aux_loss
+```
+
+`get_moe_aux_loss()` sums the per-layer `MoEMLP.aux_loss` attributes.
+For dense runs it returns `0.0` and the line is a no-op.
+
+### 6 · Backward with gradient accumulation
+
+```python
+scaled_loss = loss / tc.grad_accum_steps
+scaled_loss.backward()
+total_loss += loss.item()
+```
+
+Scaling by `grad_accum_steps` keeps the effective learning rate
+invariant to the accumulation factor.
+
+### 7 · Clip, NaN check, optimizer step
+
+After the microbatch loop:
+
+```python
+grad_norm = clip_grad_norm_(model, tc.grad_clip_norm)
+
+if not nan_detector.check_loss(avg_loss, step):
+    optimizer.zero_grad(); step += 1; continue   # skip this step
+
+optimizer.step()
+scheduler.step()
+if phase_lr_scale != 1.0:
+    for pg in optimizer.param_groups: pg["lr"] *= phase_lr_scale
+optimizer.zero_grad()
+```
+
+`clip_grad_norm_` wraps PyTorch's utility so it works with FSDP2 sharded
+parameters. The NaN detector returns `False` on NaN/Inf loss, zeroes
+the grads, and (after `max_consecutive`) signals a rollback to the
+previous checkpoint.
+
+Phase LR scaling applies *after* the scheduler — it multiplies the base
+LR that `scheduler.step()` just computed.
+
+### 8 · Step accounting
+
+```python
+step += 1
+tokens_in_step = tc.batch_size * tc.seq_len * tc.grad_accum_steps * dp_size
+tokens_seen   += tokens_in_step
+```
+
+`tokens_in_step` times all ranks in the data-parallel dimension, not the
+full `world_size` — TP, PP, and EP don't multiply unique tokens.
+
+### 9 · Phase transitions
+
+If a mixture phase is due, `sampler.update_weights(...)` rebalances the
+MixtureSampler and `data_iter = None` forces a refresh next microbatch
+so the new weights take effect immediately.
+
+### 10 · Metrics and hooks
+
+```python
+step_metrics = tracker.end_step(step=step, loss=avg_loss,
+                                grad_norm=grad_norm_val, lr=current_lr,
+                                tokens_in_step=tokens_in_step)
+hook_runner.on_step_end(StepContext(...))
+```
+
+`tracker.end_step` dispatches to WandB / TensorBoard at
+`metrics.log_interval`. `HookRunner` (from
+[`kempnerforge.training.hooks`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/hooks.py))
+runs user-defined `TrainingHook` callbacks each step.
+
+MoE runs additionally log `moe/aux_loss` and `moe/expert_balance`
+(`min/max` of per-expert token counts) at the same cadence.
+
+### 11 · Periodic work
+
+In order:
+
+- **NCCL health** (every `tc.nccl_health_check_interval` steps) — fires
+  a small all-reduce; on failure, break the loop.
+- **Eval** (every `eval_config.interval` steps) — runs `run_eval` on the
+  eval dataloader, logs metrics, fires `on_eval_end` hooks.
+- **Profiler** — `prof.step()` advances the `torch.profiler` schedule.
+- **Checkpoint** (every `checkpoint.interval` steps) — `ckpt_mgr.save`
+  writes a DCP checkpoint asynchronously and updates the `latest`
+  symlink.
+- **Graceful shutdown** — if SIGTERM/SIGUSR1 fired,
+  `ckpt_mgr.save(emergency)` and exit.
+
+## Shutdown
+
+After the loop exits:
+
+- `prof.stop()` flushes traces.
+- `ckpt_mgr.wait()` drains the last async save.
+- `hook_runner.on_train_end(step, tokens_seen)`.
+- `tracker.close()` flushes WandB / TB.
+- `destroy_distributed()` tears down the process group.
+
+## Where to read next
+
+- [Training subsystem](../training/index.md) — loss functions,
+  optimizers, schedulers in detail.
+- [Checkpointing](../checkpointing/index.md) — DCP internals and the
+  resume protocol.
+- [Resilience](../resilience/index.md) — SIGTERM, NaN, NCCL health
+  mechanics.
+- [Metrics and profiling](../metrics-and-profiling/index.md) —
+  `MetricsTracker`, MFU, profiler.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,0 +1,78 @@
+# Architecture
+
+How the pieces fit together. This section covers the forward pass, the
+parallelism application order, and the path a batch of tokens takes from
+the dataloader back to a gradient update.
+
+## One-slide overview
+
+```{tip}
+The README renders this as a mermaid diagram:
+[README § Architecture](https://github.com/KempnerInstitute/KempnerForge#architecture).
+```
+
+```
+TOML preset ─┐
+             ├──► JobConfig ──► scripts/train.py ──┬──► Model
+CLI override ┘    (dataclasses)   (training loop)  │     Token Embedding → Blocks (RoPE · GQA · SwiGLU or MoE) → Output Head
+                                                   │
+                                                   ├──► Parallelism (strict order)
+                                                   │     1 · TP → 2 · EP → 3 · FP8 → 4 · AC → 5 · FSDP2
+                                                   │
+                                                   ├──► Data
+                                                   │     MemoryMapped / HF → DistributedSampler / MixtureSampler → StatefulDataLoader
+                                                   │
+                                                   ├──► Resilience
+                                                   │     SIGTERM handler · NaN detector · NCCL health
+                                                   │
+                                                   └──► Outputs
+                                                         DCP checkpoints · MetricsTracker (WandB · TB) · torch.profiler
+```
+
+## Component responsibilities
+
+| Package | Responsibility |
+|---------|----------------|
+| `kempnerforge.config` | Typed dataclass configs, TOML loading, CLI overrides, component registry |
+| `kempnerforge.model` | `Transformer`, `TransformerBlock`, `Attention`, `SwiGLUMLP`, `MoEMLP`, `RMSNorm`, RoPE, embeddings, weight init |
+| `kempnerforge.distributed` | `DeviceMesh` construction, FSDP2, TP, EP, Float8, activation checkpointing, `build_parallel_model` |
+| `kempnerforge.data` | `MemoryMappedDataset`, `MixtureDataset`, `DistributedSampler`, `MixtureSampler`, `StatefulDataLoader` |
+| `kempnerforge.training` | Training step, optimizers (AdamW / Lion / Muon / schedule-free), LR schedulers, loss functions |
+| `kempnerforge.checkpoint` | DCP-based sharded checkpoints, async save, auto-resume |
+| `kempnerforge.resilience` | SIGTERM/SIGUSR1 handler, NaN detector, GPU + NCCL health checks |
+| `kempnerforge.metrics` | `MetricsTracker`, MFU, WandB / TensorBoard backends, memory monitor |
+| `kempnerforge.profiling` | `torch.profiler` integration, CUDA event timing |
+
+## Design principles
+
+Copied from
+[README § Design Principles](https://github.com/KempnerInstitute/KempnerForge#design-principles):
+
+- **PyTorch-native**: FSDP2, DTensor, DeviceMesh, DCP, SDPA, `torch.compile`.
+- **Distributed-first**: multi-GPU is the default, not an afterthought.
+- **Composition over inheritance**: components are composed via config, not
+  a class hierarchy.
+- **Minimal abstraction**: readable code over framework magic.
+- **Stateful everything**: dataloader, sampler, and training state all
+  support checkpoint and resume.
+- **Configuration-driven**: all behavior controlled by typed dataclass
+  configs, validated at startup.
+
+## Where to go next
+
+```{toctree}
+:maxdepth: 1
+
+model
+parallelism-order
+data-flow
+```
+
+- **[Model](model.md)** — the forward pass block by block: embeddings →
+  RoPE → attention → SwiGLU or MoE → RMSNorm → output head, plus weight
+  init.
+- **[Parallelism order](parallelism-order.md)** — the 5-step order
+  (TP → EP → FP8 → AC → FSDP2) and what goes wrong when you violate it.
+- **[Data flow](data-flow.md)** — the path of a batch from
+  `StatefulDataLoader` through forward, loss, backward, optimizer step,
+  and checkpoint tick.

--- a/docs/architecture/model.md
+++ b/docs/architecture/model.md
@@ -1,0 +1,248 @@
+# Model
+
+The forward pass block by block, with pointers to the code that implements
+each piece. KempnerForge's `Transformer` is a pre-norm Llama-style
+decoder: token embedding → N transformer blocks → final RMSNorm →
+output head. All components live under
+[`kempnerforge/model/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/kempnerforge/model).
+
+## High-level flow
+
+```
+tokens (batch, seq_len)
+   ↓ TokenEmbedding
+hidden (batch, seq_len, dim)
+   ↓ for each of n_layers TransformerBlocks:
+   ↓   x = x + Attention(RMSNorm(x), cos, sin)
+   ↓   x = x + MLP(RMSNorm(x))           (SwiGLUMLP or MoEMLP)
+   ↓ final RMSNorm
+   ↓ OutputHead (nn.Linear, bias=False)
+logits (batch, seq_len, vocab_size)
+```
+
+Pre-norm means `LayerNorm` happens before attention and MLP, not after.
+Implemented in
+[`kempnerforge/model/transformer.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/transformer.py).
+
+## Token embedding
+
+`TokenEmbedding` wraps `nn.Embedding(vocab_size, dim)`. It is optional —
+`None` on pipeline-parallel middle stages that only receive hidden states.
+[`kempnerforge/model/embedding.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/embedding.py).
+
+## RoPE (rotary position embedding)
+
+Positions are injected inside each attention block, not added to the
+embedding. `precompute_rope_frequencies(head_dim, max_seq_len, theta)`
+returns two tables of shape `(max_seq_len, head_dim // 2)`:
+
+- `cos` — cosines of `position * freq`
+- `sin` — sines of the same
+
+`apply_rope(x, cos, sin)` splits `x` along `head_dim` into two halves and
+rotates them:
+
+```
+[x1, x2] → [x1·cos − x2·sin, x2·cos + x1·sin]
+```
+
+The rotation uses real-valued sin/cos (not complex arithmetic) so
+`DTensor` metadata survives under `SequenceParallel` — a comment in
+[`kempnerforge/model/position.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/position.py)
+records that `.float()` stripped the `DTensor` wrapper in an earlier
+version.
+
+During generation, `Transformer.forward` slices `cos`/`sin` starting at
+`kv_caches[0].seq_len` so incremental tokens get the correct absolute
+positions.
+
+## Attention
+
+`Attention` in
+[`kempnerforge/model/attention.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/attention.py)
+implements grouped-query attention (GQA).
+
+### Projections
+
+Four `nn.Linear(..., bias=False)` projections:
+
+| Name | Shape |
+|------|-------|
+| `q_proj` | `dim → n_heads * head_dim` |
+| `k_proj` | `dim → n_kv_heads * head_dim` |
+| `v_proj` | `dim → n_kv_heads * head_dim` |
+| `o_proj` | `n_heads * head_dim → dim` |
+
+GQA is configured by the ratio `n_heads / n_kv_heads`:
+
+- `n_kv_heads == n_heads` → multi-head attention (MHA)
+- `n_kv_heads == 1` → multi-query attention (MQA)
+- anything in between → GQA (`configs/model/llama_7b.toml` uses
+  `n_heads=32, n_kv_heads=8`)
+
+After Q/K/V are computed, KV heads are expanded to `n_heads` via
+`repeat_interleave(n_rep, dim=1)` so SDPA sees aligned shapes.
+
+### QK-Norm
+
+When `qk_norm=True`, per-head `RMSNorm(head_dim)` is applied to Q and K
+before RoPE. Stabilizes attention logits at scale (Gemma, DeepSeek-V3).
+
+### Three attention paths
+
+1. **Packed sequences** (`doc_ids` passed in): a block-diagonal causal
+   mask isolates documents within one packed sequence. Built from
+   `doc_ids.unsqueeze(2) == doc_ids.unsqueeze(1)` intersected with the
+   causal triangle, then passed to
+   `F.scaled_dot_product_attention(..., attn_mask=...)`.
+2. **Standard causal** (training and prefill, no `doc_ids`): SDPA with
+   `is_causal=True`.
+3. **Single-token decode** (`seq_len == 1` with a KV cache): no mask —
+   the query attends to all cached positions. `is_causal=True` here
+   would incorrectly restrict attention to only the first key.
+
+A fourth, slower path fires only when `capture_attention_weights=True`:
+`_attention_with_weights` computes `softmax(Q·Kᵀ / √d)` manually so
+attention weights can be extracted for interpretability. Don't enable it
+for training runs.
+
+### KV cache placement
+
+KV cache update happens **after** RoPE, **before** GQA expansion. That
+ordering is intentional: cached keys already carry their rotary positions,
+and the cache stores `n_kv_heads` tensors, not the expanded `n_heads`
+copies.
+
+### SDPA backend
+
+`sdpa_backend` (default `"auto"`) selects flash / mem-efficient / cudnn /
+math via a context manager. `"auto"` lets PyTorch pick.
+
+## MLP
+
+Two dense variants, keyed by `activation`:
+
+- **`SwiGLUMLP`** (`activation="silu"`, Llama-style) — three linears:
+  `gate_proj + up_proj → SiLU(gate) * up → down_proj`.
+- **`StandardMLP`** (`"gelu"` or `"relu"`) — two linears:
+  `up_proj → activation → down_proj`.
+
+[`kempnerforge/model/mlp.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/mlp.py).
+The helper `build_mlp(dim, hidden_dim, activation)` looks the variant up
+in the `"mlp"` registry.
+
+### MoE variant
+
+When `ModelConfig.is_moe` is True, layers where
+`(layer_idx + 1) % moe_frequency == 0` swap `SwiGLUMLP` for `MoEMLP` (see
+[`kempnerforge/model/moe.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/moe.py)).
+`moe_frequency=1` makes every layer MoE; `moe_frequency=2` interleaves
+dense and MoE layers, with layer 0 staying dense. See
+[`docs/moe/`](../moe/index.md) for the full MoE stack.
+
+## RMSNorm
+
+`RMSNorm(dim, eps=1e-5)` in
+[`kempnerforge/model/norm.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/norm.py).
+A single learned scale vector (`self.weight`, init 1s), no bias, no mean
+subtraction:
+
+```
+x.float() * rsqrt(mean(x² , dim=-1, keepdim=True) + eps) * weight → cast back
+```
+
+The float32 cast-and-cast-back is deliberate — it prevents the variance
+statistic from overflowing in bf16 for long sequences.
+
+`LayerNorm` is also registered under the `"norm"` registry key
+`"layernorm"` if you want it; everything else in the codebase assumes
+`"rmsnorm"`.
+
+## Output head
+
+`OutputHead` is `nn.Linear(dim, vocab_size, bias=False)`. Optional, like
+`TokenEmbedding` — `None` on pipeline-parallel non-final stages.
+
+When `ModelConfig.tie_embeddings=True` (and both layers exist), the head
+shares its weight with the embedding via `OutputHead.tie_weights(emb)`
+(`self.proj.weight = emb.embedding.weight`).
+
+## TransformerBlock
+
+One block's `forward` is five lines:
+
+```python
+x = x + self.attention(self.attention_norm(x), rope_cos, rope_sin,
+                       kv_cache=kv_cache, doc_ids=doc_ids)
+x = x + self.mlp(self.mlp_norm(x))
+return x
+```
+
+Pre-norm + residual, both for attention and for MLP. No
+`drop_path`/`stochastic_depth`; no learnable scale on the residual branch.
+
+## Transformer assembly
+
+`Transformer` owns:
+
+- `token_embedding` (optional)
+- `layers: nn.ModuleDict[str, TransformerBlock]` — keyed by `str(i)`
+  instead of `nn.ModuleList` so checkpoint FQNs are stable under DCP
+- `norm` — final `RMSNorm`
+- `output_head` (optional)
+- `_rope_cos`, `_rope_sin` — precomputed frequency tables stored as plain
+  attributes (not buffers) so `model.to(bf16)` doesn't cast them to bf16
+
+Extra helpers on `Transformer`:
+
+- `init_weights_and_freqs()` — called after `model.to_empty(device=...)`
+  to fill parameter values after meta-device materialization
+- `set_moe_step(step, max_steps)` — forwards the current step to every
+  `SigmoidTopKRouter` for the adaptive bias schedule
+- `get_moe_aux_loss()` — sums the per-layer MoE aux loss; returns 0 for
+  dense models
+- `get_expert_counts()` — returns `{layer_idx: counts}` for MoE layers;
+  empty for dense
+
+The whole class is registered under the `"model"` registry key
+`"transformer"`, which is what the training loop asks for.
+
+## Weight initialization
+
+`init_weights(model, config)` in
+[`kempnerforge/model/init.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/init.py)
+applies the GPT-2 / Llama convention:
+
+- 2-D parameters (`Linear` weights, `Embedding`) get
+  `normal(0, config.init_std)` — default `0.02`.
+- Parameters whose name ends in `o_proj.weight` or `down_proj.weight` get
+  scaled by `1 / sqrt(2 * n_layers)`. Without this, the residual stream's
+  variance grows linearly with depth.
+- Biases and norm weights are left at their defaults (zeros and ones).
+- Meta-device parameters are skipped — `init_weights_and_freqs()` runs
+  after materialization.
+
+## Registry keys
+
+Swap pieces without touching the transformer code by registering a new
+builder under the right category:
+
+| Category | Existing keys | Builder |
+|----------|---------------|---------|
+| `"model"` | `"transformer"` | `@registry.register_model(...)` |
+| `"mlp"` | `"swiglu"`, `"standard_gelu"`, `"standard_relu"` | `registry.register("mlp", ...)` |
+| `"norm"` | `"rmsnorm"`, `"layernorm"` | `registry.register("norm", ...)` |
+| `"router"` | `"softmax_topk"`, `"sigmoid_topk"` | `registry.register("router", ...)` |
+| `"optimizer"` | `"adamw"`, `"lion"`, `"muon"`, `"schedule_free_adamw"` | `@registry.register_optimizer(...)` |
+| `"scheduler"` | `"cosine"`, `"linear"`, `"wsd"`, `"constant"`, `"rex"`, `"none"` | `@registry.register_scheduler(...)` |
+| `"loss"` | `"cross_entropy"`, `"chunked_cross_entropy"` | `@registry.register_loss(...)` |
+
+See [Configuration](../configuration/index.md) for the step-by-step
+pattern for registering new components.
+
+## Where to read next
+
+- [Parallelism order](parallelism-order.md) — how TP, EP, FP8, AC, and
+  FSDP2 are layered on top of this module tree.
+- [Data flow](data-flow.md) — the training-loop path that feeds this
+  forward pass.

--- a/docs/architecture/parallelism-order.md
+++ b/docs/architecture/parallelism-order.md
@@ -1,0 +1,171 @@
+# Parallelism Order
+
+Parallelisms are applied in a strict order. The wrong order silently
+produces wrong gradients or crashes at runtime with an unhelpful
+error — it is *not* a case where PyTorch prints a clear message and
+refuses. Get the order right.
+
+The canonical source is
+[`kempnerforge/distributed/parallel.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/parallel.py)
+(the module docstring and `build_parallel_model`). This page explains
+*why* each step sits where it does.
+
+## The five steps
+
+```
+1. Tensor Parallelism (TP)        apply_tensor_parallel
+2. Expert Parallelism (EP)        apply_expert_parallel
+3. Float8 Training                apply_float8         [optional]
+4. Activation Checkpointing (AC)  apply_ac             [optional]
+5. FSDP2                          apply_fsdp2
+```
+
+## Why this order
+
+### 1 · Tensor Parallelism first
+
+`apply_tensor_parallel` walks the model tree, finds `nn.Linear` modules
+by name (e.g. `attention.q_proj`, `mlp.gate_proj`), and replaces them
+with sharded `ColwiseParallel` / `RowwiseParallel` plans. It must see the
+**raw** modules.
+
+If FSDP2, Float8, or activation checkpointing have already run, those
+`nn.Linear` modules are no longer where the sharding plan expects them —
+they are wrapped in `CheckpointWrapper`, replaced with `Float8Linear`,
+or owned by FSDP2's flat-parameter machinery. `parallelize_module`
+silently skips entries it can't match.
+
+TP also needs meta-device init: the full, unsharded parameter never has
+to be allocated on any one GPU. `build_parallel_model` creates the model
+under `with torch.device("meta"):`, applies TP, then materializes just
+the local shards via `model.to_empty(device=...)`.
+
+**Violation:** apply FSDP before TP and you get a correct-looking run
+with wrong gradients — TP's plan matches zero modules, the model stays
+data-parallel only, and the loss curve *looks* fine.
+
+### 2 · Expert Parallelism second
+
+`apply_expert_parallel` walks the MoE layers and partitions experts
+across an `ep` sub-mesh. Each rank keeps `num_experts / ep_world_size`
+experts; dispatch becomes all-to-all.
+
+It runs **after** TP because TP on the attention projections is
+orthogonal to how experts are partitioned, and because EP modifies the
+routed `experts` ModuleList in place — TP's plan already skipped the
+`mlp.*` names on MoE blocks (see the check in
+`_build_block_tp_plan`).
+
+It runs **before** Float8 so the Float8 filter can still see MoE experts
+by FQN and exclude them (experts use `torch._grouped_mm`, not the
+Linear forward path).
+
+### 3 · Float8 before AC and FSDP
+
+`apply_float8` replaces `nn.Linear` with `Float8Linear` (torchao,
+TENSORWISE recipe — E4M3 forward, E5M2 backward, bf16 master weights).
+Order matters on both sides:
+
+- **After TP / EP** — Float8 needs to see the post-TP modules so the
+  Float8 cast and the TP shard stay composed. A
+  `CheckpointWrapper` or FSDP flat param would hide the `nn.Linear`
+  entirely.
+- **Before FSDP** — with `enable_fsdp_float8_all_gather=True`, FSDP
+  all-gathers the params already in float8 rather than bf16, halving
+  communication volume. That only works if Float8 ran first.
+
+The filter function excludes any FQN containing `"experts"`,
+`"shared_expert"`, or `"router"`. Experts use grouped GEMM (no
+`Linear.forward`); routers have small output dims (often not a multiple
+of 16, which `torch._scaled_mm` requires) and aren't compute-bound.
+
+**Note:** `enable_fsdp_float8_all_gather=True` is incompatible with TP
+because the float8 weight wrapper calls `aten.is_pinned` on `DTensor`s
+and that op has no sharding strategy yet.
+
+### 4 · Activation Checkpointing before FSDP
+
+`apply_ac` wraps `TransformerBlock` (mode `full`) or just `Attention`
+(mode `selective`, the balanced trade-off) in `CheckpointWrapper`. Mode
+`none` is a no-op.
+
+AC must run **before** FSDP2. FSDP2 bucketizes parameters at the
+`fully_shard` boundary; wrapping a layer in `CheckpointWrapper` *after*
+FSDP has taken ownership of its parameters breaks the bucket layout and
+the reduce-scatter that depends on it.
+
+### 5 · FSDP2 last
+
+`apply_fsdp2` calls `fully_shard(layer, mesh=dp_mesh, mp_policy=...)` on
+each `TransformerBlock`, then once on the top-level model for the
+remaining parameters (embedding, final norm, output head).
+
+- Default mixed-precision policy: `param_dtype=bf16, reduce_dtype=fp32`
+  (bf16 compute, fp32 gradient reduction).
+- `reshard_after_forward=True` frees the all-gathered parameters after
+  each forward pass (default — smallest memory footprint). Set to
+  `False` or a bucket size when pipeline parallelism reuses parameters
+  across microbatches.
+
+**EP-MoE special case.** When a block contains MoE with `ep_world_size >
+1`, FSDP2 wraps `layer.attention` and `layer.mlp` as separate units
+instead of wrapping the whole block. Per-block wrapping would fire
+`reduce_scatter` between EP's two backward `all_to_all` calls — a
+deadlock where every rank waits on a peer that is waiting on it. The
+per-sub-module split guarantees each FSDP reduce-scatter fires after
+both EP all-to-alls complete.
+
+## `build_parallel_model` in full
+
+The whole sequence, from
+[`kempnerforge/distributed/parallel.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/parallel.py):
+
+**TP path** (mesh contains a `"tp"` dim):
+```
+with torch.device("meta"): model = registry.get_model(...)(config)
+apply_tensor_parallel(model, mesh)
+apply_expert_parallel(model, mesh)
+if fp8:  apply_float8(model)
+apply_ac(model, ac_mode)
+apply_fsdp2(model, mesh, mp_policy)
+model.to_empty(device=device)
+model.init_weights_and_freqs()
+model.to(dtype=param_dtype)
+```
+
+**Non-TP path:**
+```
+model = registry.get_model(...)(config).to(device, dtype=param_dtype)
+apply_expert_parallel(model, mesh)
+if fp8:  apply_float8(model)
+apply_ac(model, ac_mode)
+apply_fsdp2(model, mesh, mp_policy)
+```
+
+`torch.compile` wraps the final model when `compile_model=True`.
+
+## Adding a new parallelism mode
+
+If you are adding a sixth step, follow
+[CONTRIBUTING § New parallelism mode](https://github.com/KempnerInstitute/KempnerForge/blob/main/CONTRIBUTING.md#new-parallelism-mode):
+decide where it fits in the dependency chain above, extend
+`build_parallel_model` with an explicit step, and add a distributed test
+that exercises the new mode in combination with the adjacent ones.
+
+## Quick reference: what goes wrong where
+
+| You did | What happens |
+|---------|--------------|
+| FSDP before TP | TP finds no `nn.Linear` to shard; run "works" with wrong gradients |
+| AC after FSDP | FSDP bucket boundaries break; reduce-scatter misfires |
+| Float8 after FSDP | FSDP cannot all-gather in float8; comms revert to bf16 |
+| FP8 + TP + `enable_fsdp_float8_all_gather=True` | Crash from `aten.is_pinned` on `DTensor` with no sharding strategy |
+| MoE+EP with per-block FSDP wrap | Backward deadlock between EP all-to-all and FSDP reduce-scatter |
+| MoE + Pipeline Parallelism | Rejected at config validation — data-dependent routing is incompatible with static stage splitting |
+
+## Where to read next
+
+- [Data flow](data-flow.md) — how a batch travels through the
+  parallelized model at step time.
+- [Reference § Parallelism recipes](../reference/index.md) — proven
+  `(model, GPU count, parallelism)` combinations.

--- a/docs/checkpointing/auto-resume.md
+++ b/docs/checkpointing/auto-resume.md
@@ -1,0 +1,199 @@
+# Auto-resume
+
+KempnerForge resumes a training run automatically on restart — no
+flag to pass, no manual path to point at. Every SLURM requeue, every
+preemption-and-restart, every "I killed the job and started it
+again" just works, as long as a checkpoint directory exists.
+
+## The resolution order
+
+[`resolve_resume_path`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/elastic.py):
+
+```python
+# kempnerforge/resilience/elastic.py (abridged — logging calls elided)
+def resolve_resume_path(checkpoint_dir: str) -> Path | None:
+    base = Path(checkpoint_dir)
+    if not base.exists():
+        return None
+
+    # 1. latest symlink
+    latest = base / "latest"
+    if latest.exists():
+        resolved = latest.resolve()
+        if resolved.exists():
+            return resolved
+
+    # 2. highest-numbered step_N directory
+    step_dirs = sorted(
+        (d for d in base.iterdir()
+         if d.is_dir() and d.name.startswith("step_") and d.name.split("_")[1].isdigit()),
+        key=lambda d: int(d.name.split("_")[1]),
+    )
+    if step_dirs:
+        return step_dirs[-1]
+
+    return None
+```
+
+Two fallbacks:
+
+1. **`latest` symlink** — the canonical pointer, updated atomically
+   after every successful save (see [Symlink updates](#symlink-updates)
+   below). Used in all healthy cases.
+2. **Highest `step_N` directory** — a safety net. If the symlink
+   is missing (disk corruption, manual `rm`, never created because
+   no save has completed), the resolver scans for the highest-numbered
+   `step_N` directory and uses that.
+
+If neither path finds anything, the function returns `None` and
+training starts from step 0.
+
+## Where it's called
+
+`scripts/train.py` calls this **once**, right after creating the
+`CheckpointManager`:
+
+```python
+resume_path = resolve_resume_path(config.checkpoint.dir)
+step, tokens_seen = 0, 0
+if resume_path or config.checkpoint.load_path:
+    step, tokens_seen, ckpt_extra_loaded = ckpt_mgr.load(
+        path=str(resume_path) if resume_path else None,
+        scheduler=scheduler,
+    )
+    if ckpt_extra_loaded.get("wandb_run_id"):
+        config.metrics.wandb_run_id = ckpt_extra_loaded["wandb_run_id"]
+```
+
+So two things can trigger a resume:
+
+- **`resume_path` found** — auto-resume; user passed nothing.
+- **`config.checkpoint.load_path` set** — explicit override; skip
+  the symlink lookup and load from that path. Useful for loading
+  pretrained weights, fine-tuning from a specific checkpoint, or
+  debugging.
+
+If both are set, `resume_path` wins (auto-resume takes precedence
+over the static config). This is deliberate: SLURM requeues should
+always pick up where they left off, not re-load the initial
+`load_path` every time.
+
+## Symlink updates
+
+Inside `CheckpointManager.save` (rank 0 only):
+
+```python
+# manager.py
+latest = self._latest_link()                # <dir>/latest
+tmp_link = latest.with_suffix(".tmp")       # <dir>/latest.tmp
+tmp_link.unlink(missing_ok=True)
+tmp_link.symlink_to(ckpt_dir.name)          # relative link: "step_1000"
+tmp_link.rename(latest)                     # atomic rename
+```
+
+Two details that matter:
+
+- **Relative target** — the symlink points at `step_1000`, not
+  `/abs/path/checkpoints/step_1000`. Checkpoint directories stay
+  portable when moved or bind-mounted.
+- **Atomic rename** — `tmp_link.rename(latest)` is a single atomic
+  syscall (`rename(2)` on POSIX). Either the old symlink is still
+  there or the new one is — never a half-written state. Safe against
+  crashes mid-save.
+
+The symlink is updated **after** the DCP save completes (async save
+futures are resolved before the next save starts), so `latest` only
+ever points at a fully-flushed checkpoint.
+
+## Retention cleanup
+
+After updating the symlink, `CheckpointManager._cleanup()` trims the
+oldest checkpoints beyond `config.checkpoint.keep_last_n`:
+
+```python
+ckpt_dirs = sorted((d for d in self.base_dir.iterdir()
+                    if d.is_dir() and d.name.startswith("step_")),
+                   key=lambda d: int(d.name.split("_")[1]))
+to_remove = ckpt_dirs[:-keep] if len(ckpt_dirs) > keep else []
+for d in to_remove:
+    shutil.rmtree(d)
+```
+
+Default `keep_last_n = 3`. The `latest` symlink always points at the
+newest, never at one scheduled for removal. If you want to keep
+everything, set `keep_last_n` to a large number — there's no
+"disable cleanup" flag (and the `__post_init__` check requires
+`keep_last_n >= 1`).
+
+## Edge cases
+
+- **Empty checkpoint directory** — `resolve_resume_path` returns
+  `None`, training starts from step 0. No error.
+- **`latest` symlink points at a removed directory** — the resolver
+  checks `resolved.exists()` after following the link; if it
+  doesn't, it falls through to the highest-`step_N` scan. This
+  catches the case where someone rm-rf'd a checkpoint but left the
+  symlink.
+- **Corrupted `step_N` directory** — `resolve_resume_path` doesn't
+  verify the contents. If DCP can't load from the resolved path,
+  `ckpt_mgr.load` raises and training aborts. In practice, async
+  saves either complete or leave a truncated directory that DCP
+  detects and errors on clearly.
+- **Fresh checkpoint dir, `load_path` set** — `load_path` is used
+  (the else branch). Training starts from the step in that
+  checkpoint.
+- **Multi-node NFS vs local disk** — the `latest` symlink lives on
+  disk along with the shards. For a shared filesystem (Lustre, NFS)
+  this just works. For local scratch, every node needs its own copy
+  of the checkpoint directory, which KempnerForge does not manage
+  automatically — use a shared filesystem.
+
+## Loading a specific step
+
+To rewind to an earlier checkpoint manually:
+
+```bash
+# Delete the symlink and let resolve_resume_path pick up step_5000
+cd checkpoints
+rm latest
+ln -s step_5000 latest
+```
+
+Or override explicitly:
+
+```toml
+[checkpoint]
+load_path = "checkpoints/step_5000"
+```
+
+The explicit override skips the symlink; SLURM requeues will still
+try auto-resume first (finding nothing newer than step 5000, they'll
+fall through to `load_path`).
+
+## Resilience interaction
+
+Auto-resume pairs with the SLURM preemption handler in
+[`kempnerforge/resilience/`](../resilience/index.md):
+
+1. SLURM sends `SIGTERM` on preemption.
+2. `SignalHandler` flags shutdown; the training loop finishes the
+   current step and saves an emergency checkpoint.
+3. `ckpt_mgr.wait()` flushes any async save before `destroy_distributed()`.
+4. SLURM requeues the job.
+5. New job starts, `resolve_resume_path` finds `latest`, training
+   resumes from the emergency checkpoint.
+
+See [Resilience § Signal handling](../resilience/index.md).
+
+## See also
+
+- [DCP model + optimizer](dcp-model.md) — the checkpoint format
+  that `ckpt_mgr.load` consumes.
+- [Train state](train-state.md) — what gets restored alongside the
+  model weights.
+- [Resharding](resharding.md) — what auto-resume does when the
+  GPU count changes between save and load.
+- [Configuration § CheckpointConfig](../configuration/config-sections.md) —
+  `load_path`, `keep_last_n`, `dir`.
+- [Resilience](../resilience/index.md) — the preemption handler
+  that drives the emergency save.

--- a/docs/checkpointing/dcp-model.md
+++ b/docs/checkpointing/dcp-model.md
@@ -1,0 +1,183 @@
+# DCP model + optimizer
+
+KempnerForge uses
+[`torch.distributed.checkpoint`](https://pytorch.org/docs/stable/distributed.checkpoint.html)
+(DCP) to save and load model and optimizer state. DCP is designed
+for sharded state — each rank writes only its local slice, the
+reader automatically reshards into whatever parallelism the loader
+has. No "rank 0 gathers everything" step.
+
+Entry point:
+[`CheckpointManager.save()`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/checkpoint/manager.py)
+in `kempnerforge/checkpoint/manager.py`.
+
+## What goes into the DCP shard
+
+```python
+dcp_state = {
+    "model":     self.model.state_dict(),
+    "optimizer": self.optimizer.state_dict(),
+}
+self._async_ckpt.save(
+    dcp_state, checkpoint_id=str(dcp_dir), process_group=self._process_group
+)
+```
+
+Two top-level keys — `"model"` and `"optimizer"`. DCP introspects the
+state dicts, finds `DTensor` / `ShardedTensor` parameters, and
+writes each shard to disk with enough metadata to reassemble.
+
+What's in each:
+
+- **`model.state_dict()`** — every parameter and buffer: weights,
+  RMSNorm scales, learned RoPE frequencies (if present), and any
+  registered buffer. Under FSDP2 these are `DTensor`s; under TP
+  they're `DTensor`s on a 2D mesh. DCP handles both.
+- **`optimizer.state_dict()`** — AdamW's `exp_avg`, `exp_avg_sq`,
+  `step` counters; Lion's `exp_avg`; Muon's internal state. All
+  per-parameter tensors live on the same device and parallelism
+  shape as the parameter, so DCP saves them symmetrically.
+
+Not in the DCP shard: scheduler, dataloader, RNG, and training
+metadata. Those go in `train_state.pt` alongside —
+[see Train state](train-state.md).
+
+## On-disk layout
+
+```
+checkpoints/
+├── step_1000/
+│   ├── .metadata                         ← DCP global manifest
+│   ├── __0_0.distcp                      ← rank-0 model shard
+│   ├── __1_0.distcp                      ← rank-1 model shard
+│   ├── ...                               ← one `.distcp` per rank
+│   ├── train_state.pt                    ← non-distributed state
+│   └── metadata.json                     ← human-readable step info
+├── step_2000/                            ← same layout
+└── latest -> step_2000                   ← symlink
+```
+
+`.distcp` files are the actual tensor storage (one per rank, written
+in parallel). `.metadata` is the global index that lets the reader
+figure out which `.distcp` file contains what.
+
+### With pipeline parallelism
+
+PP makes each stage hold a different set of parameters — DCP needs
+disjoint shards per stage, so `save()` writes to a per-stage
+subdirectory:
+
+```python
+# manager.py
+dcp_dir = ckpt_dir / f"pp{self._pp_rank}" if self._pp_rank is not None else ckpt_dir
+```
+
+```
+checkpoints/step_1000/
+├── pp0/                           ← stage 0 shards (embedding + first layers)
+│   ├── .metadata
+│   └── __*_0.distcp
+├── pp1/                           ← stage 1 shards
+│   ├── .metadata
+│   └── __*_0.distcp
+├── pp2/                           ← ...
+├── pp3/                           ← last stage (final norm + output head)
+└── train_state.pt                 ← one per checkpoint, written by global rank 0
+```
+
+Each stage also gets a process group scoped to that stage's DP + TP
+ranks:
+
+```python
+# scripts/train.py
+non_pp_dims = [d for d in device_mesh.mesh_dim_names if d != "pp"]
+if len(non_pp_dims) == 1:
+    ckpt_pg = device_mesh[non_pp_dims[0]].get_group()
+elif len(non_pp_dims) > 1:
+    ckpt_pg = device_mesh[tuple(non_pp_dims)].get_group()
+ckpt_mgr = CheckpointManager(config.checkpoint, model, optimizer,
+                             process_group=ckpt_pg, pp_rank=pp_rank)
+```
+
+A 1-D mesh slice has to be indexed by the dim name directly;
+`tuple(...)` wrapping is only valid for ≥2 dims. Both branches land
+on the same thing semantically — every rank at the same PP position
+coordinating together.
+
+Without the scoped group, DCP would try to coordinate across all
+world ranks (including other PP stages), and the stage-0 ranks
+would hang waiting for stage-1's shards.
+
+## Save modes
+
+[`AsyncCheckpointer`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/checkpoint/async_save.py)
+wraps DCP's `save` / `async_save` behind a mode flag:
+
+| Config | Behavior | Use |
+|--------|----------|-----|
+| `async_mode = "disabled"` | `dcp.save()` — blocking | Simple, debugging, small models |
+| `async_mode = "async"` | `dcp.async_save()` — snapshots to CPU, writes in background | Default for production |
+| `async_mode = "async_with_pinned_mem"` | Async with pinned-memory staging (faster GPU→CPU copy) | Very large models where GPU→CPU throughput bottlenecks the snapshot |
+
+Every `save()` call first does `self.wait()` — the previous async
+save must fully complete before starting a new one. This avoids
+holding two CPU snapshots at once and avoids racing on the same
+directory.
+
+The returned future is an `AsyncCheckpointerFuture`; `wait()` calls
+`.result()` which blocks until the background writer has flushed to
+disk. Training calls `ckpt_mgr.wait()` once before shutdown
+(`scripts/train.py` line ~788) to flush any pending save.
+
+## Process groups
+
+The `process_group=` kwarg on `dcp.save` and `dcp.load` scopes the
+all-gather / all-reduce calls that DCP uses internally. Rules:
+
+- Non-PP: use the default global group (`process_group=None`). Every
+  rank holds a slice of the same state.
+- PP: use a per-stage group. Stage `i`'s ranks (all DP × TP ranks at
+  PP position `i`) coordinate alone — they produce one DCP shard set
+  under `pp{i}/`.
+
+`CheckpointManager` stores the group at construction time and passes
+it through on every save/load.
+
+## Loading
+
+Load is the mirror image of save:
+
+```python
+dcp_state = {"model": self.model.state_dict(), "optimizer": self.optimizer.state_dict()}
+dcp.load(dcp_state, checkpoint_id=str(dcp_dir), process_group=self._process_group)
+self.model.load_state_dict(dcp_state["model"])
+self.optimizer.load_state_dict(dcp_state["optimizer"])
+```
+
+The first `state_dict()` call gives DCP the **shape** to fill — it
+doesn't contain the saved data, just the tensor metadata DCP needs
+to know what to load where. `dcp.load` mutates the tensors in place
+with the loaded values. Then `load_state_dict` consumes them.
+
+Loading with a different GPU count triggers DCP's automatic
+resharding — see [Resharding](resharding.md).
+
+To skip loading the optimizer (e.g. for fine-tuning), pass
+`exclude_keys=["optimizer"]`:
+
+```python
+ckpt_mgr.load(path=..., exclude_keys=["optimizer"])   # scripts/eval.py does this
+```
+
+## See also
+
+- [Resharding](resharding.md) — the save-at-N, load-at-M mechanics
+  that make DCP worth the extra files.
+- [Train state](train-state.md) — what else is in each checkpoint
+  directory.
+- [Auto-resume](auto-resume.md) — how KempnerForge finds the right
+  `step_N` on restart.
+- [HF conversion](hf-conversion.md) — exporting DCP shards to
+  HuggingFace safetensors.
+- [Configuration § CheckpointConfig](../configuration/config-sections.md) —
+  `async_mode`, `interval`, `keep_last_n`, `dir`.

--- a/docs/checkpointing/hf-conversion.md
+++ b/docs/checkpointing/hf-conversion.md
@@ -1,0 +1,201 @@
+# HuggingFace conversion
+
+[`scripts/convert_checkpoint.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/convert_checkpoint.py)
+converts between KempnerForge's DCP format and HuggingFace's
+safetensors (or `.bin`) format. Two directions:
+
+- **`dcp-to-hf`** — export a DCP checkpoint for HF inference,
+  model cards, or pushing to the Hub.
+- **`hf-to-dcp`** — import HF pretrained weights (e.g.
+  `meta-llama/Llama-3.1-8B`) into DCP for continued pretraining or
+  fine-tuning.
+
+Both directions are offline — no distributed training required,
+runs on a single CPU or GPU.
+
+## DCP → HuggingFace
+
+```bash
+uv run python scripts/convert_checkpoint.py dcp-to-hf \
+    --dcp-dir checkpoints/step_10000 \
+    --hf-dir exports/my_model \
+    --config configs/model/llama_7b.toml
+```
+
+What happens:
+
+1. Build a bare `Transformer(model_config)` on CPU — the default
+   random-initialized parameters serve only as target shapes that
+   DCP overwrites on load.
+2. Detect whether `dcp_dir` contains PP stage subdirectories
+   (`pp0/`, `pp1/`, …). If yes, load each stage's shards one at a
+   time with `strict=False` — each stage holds a disjoint slice of
+   the full model.
+3. Convert state dict keys from KempnerForge → HF naming.
+4. Cast to the requested dtype (default `bfloat16`).
+5. Write `model.safetensors` (or fall back to `pytorch_model.bin`
+   if the `safetensors` package isn't installed) plus a
+   `config.json` compatible with `AutoModelForCausalLM`.
+
+```
+exports/my_model/
+├── config.json              ← HF model config
+└── model.safetensors        ← weights
+```
+
+### Dtypes
+
+```bash
+--dtype bfloat16      # default
+--dtype float16       # e.g. for vLLM
+--dtype float32       # rarely useful; largest files
+```
+
+No optimizer / scheduler / RNG — only weights. If you need those,
+keep the DCP checkpoint; HF format doesn't carry them.
+
+### With PP
+
+A PP checkpoint has per-stage shards. The conversion script
+handles this automatically:
+
+```python
+# scripts/convert_checkpoint.py _detect_pp_stages
+pp_dirs = sorted((d for d in dcp_path.iterdir()
+                  if d.is_dir() and d.name.startswith("pp")),
+                 key=lambda d: int(d.name[2:]))
+```
+
+If any `pp0/`, `pp1/`, … exist, the script loads each one sequentially
+into the same full-model state dict via `load_state_dict(..., strict=False)`.
+Each stage fills in its owned slice of keys; at the end, the full
+model state is assembled.
+
+This is the path to use when you want to **reshard a PP checkpoint to
+different PP** — no direct DCP resharding across PP boundaries
+exists, but `dcp-to-hf` → `hf-to-dcp` round-trips through a
+non-sharded format and lets you re-emit at a different `pp` degree.
+
+## HuggingFace → DCP
+
+```bash
+# From a local HF directory
+uv run python scripts/convert_checkpoint.py hf-to-dcp \
+    --hf-dir /shared/models/llama-3.1-8b \
+    --dcp-dir checkpoints/pretrained \
+    --config configs/model/llama_8b.toml
+
+# Or from the HF Hub directly
+uv run python scripts/convert_checkpoint.py hf-to-dcp \
+    --hf-dir meta-llama/Llama-3.1-8B \
+    --dcp-dir checkpoints/pretrained \
+    --config configs/model/llama_8b.toml
+```
+
+What happens:
+
+1. Load the HF state dict:
+   - Local dir: prefer `*.safetensors`, fall back to
+     `pytorch_model*.bin`.
+   - HF ID: download via
+     `transformers.AutoModelForCausalLM.from_pretrained`.
+2. Convert keys HF → KempnerForge naming.
+3. `model.load_state_dict(converted, strict=False)` — missing KF
+   keys (e.g. learned RoPE frequencies) stay at their default init
+   and are logged as warnings.
+4. Write as DCP via `dcp.save({"model": model.state_dict()}, ...)`.
+
+```
+checkpoints/pretrained/
+├── .metadata               ← DCP index
+└── __*_0.distcp            ← weight shards
+```
+
+Point a training config at this directory via
+`[checkpoint] load_path = "checkpoints/pretrained"` and
+training picks it up like any other DCP checkpoint.
+
+## Key mapping
+
+KempnerForge uses Llama-style naming with a few differences. The
+main translations:
+
+| KempnerForge | HuggingFace |
+|--------------|-------------|
+| `token_embedding.embedding.weight` | `model.embed_tokens.weight` |
+| `output_head.proj.weight` | `lm_head.weight` |
+| `norm.weight` | `model.norm.weight` |
+| `layers.{i}.attention.{q,k,v,o}_proj.weight` | `model.layers.{i}.self_attn.{q,k,v,o}_proj.weight` |
+| `layers.{i}.attention_norm.weight` | `model.layers.{i}.input_layernorm.weight` |
+| `layers.{i}.mlp_norm.weight` | `model.layers.{i}.post_attention_layernorm.weight` |
+| `layers.{i}.mlp.{gate,up,down}_proj.weight` | `model.layers.{i}.mlp.{gate,up,down}_proj.weight` |
+
+MoE-specific:
+
+| KempnerForge | HuggingFace |
+|--------------|-------------|
+| `layers.{i}.mlp.router.gate.weight` | `model.layers.{i}.mlp.gate.weight` |
+| `layers.{i}.mlp.router.expert_bias` | `model.layers.{i}.mlp.expert_bias` |
+| `layers.{i}.mlp.shared_expert.*` | `model.layers.{i}.mlp.shared_experts.*` (plural in HF) |
+| `layers.{i}.mlp.experts.{j}.*` | `model.layers.{i}.mlp.experts.{j}.*` (identical) |
+
+The mapping logic is in `_kf_to_hf_key` and `_hf_to_kf_key` in
+`convert_checkpoint.py` — order-sensitive string replacements (e.g.
+`.attention_norm.` handled before `.attention.` to avoid partial
+matches).
+
+## Generated `config.json`
+
+For a dense model:
+
+```json
+{
+  "architectures": ["LlamaForCausalLM"],
+  "model_type": "llama",
+  "hidden_size": 4096,
+  "intermediate_size": 14336,
+  "num_hidden_layers": 32,
+  "num_attention_heads": 32,
+  "num_key_value_heads": 8,
+  "vocab_size": 128256,
+  "max_position_embeddings": 4096,
+  "rope_theta": 500000.0,
+  "rms_norm_eps": 1e-06,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16"
+}
+```
+
+For MoE the architecture is `MixtralForCausalLM` and three extra
+fields (`num_local_experts`, `num_experts_per_tok`,
+`router_aux_loss_coef`) are added.
+
+Not included: tokenizer files. Copy `tokenizer.json`, `tokenizer_config.json`,
+`special_tokens_map.json`, etc. from the source HF repo separately
+(they're not part of the weights).
+
+## Limitations
+
+- **One architecture at a time** — the converter assumes the model
+  is Llama or Mixtral style. Models with non-standard attention
+  variants (MLA, linear attention) need additional mapping.
+- **No optimizer state** — HF format doesn't carry optimizer state,
+  so `hf-to-dcp` produces a checkpoint with **model weights only**.
+  Training resumes with a fresh optimizer.
+- **Missing keys on `hf-to-dcp`** — the HF model may not have some
+  KempnerForge-specific buffers (e.g. `freqs_cis` for RoPE). These
+  stay at default init; the warning is informational, not an error.
+- **Key renames on `dcp-to-hf`** — if you've added custom modules to
+  the model, they'll land in the HF output under the KempnerForge
+  names (no translation rule). Downstream HF code won't recognize
+  them.
+
+## See also
+
+- [DCP model + optimizer](dcp-model.md) — the source format for
+  `dcp-to-hf` and the target format for `hf-to-dcp`.
+- [Resharding](resharding.md) — using `dcp-to-hf` → `hf-to-dcp` as
+  an escape hatch when DCP's automatic resharding can't handle your
+  change (e.g. changing PP degree).
+- [Configuration § CheckpointConfig](../configuration/config-sections.md) —
+  `load_path` to pick up a converted checkpoint.

--- a/docs/checkpointing/index.md
+++ b/docs/checkpointing/index.md
@@ -1,0 +1,54 @@
+# Checkpointing
+
+Distributed checkpoints via `torch.distributed.checkpoint` (DCP):
+what's saved, how resharding works, auto-resume rules, and
+HuggingFace interchange.
+
+```{toctree}
+:maxdepth: 1
+
+dcp-model
+resharding
+train-state
+auto-resume
+hf-conversion
+```
+
+## At a glance
+
+Every checkpoint lands in `{config.checkpoint.dir}/step_{N}/` and
+contains two kinds of state:
+
+| File(s) | Contents | Format |
+|---------|----------|--------|
+| DCP shards (`.distcp` + `.metadata`) | Model + optimizer state, one shard per rank | [DCP § Model + optimizer](dcp-model.md) |
+| `train_state.pt` | step, tokens_seen, scheduler, RNG, extras (e.g. `phase_idx`, `wandb_run_id`) | [Train state](train-state.md) |
+| `metadata.json` | Human-readable `{"step": N, "tokens_seen": M}` | Plain JSON |
+| `latest` symlink | Points at the most recent `step_N` (updated atomically) | [Auto-resume](auto-resume.md) |
+
+## Key modules
+
+- [`kempnerforge/checkpoint/manager.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/checkpoint/manager.py)
+  — `CheckpointManager.save()`/`load()`/`wait()`, `latest` symlink
+  maintenance, retention cleanup.
+- [`kempnerforge/checkpoint/async_save.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/checkpoint/async_save.py)
+  — `AsyncCheckpointer`: sync / async / pinned-memory modes.
+- [`kempnerforge/checkpoint/state.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/checkpoint/state.py)
+  — `build_train_state` / `restore_train_state`, RNG capture.
+- [`kempnerforge/resilience/elastic.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/elastic.py)
+  — `resolve_resume_path()` (checks the `latest` symlink and falls
+  back to the highest `step_N`).
+- [`scripts/convert_checkpoint.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/convert_checkpoint.py)
+  — `dcp-to-hf` and `hf-to-dcp` CLI.
+
+## Read next
+
+- **New reader**: [DCP model + optimizer](dcp-model.md) →
+  [Train state](train-state.md).
+- **Resuming a job**: [Auto-resume](auto-resume.md) first, then
+  [Resharding](resharding.md) if you're changing GPU count.
+- **Exporting for inference or HF checkpoints**:
+  [HF conversion](hf-conversion.md).
+- **Config knobs**:
+  [Configuration § CheckpointConfig](../configuration/config-sections.md)
+  (search for `interval`, `async_mode`, `keep_last_n`, `load_path`).

--- a/docs/checkpointing/resharding.md
+++ b/docs/checkpointing/resharding.md
@@ -1,0 +1,114 @@
+# Resharding
+
+The reason KempnerForge uses DCP instead of plain `torch.save` is
+**automatic resharding**: a checkpoint written at 32 GPUs can be
+loaded at 64 GPUs (or 16, or 8, or 1) without any conversion step.
+
+No code in `CheckpointManager` does this — DCP handles it entirely.
+What KempnerForge contributes is a checkpoint layout that survives
+the trip.
+
+## How it works
+
+Each `.distcp` shard contains **local tensor data** plus coordinates
+— which slice of which full parameter this shard represents. The
+`.metadata` file is a global index mapping parameter name → list of
+shards. On load:
+
+1. The loader's state dict gives DCP the target shape: e.g.
+   `layers.0.attention.q_proj.weight` is a `DTensor(Shard(0))` on a
+   `dp_shard=16` mesh.
+2. DCP reads `.metadata` to find every shard contributing to that
+   parameter.
+3. DCP assembles the right slice for each loader rank, doing
+   all-to-alls / point-to-points internally. Ranks that owned
+   non-overlapping slices exchange data; ranks with overlapping
+   slices pick the right piece.
+4. The loader's tensor is mutated in place.
+
+The catch: **parameter names must match**. If you rename a layer
+between save and load, DCP won't find the saved shard and will
+either error or silently leave the tensor uninitialized (it warns).
+
+## What it lets you change
+
+| Across save/load | Works | Caveat |
+|------------------|:-----:|--------|
+| `dp_shard` | yes | Any factor of the parameter shape |
+| `dp_replicate` | yes | Just adds replication on the load side |
+| `tp` | yes | Heads must still divide evenly |
+| `ep` | yes | `num_experts` still must divide evenly |
+| World size | yes | Pure rebalance across fewer/more ranks |
+| **`pp` stage count** | **no** | Per-stage `pp{N}/` subdirs; changing `pp` reassigns layers and moves the embedding/output to different stages |
+| Precision (bf16 → fp32) | yes | DCP upcasts on load |
+| Add a new parameter | yes | Missing-from-shard → warned, default-initialized |
+| Rename a parameter | no | Old name not in `.metadata` → error (or you patch the state dict keys before `load_state_dict`) |
+
+## PP — the one special case
+
+PP stores shards per-stage under `pp0/`, `pp1/`, …. A checkpoint saved
+at `pp=4` is **not loadable at `pp=2`** directly — DCP has no way to
+reassemble the stage boundaries. You have one of two paths:
+
+1. **Convert first.** Use
+   [`scripts/convert_checkpoint.py dcp-to-hf`](hf-conversion.md) to
+   flatten the per-stage shards into a single HF state dict, then
+   `hf-to-dcp` to re-emit a single-stage DCP checkpoint. This works
+   because the HF conversion reads every `pp{i}/` subdirectory and
+   merges them.
+2. **Keep the same `pp` on resume.** Auto-resume never changes the
+   parallelism shape, so a straight restart always works.
+
+The conversion path is what shipped configs use in practice: PP is
+chosen for the largest runs where memory forces it, and those runs
+typically don't need to rebalance mid-training.
+
+## What to check if resharding fails
+
+- **Tensor shape mismatch**: the most common cause is that the
+  model config changed between save and load (e.g. `n_heads`
+  changed, `dim` changed, `vocab_size` changed). DCP errors with
+  the target vs saved shape. Diff the configs.
+- **Missing parameter**: the saver never wrote a tensor for
+  `layers.42.mlp.some_new_module` because that module wasn't in the
+  model yet. DCP warns; the tensor stays default-initialized. Fine
+  when you've added a new head or adapter; bad when you expected
+  transfer.
+- **Extra parameter**: the saver wrote a tensor the loader doesn't
+  want (you removed a module). DCP ignores the extra shard —
+  silently, so watch the checkpoint size rather than relying on
+  warnings.
+- **`.metadata` disagreement between `pp{i}/` subdirs**: always a
+  bug — different PP stages should save independently. File an
+  issue.
+
+## Example: scale-up from 16 to 64 GPUs
+
+```bash
+# Train at 16 GPUs
+uv run torchrun --nproc_per_node=16 scripts/train.py configs/train/7b.toml \
+    --train.max_steps=5000 --checkpoint.dir=/checkpoints/7b_run
+
+# Bump to 64 GPUs and resume
+uv run torchrun --nproc_per_node=64 scripts/train.py configs/train/7b.toml \
+    --train.max_steps=20000 --checkpoint.dir=/checkpoints/7b_run
+```
+
+Auto-resume follows the `latest` symlink, `CheckpointManager.load`
+calls `dcp.load`, DCP reshards the 16-way sharded state into 64-way,
+training continues from step 5000. No manual intervention.
+
+The one thing that changes: effective batch size — 4× the DP ranks
+means 4× the batch per step. Adjust `grad_accum_steps` downward if
+you need to keep the global batch size constant.
+
+## See also
+
+- [DCP model + optimizer](dcp-model.md) — what's in each shard and
+  why `state_dict()` has to describe the target shape on load.
+- [Auto-resume](auto-resume.md) — how the training script chooses
+  which checkpoint to reshard.
+- [HF conversion](hf-conversion.md) — the escape hatch for
+  re-emitting a checkpoint with different PP.
+- [Device mesh](../distributed/device-mesh.md) — the mesh construction
+  that determines the target shard layout.

--- a/docs/checkpointing/train-state.md
+++ b/docs/checkpointing/train-state.md
@@ -1,0 +1,168 @@
+# Train state
+
+DCP covers model and optimizer; everything else — scheduler, RNG,
+training metadata, user extras — goes in a separate
+`train_state.pt` file written by rank 0.
+
+Entry points, both in
+[`kempnerforge/checkpoint/state.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/checkpoint/state.py):
+
+- `build_train_state(step, tokens_seen, scheduler, dataloader, extra)`
+  — builds the save dict.
+- `restore_train_state(state, scheduler, dataloader)` — reloads into
+  the scheduler / dataloader, returns `(step, tokens_seen, extra)`.
+
+## What's inside `train_state.pt`
+
+```python
+{
+    "step":        int,                   # current training step
+    "tokens_seen": int,                   # cumulative token count across DP ranks
+    "rng": {                              # full RNG capture (see below)
+        "python":     random.getstate(),
+        "numpy":      np.random.get_state(),
+        "torch_cpu":  torch.random.get_rng_state(),
+        "torch_cuda": torch.cuda.get_rng_state(),   # if CUDA available
+    },
+    "scheduler":   scheduler.state_dict(),            # present if scheduler passed
+    "dataloader":  dataloader.state_dict(),           # present if dataloader passed
+    # ... plus whatever was in the `extra` dict
+}
+```
+
+## Who writes it
+
+```python
+# manager.py, inside save()
+if self._rank == 0:
+    train_state = build_train_state(
+        step=step, tokens_seen=tokens_seen,
+        scheduler=scheduler, dataloader=dataloader, extra=extra,
+    )
+    torch.save(train_state, ckpt_dir / "train_state.pt")
+```
+
+Only global rank 0 writes — the file is not sharded. On load, rank
+0 reads and broadcasts it to every rank via
+`dist.broadcast_object_list` so all ranks agree on `step`, scheduler
+LR, RNG seeds, etc.
+
+## RNG capture
+
+`get_rng_state()` snapshots **four** generators:
+
+| Key | Generator | What it controls |
+|-----|-----------|------------------|
+| `python` | `random.getstate()` | Any use of the `random` module |
+| `numpy` | `np.random.get_state()` | Data loader sampling seeds, augmentations |
+| `torch_cpu` | `torch.random.get_rng_state()` | Dropout, random init on CPU |
+| `torch_cuda` | `torch.cuda.get_rng_state()` | Any CUDA-side randomness (dropout on GPU) |
+
+On load, `set_rng_state()` restores them all. Result: a resumed run
+produces the **exact same loss trajectory** as an uninterrupted run,
+step for step.
+
+The one thing the RNG snapshot doesn't cover: multi-process
+dataloader workers spawned by `torch.utils.data.DataLoader` have
+their own RNG state. Their seeds are set deterministically at worker
+init from the parent process's state, so they stay reproducible as
+long as `num_workers` doesn't change.
+
+## Scheduler state
+
+Passed through verbatim: whatever `scheduler.state_dict()` returns.
+For `LambdaLR` (the base of every registered scheduler — cosine,
+linear, wsd, rex, constant) the dict contains the step count and
+base LR, which together determine the next LR value. Restoring it
+gets you back the same LR schedule from that step.
+
+Pure `phase.lr_scale` overlays live in the training loop and are
+recomputed from the current phase, so they don't need to be saved.
+
+See [Training § Schedulers](../training/schedulers.md).
+
+## Dataloader state
+
+The infrastructure supports dataloader state (via
+`dataloader.state_dict()` / `load_state_dict()` on KempnerForge's
+`StatefulDataLoader`), but the shipped training loop in
+`scripts/train.py` **does not currently pass the dataloader** to
+`ckpt_mgr.save()`:
+
+```python
+ckpt_mgr.save(
+    step=step,
+    tokens_seen=tokens_seen,
+    scheduler=scheduler,
+    extra=ckpt_extra,          # note: no dataloader=...
+)
+```
+
+On resume, the dataloader restarts at the beginning of its epoch.
+Combined with sampler resume logic (see
+[Data § Stateful dataloader](../data/index.md)) and
+deterministic RNG, this is usually fine for most pretraining
+workflows — you may replay a few batches on resume but loss is not
+affected long-term.
+
+If exact-batch-level reproducibility matters, pass `dataloader=` into
+`ckpt_mgr.save()` yourself; `build_train_state` will pick it up
+automatically.
+
+## The `extra` dict
+
+Anything that isn't step / tokens / RNG / scheduler / dataloader
+can be threaded through `extra`:
+
+```python
+# scripts/train.py — around the checkpoint call
+ckpt_extra = {"phase_idx": current_phase_idx} if active_phases else {}
+if config.metrics.wandb_run_id:
+    ckpt_extra["wandb_run_id"] = config.metrics.wandb_run_id
+
+ckpt_mgr.save(step=step, tokens_seen=tokens_seen, scheduler=scheduler,
+              extra=ckpt_extra)
+```
+
+On load, `restore_train_state` strips out the "standard" keys
+(`step`, `tokens_seen`, `rng`, `scheduler`, `dataloader`) and returns
+the rest as the third tuple element:
+
+```python
+step, tokens_seen, extra = ckpt_mgr.load(path=..., scheduler=scheduler)
+if extra.get("wandb_run_id"):
+    config.metrics.wandb_run_id = extra["wandb_run_id"]
+```
+
+KempnerForge uses this for:
+
+- `phase_idx` — current curriculum phase (so training resumes the
+  correct data mix without skipping forward).
+- `wandb_run_id` — so resumed runs append to the same W&B run rather
+  than starting a new one.
+
+Custom training workflows can use it for anything
+`torch.save`-serializable.
+
+## Save failures
+
+`torch.save` uses `pickle` under the hood. If any object in the
+train state isn't picklable, the save raises — the DCP shard is
+already on disk, but the non-distributed state file is missing.
+
+Practical implication: keep `extra=` values to primitives, lists,
+dicts, and tensors. Don't stuff a live logger, process group, or
+generator in there.
+
+## See also
+
+- [DCP model + optimizer](dcp-model.md) — what DCP handles that
+  train state does not.
+- [Auto-resume](auto-resume.md) — how the training loop reads
+  `train_state.pt` on startup.
+- [Training § Schedulers](../training/schedulers.md) — what's in
+  `scheduler.state_dict()`.
+- [Data § Stateful dataloader](../data/index.md) —
+  why the current train.py doesn't pass the dataloader.
+- [Metrics § WandB resume](../metrics-and-profiling/index.md) — how
+  `wandb_run_id` in `extra` enables resumed W&B runs.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import importlib.metadata
 
 project = "KempnerForge"
-author = "Kempner Institute"
-copyright = "2026, Kempner Institute"
+author = "Kempner Institute for the Study of Natural and Artificial Intelligence at Harvard University"
+copyright = "2026, Kempner Institute for the Study of Natural and Artificial Intelligence at Harvard University"
 
 try:
     release = importlib.metadata.version("kempnerforge")
@@ -20,7 +20,6 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
-    "sphinx_autodoc_typehints",
     "sphinx_copybutton",
     "myst_parser",
 ]
@@ -33,6 +32,18 @@ source_suffix = {
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 autosummary_generate = True
+autodoc_mock_imports = [
+    "torch",
+    "torchao",
+    "torchdata",
+    "datasets",
+    "transformers",
+    "wandb",
+    "tensorboard",
+    "sympy",
+    "numpy",
+    "triton",
+]
 autodoc_default_options = {
     "members": True,
     "undoc-members": False,
@@ -80,7 +91,7 @@ html_theme_options = {
 
 nitpicky = False
 
-# PyTorch's DeviceMesh has an unresolved ``ArrayLike`` forward reference in
-# its signature — that is upstream, not ours, so suppress those warnings so
-# ``-W`` in CI still catches real issues in our own code.
-suppress_warnings = ["sphinx_autodoc_typehints.forward_reference"]
+# Autosummary generates stubs for both package re-exports (e.g. kempnerforge.config.JobConfig)
+# and their defining submodules (kempnerforge.config.job.JobConfig). Docstring refs to the
+# short name then resolve to two targets; silence those ambiguities.
+suppress_warnings = ["ref.python"]

--- a/docs/configuration/cli-overrides.md
+++ b/docs/configuration/cli-overrides.md
@@ -1,0 +1,129 @@
+# CLI overrides
+
+Any `JobConfig` field reachable through dotted attributes can be
+overridden from the command line with `--section.key=value`. Parsing
+happens in `_parse_cli_overrides` in
+[`kempnerforge/config/loader.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/loader.py);
+type coercion happens in `_coerce_value` in the same file.
+
+## Syntax
+
+```bash
+uv run python scripts/train.py configs/train/debug.toml \
+    --model.dim=512 \
+    --train.compile_model=false \
+    --optimizer.lr=1e-4 \
+    --optimizer.betas="[0.9,0.95]" \
+    --distributed.tp=2
+```
+
+Each flag must begin with `--`. Parsing splits once on `=`:
+
+- Left of `=` is the dotted path. It builds a nested dict:
+  `--model.dim=512` becomes `{"model": {"dim": 512}}`.
+- Right of `=` is the literal value. The loader calls
+  `ast.literal_eval` on it. If that raises, the raw string is kept.
+
+## Value parsing
+
+`ast.literal_eval` accepts Python literals:
+
+| CLI snippet | Parsed as |
+|-------------|-----------|
+| `--model.dim=512` | `int(512)` |
+| `--optimizer.lr=3e-4` | `float(0.0003)` |
+| `--train.compile_model=true` | `bool(True)` (via coercion — see below) |
+| `--optimizer.betas=[0.9,0.95]` | `list → tuple(0.9, 0.95)` (coerced to tuple by field type) |
+| `--checkpoint.load_path=/scratch/ckpt` | `str("/scratch/ckpt")` (literal_eval fails, keep as string) |
+| `--data.anneal_weights={"c4":0.7,"books":0.3}` | `dict` (parsed into `DataConfig.anneal_weights`) |
+
+Quote any value the shell would otherwise eat:
+
+```bash
+--optimizer.betas="[0.9,0.95]"   # list literal with spaces/brackets
+--data.dataset_path="/n/holylfs06/.../shards"
+```
+
+Lists of dataclasses (`DataConfig.datasets`, `DataConfig.phases`) are
+not ergonomic on the CLI — pass them in the TOML preset instead. The
+loader will accept them if you really want to, by expanding each entry
+to a dict literal, but the TOML version is readable:
+
+```toml
+[[data.datasets]]
+path = "/scratch/c4"
+weight = 0.7
+name = "c4"
+
+[[data.datasets]]
+path = "/scratch/books"
+weight = 0.3
+name = "books"
+```
+
+## Boolean shorthand
+
+A flag with no `=` becomes `True`:
+
+```bash
+--train.compile_model     # equivalent to --train.compile_model=true
+```
+
+For `False`, write it explicitly: `--train.compile_model=false`.
+
+The bool coercion also accepts the strings `"true"`, `"1"`, `"yes"`
+(case-insensitive) as `True`; everything else falls back to
+`bool(value)`.
+
+## Type coercion
+
+After `ast.literal_eval` produces a raw value, `_coerce_value` walks
+the dataclass type hint and coerces:
+
+| Field type | Input | Result |
+|------------|-------|--------|
+| `int` | `"512"` or `3.0` | `int(…)` |
+| `float` | `"3e-4"` or `1` | `float(…)` |
+| `bool` | `"true"`, `"1"`, `"yes"` | `True`; else `bool(value)` |
+| `tuple[float, float]` | `[0.9, 0.95]` | `(0.9, 0.95)` |
+| `list[str]` | `"a"` | `["a"]` (wraps bare scalar) |
+| `list[DatasetSource]` | `[{"path": …}]` | `[DatasetSource(path=…)]` (recursive) |
+| `Literal["bf16", "fp16", "fp32", "fp8"]` | anything else | `ValueError` |
+| `StrEnum` (`NormType`, `SchedulerType`, …) | `"rmsnorm"` | `NormType.rmsnorm` |
+| `X \| None` (Optional) | `None` → `None`; else coerce to `X` |
+
+`Literal` fields reject unknown strings at coercion time — a typo like
+`--train.mixed_precision=bfloat16` (should be `"bf16"`) fails before
+training starts.
+
+## Unknown keys
+
+`_apply_dict_to_dataclass` rejects keys not declared on the dataclass.
+A typo surfaces immediately:
+
+```bash
+$ uv run python scripts/train.py configs/train/debug.toml --model.dimm=512
+ValueError: Unknown config keys in ModelConfig: ['dimm'].
+Valid keys: ['activation', 'dim', ...]
+```
+
+## Inspecting the final config
+
+Print the resolved config before the training loop begins by adding
+the flag to `scripts/train.py` or dumping it from a REPL:
+
+```python
+from kempnerforge.config import load_config
+from dataclasses import asdict
+import json
+
+config = load_config("configs/train/debug.toml",
+                     cli_args=["--model.dim=512"])
+print(json.dumps(asdict(config), indent=2, default=str))
+```
+
+## See also
+
+- [Config sections](config-sections.md) — every field you can override.
+- [Validation rules](validation-rules.md) — what the loader checks
+  after overrides land.

--- a/docs/configuration/config-sections.md
+++ b/docs/configuration/config-sections.md
@@ -1,0 +1,281 @@
+# Config sections
+
+`JobConfig` aggregates ten typed sub-configs. Each one lives in its own
+module under
+[`kempnerforge/config/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/kempnerforge/config)
+and declares its fields with dataclass defaults. TOML sections map
+one-to-one onto these dataclass attributes:
+
+```toml
+[model]          # → config.model   (ModelConfig)
+[train]          # → config.train   (TrainConfig)
+[optimizer]      # → config.optimizer
+[scheduler]      # → config.scheduler
+[data]           # → config.data
+[eval]           # → config.eval
+[distributed]    # → config.distributed
+[checkpoint]     # → config.checkpoint
+[metrics]        # → config.metrics
+[profiling]      # → config.profiling
+```
+
+## JobConfig
+
+Owns the ten sub-configs and the cross-section `validate` method.
+[`kempnerforge/config/job.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/job.py).
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `model` | `ModelConfig` | architecture + MoE knobs |
+| `train` | `TrainConfig` | loop-level hyperparameters |
+| `optimizer` | `OptimizerConfig` | registry key + LR + betas + optimizer-specific knobs |
+| `scheduler` | `SchedulerConfig` | LR schedule shape and warmup |
+| `data` | `DataConfig` | dataset sources, mixing, annealing |
+| `eval` | `EvalConfig` | in-loop eval cadence and data source |
+| `distributed` | `DistributedConfig` | parallelism dims, NCCL timeout |
+| `checkpoint` | `CheckpointConfig` | DCP save cadence, retention, resume path |
+| `metrics` | `MetricsConfig` | logging cadence and backends |
+| `profiling` | `ProfilingConfig` | torch.profiler window and trace dir |
+
+## `[model]` — `ModelConfig`
+
+Architecture hyperparameters and MoE knobs.
+[`kempnerforge/config/model.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/model.py).
+
+### Dense
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `dim` | `int` | `4096` | hidden size |
+| `n_layers` | `int` | `32` | number of transformer blocks |
+| `n_heads` | `int` | `32` | attention heads |
+| `n_kv_heads` | `int \| None` | `None` | GQA: `None` → MHA (= `n_heads`), `1` → MQA, else GQA |
+| `vocab_size` | `int` | `32000` | embedding table size |
+| `ffn_dim_multiplier` | `float` | `1.0` | scales Llama-style `4·dim·(2/3)` hidden width |
+| `ffn_hidden_dim` | `int \| None` | `None` | hard-override the computed FFN width |
+| `norm_type` | `"rmsnorm" \| "layernorm"` | `"rmsnorm"` | registry key for norm builder |
+| `norm_eps` | `float` | `1e-5` | norm epsilon |
+| `activation` | `"silu" \| "gelu" \| "relu"` | `"silu"` | MLP activation (`silu` → SwiGLU) |
+| `max_seq_len` | `int` | `2048` | RoPE table length; `train.seq_len` must be ≤ this |
+| `rope_theta` | `float` | `10000.0` | RoPE frequency base |
+| `tie_embeddings` | `bool` | `False` | share embedding and output-head weight |
+| `qk_norm` | `bool` | `False` | RMSNorm over Q/K per head before RoPE |
+| `init_std` | `float` | `0.02` | weight-init std (GPT-2 / Llama convention) |
+| `model_type` | `str` | `"transformer"` | `model` registry key |
+| `sdpa_backend` | `str` | `"auto"` | one of `"auto"`, `"flash"`, `"efficient"`, `"cudnn"`, `"math"` |
+
+### MoE (all defaults produce a dense model)
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `num_experts` | `int` | `0` | `0` → dense; `>0` → MoE |
+| `moe_top_k` | `int` | `2` | experts selected per token |
+| `moe_frequency` | `int` | `1` | MoE every N layers (1=all, 2=alternating) |
+| `moe_router` | `str` | `"softmax_topk"` | `router` registry key |
+| `moe_shared_experts` | `int` | `0` | shared experts that always process every token |
+| `moe_aux_loss_weight` | `float` | `0.01` | coefficient in training loss |
+| `moe_capacity_factor` | `float` | `0.0` | `0` → no drop; `>0` → cap tokens/expert (typical `1.25`) |
+| `moe_sequence_aux_loss_weight` | `float` | `0.0` | sequence-level balance loss (0 = off) |
+| `moe_gradient_scale` | `bool` | `False` | per-expert gradient normalization |
+| `moe_bias_schedule` | `str` | `"constant"` | `"constant"`, `"cosine_decay"`, `"linear_warmup"` |
+| `moe_packed_experts` | `bool` | `False` | pack expert weights into one tensor per projection |
+
+Computed properties: `is_moe`, `head_dim`, `computed_ffn_hidden_dim`,
+`num_params_estimate`.
+
+## `[train]` — `TrainConfig`
+
+Training-loop hyperparameters.
+[`kempnerforge/config/training.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/training.py).
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `batch_size` | `int` | `8` | per-device micro-batch size |
+| `seq_len` | `int` | `2048` | tokens per sequence |
+| `max_steps` | `int` | `100000` | training-loop termination |
+| `grad_accum_steps` | `int` | `1` | microbatches per optimizer step |
+| `grad_clip_norm` | `float` | `1.0` | `clip_grad_norm_` cap |
+| `seed` | `int` | `42` | torch/numpy/python RNG seed |
+| `compile_model` | `bool` | `True` | wrap the model with `torch.compile` |
+| `mixed_precision` | `"bf16" \| "fp16" \| "fp32" \| "fp8"` | `"bf16"` | master-weight dtype; `"fp8"` uses bf16 masters with fp8 compute |
+| `activation_checkpointing` | `"none" \| "full" \| "selective"` | `"none"` | AC policy |
+| `loss_fn` | `str` | `"cross_entropy"` | `loss` registry key (or `"chunked_cross_entropy"`) |
+| `z_loss_weight` | `float` | `0.0` | logit-magnitude regularizer (PaLM uses `1e-4`) |
+| `ce_chunk_size` | `int` | `0` | chunk size for `chunked_cross_entropy` (`0` → auto 4096) |
+| `shutdown_timeout_sec` | `float` | `600.0` | graceful shutdown timeout before forced exit |
+| `nccl_health_check_interval` | `int` | `0` | NCCL liveness all-reduce every N steps (`0` = disabled) |
+
+Computed properties: `param_dtype`, `is_fp8`.
+
+## `[optimizer]` — `OptimizerConfig`
+
+Optimizer settings. `name` picks the registry builder; the other fields
+are shared (AdamW/Lion) or optimizer-specific.
+[`kempnerforge/config/optimizer.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/optimizer.py).
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `name` | `str` | `"adamw"` | one of `adamw`, `lion`, `muon`, `schedule_free_adamw` |
+| `lr` | `float` | `3e-4` | peak learning rate |
+| `weight_decay` | `float` | `0.1` | L2 on 2-D params |
+| `betas` | `tuple[float, float]` | `(0.9, 0.95)` | AdamW / Lion momenta |
+| `eps` | `float` | `1e-8` | numerical safety (AdamW) |
+| `fused` | `bool` | `True` | use fused AdamW when available |
+| `muon_momentum` | `float` | `0.95` | Muon momentum coefficient |
+| `muon_ns_steps` | `int` | `5` | Newton–Schulz iterations for Muon |
+| `muon_adam_lr` | `float \| None` | `None` | LR for 1-D params in Muon's AdamW fallback; `None` → same as `lr` |
+| `schedule_free_warmup_steps` | `int` | `0` | internal warmup for schedule-free |
+
+## `[scheduler]` — `SchedulerConfig`
+
+LR schedule shape and warmup.
+[`kempnerforge/config/scheduler.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/scheduler.py).
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `name` | `"cosine" \| "linear" \| "wsd" \| "constant" \| "rex" \| "none"` | `"cosine"` | `scheduler` registry key |
+| `warmup_steps` | `int` | `2000` | linear warmup length |
+| `decay_steps` | `int \| None` | `None` | `None` → decay over remaining steps |
+| `min_lr_ratio` | `float` | `0.1` | floor = `lr * min_lr_ratio` |
+| `stable_steps` | `int \| None` | `None` | WSD: steps at constant LR between warmup and decay |
+| `wsd_decay_type` | `"cosine" \| "linear" \| "sqrt"` | `"cosine"` | WSD cooldown shape |
+| `rex_alpha` | `float` | `1.0` | REX exponent: `(1 - t/T)^alpha` |
+
+## `[data]` — `DataConfig`
+
+Single dataset, HuggingFace source, or mixture; optional phase schedule.
+[`kempnerforge/config/data.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/data.py).
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `dataset_path` | `str` | `""` | directory of pre-tokenized shards |
+| `file_pattern` | `str` | `"*.npy"` | glob inside `dataset_path` |
+| `tokenizer_path` | `str` | `""` | path or HF id for the tokenizer |
+| `num_workers` | `int` | `4` | DataLoader workers |
+| `pin_memory` | `bool` | `True` | DataLoader pin memory |
+| `prefetch_factor` | `int` | `2` | DataLoader prefetch factor |
+| `hf_dataset_name` | `str \| None` | `None` | HF dataset id (e.g. `"wikitext"`) |
+| `hf_dataset_config` | `str \| None` | `None` | HF dataset config (e.g. `"wikitext-2-raw-v1"`) |
+| `hf_dataset_split` | `str` | `"train"` | HF split |
+| `hf_dataset_text_field` | `str` | `"text"` | field to tokenize |
+| `hf_streaming` | `bool` | `False` | use `IterableDataset` for large corpora |
+| `pack_sequences` | `bool` | `False` | document-aware packing with cross-doc isolation (feeds `doc_ids` to attention) |
+| `datasets` | `list[DatasetSource]` | `[]` | multi-dataset mixture (overrides `dataset_path`/`hf_dataset_name` when non-empty) |
+| `mix_temperature` | `float` | `1.0` | weight scaling; `1.0` → as-is, larger → more uniform |
+| `phases` | `list[TrainingPhase]` | `[]` | multi-phase schedule with weight/LR transitions |
+| `anneal_start_step` | `int` | `0` | syntactic sugar for a common 2-phase annealing pattern (`0` = disabled) |
+| `anneal_weights` | `dict[str, float]` | `{}` | per-dataset weights applied at `anneal_start_step` |
+
+### `DatasetSource`
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `path` | `str` | `""` | pre-tokenized directory |
+| `weight` | `float` | `1.0` | relative sampling weight (must be `> 0`) |
+| `name` | `str` | `""` | name for per-dataset metrics (auto-derived if empty) |
+| `hf_name` | `str` | `""` | HF dataset id |
+| `hf_config` | `str` | `""` | HF dataset config |
+
+Either `path` or `hf_name` must be set per source.
+
+### `TrainingPhase`
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `start_step` | `int` | `0` | step at which the phase activates |
+| `dataset_weights` | `dict[str, float]` | `{}` | per-dataset weights for this phase |
+| `lr_scale` | `float` | `1.0` | multiplier applied to scheduler LR |
+
+`phases[*].start_step` must be strictly increasing; `phases` and
+`anneal_start_step` are mutually exclusive.
+
+## `[eval]` — `EvalConfig`
+
+In-loop evaluation. Disabled by default.
+[`kempnerforge/config/eval.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/eval.py).
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `enabled` | `bool` | `False` | gate in-loop eval |
+| `interval` | `int` | `1000` | eval every N training steps |
+| `steps` | `int` | `50` | eval batches per evaluation |
+| `dataset_path` | `str` | `""` | pre-tokenized eval shards |
+| `file_pattern` | `str` | `"*.npy"` | glob inside `dataset_path` |
+| `hf_dataset_name` | `str \| None` | `None` | HF dataset id |
+| `hf_dataset_config` | `str \| None` | `None` | HF dataset config |
+| `hf_dataset_split` | `str` | `"validation"` | HF split |
+
+If `enabled=True`, at least one of `dataset_path` / `hf_dataset_name`
+must be set; `validate()` rejects the combination otherwise.
+
+## `[distributed]` — `DistributedConfig`
+
+Parallelism dimensions and NCCL settings.
+[`kempnerforge/config/distributed.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/distributed.py).
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `dp_shard` | `int` | `-1` | FSDP shard degree; `-1` → auto (use remaining GPUs) |
+| `dp_replicate` | `int` | `1` | DDP-style replication over FSDP groups |
+| `tp` | `int` | `1` | tensor parallel |
+| `pp` | `int` | `1` | pipeline parallel |
+| `pp_schedule` | `"1f1b" \| "gpipe" \| "interleaved_1f1b"` | `"1f1b"` | pipeline schedule |
+| `cp` | `int` | `1` | context parallel (stub; PyTorch 2.11 ring attention) |
+| `ep` | `int` | `1` | expert parallel (MoE only) |
+| `nccl_timeout_sec` | `int` | `1800` | NCCL collective timeout |
+| `backend` | `str` | `"cpu:gloo,cuda:nccl"` | `torch.distributed` backend mapping |
+
+The product `dp_replicate × dp_shard × tp × pp × cp × ep` must equal
+`world_size`. Methods: `validate_world_size(ws)`, `resolve(ws)`.
+
+## `[checkpoint]` — `CheckpointConfig`
+
+DCP-based checkpointing.
+[`kempnerforge/config/checkpoint.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/checkpoint.py).
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `dir` | `str` | `"checkpoints"` | root directory for `step_N/` + `latest` symlink |
+| `interval` | `int` | `1000` | save every N steps |
+| `async_mode` | `"disabled" \| "async" \| "async_with_pinned_mem"` | `"disabled"` | DCP async-save mode |
+| `keep_last_n` | `int` | `3` | retain the most recent N checkpoints |
+| `load_path` | `str \| None` | `None` | explicit resume path (overrides `latest` symlink) |
+| `export_dtype` | `"float32" \| "bfloat16"` | `"bfloat16"` | dtype for HF exports via `scripts/convert_checkpoint.py` |
+| `exclude_from_loading` | `list[str]` | `[]` | FQN prefixes to skip on load (e.g. to reinit a head) |
+
+## `[metrics]` — `MetricsConfig`
+
+Logging cadence and backend toggles.
+[`kempnerforge/config/metrics.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/metrics.py).
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `log_interval` | `int` | `10` | log every N steps (stdout + enabled backends) |
+| `enable_wandb` | `bool` | `False` | turn on WandB backend |
+| `enable_tensorboard` | `bool` | `False` | turn on TensorBoard backend |
+| `wandb_project` | `str` | `"kempnerforge"` | WandB project name |
+| `wandb_run_name` | `str \| None` | `None` | `None` → auto-generated |
+| `wandb_run_id` | `str` | `""` | restored from checkpoint on resume; empty = new run |
+| `tensorboard_dir` | `str` | `"tb_logs"` | TB log directory |
+
+## `[profiling]` — `ProfilingConfig`
+
+`torch.profiler` window.
+[`kempnerforge/config/profiling.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/profiling.py).
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `enable` | `bool` | `False` | run the profiler during the loop |
+| `start_step` | `int` | `5` | first step recorded |
+| `end_step` | `int` | `8` | last step recorded (must be `>` `start_step`) |
+| `trace_dir` | `str` | `"profiler_traces"` | output directory for Chrome/Perfetto traces |
+
+## Where to read next
+
+- [CLI overrides](cli-overrides.md) — reshape any of these fields from
+  the command line.
+- [Validation rules](validation-rules.md) — what `__post_init__` and
+  `validate(world_size)` enforce.
+- [Registry](registry.md) — how the string keys above
+  (`moe_router`, `norm_type`, `optimizer.name`, `scheduler.name`,
+  `loss_fn`, `model_type`) resolve to builders.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,0 +1,58 @@
+# Configuration
+
+Every run is driven by a typed `JobConfig` built from three layers:
+dataclass defaults, a TOML preset, and `--section.key=value` CLI
+overrides. All three flow through `load_config` in
+[`kempnerforge/config/loader.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/loader.py).
+
+```python
+from kempnerforge.config import load_config
+
+config = load_config("configs/train/debug.toml",
+                     cli_args=["--model.dim=512", "--train.compile_model=false"])
+config.validate(world_size=1)
+```
+
+`validate(world_size)` enforces cross-section rules that a single
+dataclass can't check on its own (e.g. parallelism factors × world size,
+`tie_embeddings` vs PP, FP8 vs TP, MoE vs PP).
+
+## Layering
+
+1. **Defaults** — every dataclass in
+   [`kempnerforge/config/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/kempnerforge/config)
+   declares field defaults that reproduce a 7B Llama-like run.
+2. **TOML preset** — `configs/train/*.toml` overlays those defaults.
+   Unknown keys raise `ValueError` (catches typos like `modell.dim`
+   immediately, not at step 1000).
+3. **CLI overrides** — each `--section.key=value` flag rewrites the
+   layered dict. `ast.literal_eval` parses ints, floats, lists, tuples,
+   and booleans; anything unparseable stays as a string.
+
+## Pages
+
+```{toctree}
+:maxdepth: 1
+
+config-sections
+cli-overrides
+validation-rules
+registry
+```
+
+- **[Config sections](config-sections.md)** — `JobConfig` and its 10
+  sub-configs, field by field.
+- **[CLI overrides](cli-overrides.md)** — dotted-path syntax, booleans,
+  lists, nested dataclasses.
+- **[Validation rules](validation-rules.md)** — per-dataclass
+  `__post_init__` checks plus `JobConfig.validate(world_size)`
+  cross-section rules.
+- **[Registry](registry.md)** — the seven component categories
+  (`model`, `optimizer`, `scheduler`, `loss`, `norm`, `router`,
+  `mlp`) and how to plug a new builder in.
+
+## See also
+
+- [Architecture § Design principles](../architecture/index.md#design-principles)
+- [Parallelism order](../architecture/parallelism-order.md) — the
+  invariants the cross-section validator enforces.

--- a/docs/configuration/registry.md
+++ b/docs/configuration/registry.md
@@ -1,0 +1,144 @@
+# Registry
+
+The component registry is a two-level map
+`category → name → builder`, lives in
+[`kempnerforge/config/registry.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/registry.py),
+and is the single indirection that lets configs pick components by
+string. Seven categories ship populated; you can add your own builder
+under any of them (or create a new category) without touching the core
+training loop.
+
+```python
+from kempnerforge.config.registry import registry
+
+registry.register("mlp", "my_mlp", builder_fn)
+model = registry.get("mlp", "my_mlp")(dim=4096, hidden_dim=11008)
+```
+
+`register(category, name, obj)` fails fast on duplicate names; `get`
+raises `KeyError` with an "Available: […]" hint when a name is missing;
+`list(category)` returns registered names.
+
+## The seven categories
+
+| Category | Registered keys | Selected by config field |
+|----------|-----------------|--------------------------|
+| `model` | `transformer` | `model.model_type` |
+| `optimizer` | `adamw`, `lion`, `muon`, `schedule_free_adamw` | `optimizer.name` |
+| `scheduler` | `cosine`, `linear`, `wsd`, `constant`, `rex`, `none` | `scheduler.name` |
+| `loss` | `cross_entropy`, `chunked_cross_entropy` | `train.loss_fn` |
+| `norm` | `rmsnorm`, `layernorm` | `model.norm_type` |
+| `router` | `softmax_topk`, `sigmoid_topk` | `model.moe_router` |
+| `mlp` | `swiglu`, `standard_gelu`, `standard_relu` | `model.activation` (mapped) |
+
+The `mlp` case is the only one that isn't a direct string match:
+`build_mlp` in
+[`kempnerforge/model/mlp.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/mlp.py)
+maps `activation="silu"` → `swiglu`, `"gelu"` → `standard_gelu`,
+`"relu"` → `standard_relu` before calling `registry.get("mlp", …)`.
+
+## Consumers
+
+Where each category is looked up in the codebase:
+
+| Category | Call site |
+|----------|-----------|
+| `model` | `registry.get_model(model_config.model_type)` in [`kempnerforge/distributed/parallel.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/parallel.py) |
+| `optimizer` | `registry.get_optimizer(config.name)` in [`kempnerforge/training/optimizer.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/optimizer.py) |
+| `scheduler` | `registry.get_scheduler(name)` in [`kempnerforge/training/scheduler.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/scheduler.py) |
+| `loss` | `registry.get_loss(config.loss_fn)` in [`kempnerforge/training/loss.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/loss.py) |
+| `norm` | `registry.get("norm", norm_type)` in [`kempnerforge/model/norm.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/norm.py) |
+| `router` | `registry.get("router", router_type)` in [`kempnerforge/model/moe.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/moe.py) |
+| `mlp` | `registry.get("mlp", key)` in [`kempnerforge/model/mlp.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/mlp.py) |
+
+## Registering a new builder
+
+Four of the seven categories provide a decorator (`register_model`,
+`register_optimizer`, `register_scheduler`, `register_loss`). The other
+three are registered with `register("category", "name", fn)` at
+module-import time. Both routes land in the same `_stores` dict.
+
+### With a decorator
+
+```python
+from kempnerforge.config.registry import registry
+
+@registry.register_optimizer("my_adam")
+def build_my_adam(params, config):
+    return MyAdam(params, lr=config.lr, betas=config.betas)
+```
+
+Configs then pick it up via `[optimizer] name = "my_adam"`.
+
+### With `register(...)`
+
+```python
+from kempnerforge.config.registry import registry
+from kempnerforge.model.norm import RMSNorm
+
+def _build_my_norm(dim, eps):
+    return MyNorm(dim, eps=eps)
+
+registry.register("norm", "my_norm", _build_my_norm)
+```
+
+Configs then pick it up via `[model] norm_type = "my_norm"`.
+
+### Making sure the module runs
+
+Registration happens at import. If nothing imports the module that
+calls `registry.register`, the entry never lands. Typical approach:
+
+- Put the new builder in a module under
+  `kempnerforge/<subsystem>/`, and add an import in that package's
+  `__init__.py` (or the existing module the training loop already
+  pulls in). Existing example:
+  [`kempnerforge/model/norm.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/norm.py)
+  registers at module scope, and
+  [`kempnerforge/model/__init__.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/__init__.py)
+  imports it so the registration runs.
+- Third-party code (not landed in `kempnerforge/`) can import its
+  registration module explicitly before calling `load_config` or
+  `build_parallel_model`.
+
+## Adding a new category
+
+There's nothing special about the seven — `register(category, name,
+obj)` creates the store on first use:
+
+```python
+registry.register("reward_model", "pair_rm", build_pair_rm)
+builder = registry.get("reward_model", "pair_rm")
+```
+
+The convenience `register_*` / `get_*` methods on `Registry` are just
+sugar over the generic `register` / `get`. Add your own if it reads
+better.
+
+## Signatures
+
+The registry is untyped — `register(category, name, obj)` accepts any
+callable. The de-facto contract is "the call site expects a specific
+signature, and your builder has to match it." Existing examples:
+
+| Category | Expected signature |
+|----------|--------------------|
+| `model` | `fn(config: ModelConfig) → nn.Module` |
+| `optimizer` | `fn(params, config: OptimizerConfig) → torch.optim.Optimizer` |
+| `scheduler` | `fn(optimizer, config: SchedulerConfig, max_steps: int) → LRScheduler` |
+| `loss` | `fn(logits, labels, …) → Tensor` (see existing `cross_entropy` for the exact kwargs) |
+| `norm` | `fn(dim: int, eps: float) → nn.Module` |
+| `router` | `fn(dim, num_experts, top_k, **kwargs) → nn.Module` |
+| `mlp` | `fn(dim: int, hidden_dim: int) → nn.Module` |
+
+Check the closest existing builder (e.g.
+[`_build_swiglu`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/mlp.py))
+before writing a new one — matching its signature exactly is the
+fastest path to correctness.
+
+## See also
+
+- [Config sections](config-sections.md) — which config fields resolve
+  to which registry category.
+- [Architecture § Model](../architecture/model.md#registry-keys) — the
+  per-component registry lookup table from the model side.

--- a/docs/configuration/validation-rules.md
+++ b/docs/configuration/validation-rules.md
@@ -1,0 +1,258 @@
+# Validation rules
+
+Validation runs in two passes:
+
+1. **Per-dataclass `__post_init__`** — fires the moment the dataclass is
+   instantiated (i.e. as soon as the TOML and CLI overrides land).
+   Checks fields that can be validated in isolation.
+2. **`JobConfig.validate(world_size)`** — called explicitly by the
+   launchers
+   ([`scripts/train.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/train.py),
+   [`scripts/eval.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/eval.py))
+   once `world_size` is known. Checks rules that cross section
+   boundaries.
+
+All invalid cases raise `ValueError` with a message naming the fields
+involved, unless noted otherwise.
+
+## Per-dataclass `__post_init__`
+
+### `ModelConfig`
+
+File:
+[`kempnerforge/config/model.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/model.py).
+
+- `n_kv_heads` defaults to `n_heads` if left `None` (MHA).
+- `dim`, `n_layers`, `n_heads`, `vocab_size`, `n_kv_heads` must all be
+  positive.
+- `dim % n_heads == 0` (head dim is integral).
+- `n_heads % n_kv_heads == 0` (GQA replication factor is integral).
+- `sdpa_backend ∈ {"auto", "flash", "efficient", "cudnn", "math"}`.
+- When `num_experts > 0` (MoE):
+  - `moe_top_k > 0`
+  - `moe_top_k ≤ num_experts`
+  - `moe_frequency > 0`
+  - `moe_sequence_aux_loss_weight ≥ 0`
+  - `moe_bias_schedule ∈ {"constant", "cosine_decay", "linear_warmup"}`
+
+### `TrainConfig`
+
+File:
+[`kempnerforge/config/training.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/training.py).
+
+- `batch_size`, `seq_len`, `max_steps`, `grad_accum_steps` all positive.
+- `grad_clip_norm > 0`.
+
+### `OptimizerConfig`
+
+File:
+[`kempnerforge/config/optimizer.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/optimizer.py).
+
+- `lr > 0`.
+- `weight_decay ≥ 0`.
+- `betas[0], betas[1] ∈ [0, 1)`.
+- `muon_momentum ∈ (0, 1)`.
+- `muon_ns_steps > 0`.
+- `schedule_free_warmup_steps ≥ 0`.
+
+### `SchedulerConfig`
+
+File:
+[`kempnerforge/config/scheduler.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/scheduler.py).
+
+- `warmup_steps ≥ 0`.
+- `min_lr_ratio ∈ [0, 1]`.
+- `wsd_decay_type ∈ {"cosine", "linear", "sqrt"}`.
+- `rex_alpha > 0`.
+
+### `DataConfig` (and nested types)
+
+File:
+[`kempnerforge/config/data.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/data.py).
+
+`DataConfig`:
+
+- `num_workers ≥ 0`.
+- `prefetch_factor ≥ 1`.
+- `mix_temperature > 0`.
+- Every `DatasetSource` in `datasets` has `path` or `hf_name` set.
+- If `phases` is non-empty, `phases[*].start_step` is strictly
+  monotonically increasing (and unique).
+- `anneal_start_step ≥ 0`.
+- `phases` and `anneal_start_step > 0` are mutually exclusive.
+
+`DatasetSource`:
+
+- `weight > 0`.
+
+`TrainingPhase`:
+
+- `start_step ≥ 0`.
+- `lr_scale > 0`.
+- Every weight in `dataset_weights ≥ 0`.
+
+### `EvalConfig`
+
+File:
+[`kempnerforge/config/eval.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/eval.py).
+
+- `interval > 0`.
+- `steps > 0`.
+
+(Data-source presence is enforced by `JobConfig.validate`, not here —
+a disabled eval is still a valid `EvalConfig`.)
+
+### `DistributedConfig`
+
+File:
+[`kempnerforge/config/distributed.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/distributed.py).
+
+- `dp_shard ∈ {-1} ∪ {1, 2, …}` (negative values other than `-1`
+  rejected; `-1` is the auto-resolve sentinel).
+- `dp_replicate, tp, pp, cp, ep ≥ 1`.
+
+World-size validation happens in `validate_world_size` (called from
+`JobConfig.validate`).
+
+### `CheckpointConfig`
+
+File:
+[`kempnerforge/config/checkpoint.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/checkpoint.py).
+
+- `interval > 0`.
+- `keep_last_n ≥ 1`.
+
+### `MetricsConfig`
+
+File:
+[`kempnerforge/config/metrics.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/metrics.py).
+
+- `log_interval > 0`.
+
+### `ProfilingConfig`
+
+File:
+[`kempnerforge/config/profiling.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/profiling.py).
+
+- `end_step > start_step`.
+
+## Cross-section rules — `JobConfig.validate(world_size)`
+
+File:
+[`kempnerforge/config/job.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/job.py).
+
+### Parallelism arithmetic
+
+`distributed.validate_world_size(world_size)` requires
+
+```
+dp_replicate × dp_shard × tp × pp × cp × ep == world_size
+```
+
+with `dp_shard=-1` resolving to `world_size / (dp_replicate·tp·pp·cp·ep)`
+(must be an integer). Any mismatch raises `ValueError` naming all six
+factors and the resolved `dp_shard`.
+
+### Sequence length
+
+```
+train.seq_len ≤ model.max_seq_len
+```
+
+The RoPE frequency tables are sized by `model.max_seq_len`; exceeding
+it would index past the end.
+
+### Tie embeddings vs pipeline parallel
+
+```
+model.tie_embeddings && distributed.pp > 1  →  ValueError
+```
+
+The embedding and output-head weights must live on different pipeline
+stages, so they can't be tied.
+
+### Eval data source
+
+```
+eval.enabled && !eval.dataset_path && !eval.hf_dataset_name  →  ValueError
+```
+
+### Tensor-parallel head divisibility
+
+When `distributed.tp > 1`:
+
+- `model.n_heads % distributed.tp == 0`
+- `model.n_kv_heads % distributed.tp == 0`
+
+### FP8 + TP
+
+```
+train.is_fp8 && distributed.tp > 1  →  ValueError
+```
+
+Rationale in the error message: `torchao.Float8Linear` does not compose
+with DTensor sharding today.
+
+### MoE + PP
+
+```
+model.is_moe && distributed.pp > 1  →  ValueError
+```
+
+Rationale: routing is data-dependent and resists pipeline-stage
+splitting. Use FSDP, TP, or EP instead.
+
+### Expert parallel
+
+When `distributed.ep > 1`:
+
+- `model.is_moe` must be `True` (the error reads
+  `"ep > 1 requires an MoE model (num_experts > 0)"`).
+- `model.num_experts % distributed.ep == 0`.
+
+### MoE + torch.compile — warning, not error
+
+```
+model.is_moe && train.compile_model  →  logger.warning(…)
+```
+
+Routing produces data-dependent shapes that break `torch.compile`'s
+graph, so the loop logs a warning but still runs. Set
+`train.compile_model=false` for MoE runs.
+
+## Example: a failing config and its error
+
+```toml
+# configs/train/bad.toml
+[model]
+n_heads = 17         # prime → TP divisibility will fail
+max_seq_len = 1024
+
+[train]
+seq_len = 2048       # exceeds max_seq_len
+
+[distributed]
+tp = 4
+```
+
+Loading works (no `__post_init__` failure since each field is valid in
+isolation), but `validate(world_size=4)` raises:
+
+```
+ValueError: train.seq_len (2048) exceeds model.max_seq_len (1024)
+```
+
+Fix `seq_len`, re-run, and the next error is:
+
+```
+ValueError: n_heads (17) must be divisible by tp (4)
+```
+
+`validate` is ordered — each call surfaces the first failing invariant.
+
+## See also
+
+- [Config sections](config-sections.md) — every field that these rules
+  reference.
+- [Architecture § Parallelism order](../architecture/parallelism-order.md)
+  — the 5-step order these cross-section rules exist to protect.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,3 @@
+```{include} ../CONTRIBUTING.md
+:parser: myst_parser.sphinx_
+```

--- a/docs/data/huggingface.md
+++ b/docs/data/huggingface.md
@@ -1,0 +1,140 @@
+# HuggingFace datasets
+
+Two classes, one selector flag:
+
+- **`HuggingFaceDataset`** (eager) — loads the entire split into
+  memory, tokenizes once, packs into fixed-length sequences.
+- **`StreamingHuggingFaceDataset`** (streaming) — an `IterableDataset`
+  that pulls documents from the Hub on the fly, tokenizes per
+  iteration, and yields packed sequences as they fill.
+
+Config flag: `data.hf_streaming` (default `false`).
+
+Both classes live in
+[`kempnerforge/data/dataset.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/data/dataset.py).
+
+## Eager — `HuggingFaceDataset`
+
+```toml
+[data]
+hf_dataset_name       = "wikitext"
+hf_dataset_config     = "wikitext-103-raw-v1"   # optional
+hf_dataset_split      = "train"
+hf_dataset_text_field = "text"
+hf_streaming          = false
+tokenizer_path        = "gpt2"
+```
+
+Flow on construction:
+
+1. `AutoTokenizer.from_pretrained(tokenizer_path)` — loads the
+   tokenizer. The EOS token ID falls back to `0` if the tokenizer
+   doesn't declare one.
+2. `load_dataset(name, config, split=split)` — the full HF split is
+   materialized.
+3. Each example's `text_field` is encoded with `add_special_tokens=False`,
+   an EOS token is appended, and the combined token stream is sliced
+   into fixed `(seq_len + 1)` chunks. The extra `+1` is for the
+   next-token label offset.
+4. Partial remainder at the end is discarded — clean, full sequences
+   only.
+
+At training time `__getitem__(idx)` returns
+`{"input_ids": tokens[:-1], "labels": tokens[1:]}` (plus `doc_ids` if
+`pack_sequences=true`).
+
+Good for: small-to-medium corpora that fit in memory; repeatable
+experiments where you want a fixed sequence order.
+
+Bad for: anything where `load_dataset(...)` itself would OOM.
+
+## Streaming — `StreamingHuggingFaceDataset`
+
+```toml
+[data]
+hf_dataset_name = "allenai/c4"
+hf_dataset_split = "train"
+hf_streaming = true
+tokenizer_path = "meta-llama/Llama-3-8B"
+```
+
+Stream mode is an `IterableDataset`:
+
+- No `__len__`, no sampler (the dataset is its own iterator).
+- `scripts/train.py` wraps it in a plain `torch.utils.data.DataLoader`,
+  not `StatefulDataLoader`.
+- Distributed sharding happens inside the iterator:
+  `if doc_idx % world_size != rank: continue`. Each rank takes every
+  `world_size`-th document.
+
+Buffered shuffling is applied at the HF level:
+
+```python
+ds = load_dataset(name, config, split=split, streaming=True)
+ds = ds.shuffle(seed=self.seed + self._epoch,
+                buffer_size=self.shuffle_buffer_size)   # default 10k
+```
+
+The default buffer holds 10,000 examples. Larger buffers give better
+shuffle quality at the cost of startup latency and RAM.
+
+### Tokenizer is lazy
+
+The tokenizer is loaded on first `__iter__` call, not at construction.
+This sidesteps a common `fork()` issue with multiprocessing DataLoader
+workers: a tokenizer loaded in the parent can deadlock if the worker
+processes fork after HF has already spawned its own threads.
+
+### Resumption in streaming mode
+
+State is `{"epoch", "rank_docs_consumed"}`. On resume,
+`load_state_dict` sets `_skip_rank_docs = rank_docs_consumed`; the
+next `__iter__` fast-forwards past that many documents on this rank
+before yielding anything.
+
+Note: this only works if the same number of DP ranks is used at
+save and load time. Change the rank count and each rank's document
+stream looks different.
+
+## Packing and document boundaries
+
+Same as [Memory-mapped § Sequence packing](memory-mapped.md#sequence-packing):
+setting `pack_sequences = true` adds `doc_ids` to each sample and
+masks cross-document label positions with `-100`. Both HF paths
+support it.
+
+## Eval datasets
+
+`[eval]` can mirror either path independently of training:
+
+```toml
+[eval]
+enabled          = true
+hf_dataset_name  = "wikitext"
+hf_dataset_split = "validation"
+```
+
+For HF eval sets, rank 0 tokenizes and broadcasts the packed tensor
+to all ranks via `torch.distributed.broadcast`. This is a deliberate
+choice to avoid `load_dataset` file-lock (`flock`) failures on
+cluster filesystems (Lustre, VAST) where parallel opens crash.
+
+## Limitations
+
+- Eager mode re-tokenizes on every process start; no tokenized cache
+  beyond the HF `~/.cache/huggingface/` layer.
+- Streaming mode with shuffling + resumption isn't bit-exact: after
+  resume the same rank will see a different *shuffled order* because
+  buffered shuffle state isn't captured.
+- Neither class supports on-disk tokenization caching. If you want
+  that, pre-tokenize with `tatm` and switch to
+  [Memory-mapped](memory-mapped.md).
+
+## See also
+
+- [Memory-mapped](memory-mapped.md) — the faster path once you have
+  pre-tokenized shards.
+- [Mixing and annealing](mixing-and-annealing.md) — compose HF sources
+  alongside mmap ones in a `MixtureDataset`.
+- [`configs/train/hf_wikitext.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/hf_wikitext.toml) —
+  a working streaming-mode config.

--- a/docs/data/index.md
+++ b/docs/data/index.md
@@ -1,0 +1,80 @@
+# Data
+
+KempnerForge's data pipeline: the dataset types, the sampler that
+partitions work across data-parallel ranks, the stateful dataloader
+that makes checkpoint resume possible, and the mixing / annealing
+hooks used for curriculum training.
+
+Entry point: `scripts/train.py` picks one of four paths based on
+config — pre-tokenized mmap, HuggingFace eager, HuggingFace streaming,
+or multi-source mixture.
+
+## At a glance
+
+| Config path | Dataset class | Sampler | Notes |
+|-------------|---------------|---------|-------|
+| `data.dataset_path = "..."` | `MemoryMappedDataset` | `DistributedSampler` | Pre-tokenized `.npy` / `.bin` shards. Fastest path. |
+| `data.hf_dataset_name = "..."` (+ `hf_streaming=false`) | `HuggingFaceDataset` | `DistributedSampler` | Eager download, tokenize once, pack into RAM. |
+| `data.hf_dataset_name = "..."` + `hf_streaming=true` | `StreamingHuggingFaceDataset` | (none — `IterableDataset`) | On-the-fly tokenization from a streaming Hub dataset. |
+| `data.datasets = [...]` (non-empty) | `MixtureDataset` over sub-datasets | `MixtureSampler` | Weighted mixing across multiple sources; phase transitions rebalance weights. |
+
+All of the map-style datasets and samplers implement `state_dict()` /
+`load_state_dict()`. `StatefulDataLoader` wraps them and tracks the
+batch position inside an epoch so training can resume exactly after a
+checkpoint — see [Stateful dataloader](stateful-dataloader.md).
+
+## Config
+
+Everything here is driven by `DataConfig` (`kempnerforge/config/data.py`):
+
+```toml
+[data]
+dataset_path    = ""              # pre-tokenized shard directory
+file_pattern    = "*.npy"         # glob for shard files (also "*.bin")
+tokenizer_path  = ""              # HF tokenizer name or local path
+num_workers     = 4
+pin_memory      = true
+prefetch_factor = 2
+pack_sequences  = false           # cross-doc label masking via EOS
+
+# HuggingFace path
+hf_dataset_name      = ""           # default: None (str | None)
+hf_dataset_config    = ""           # default: None (str | None)
+hf_dataset_split     = "train"
+hf_dataset_text_field = "text"
+hf_streaming         = false
+
+# Multi-dataset mixing
+datasets        = []              # list of DatasetSource tables
+mix_temperature = 1.0             # weight scaling (1.0 = as-is, >1 = more uniform)
+
+# Phase scheduling (step-triggered weight + LR transitions)
+phases            = []
+anneal_start_step = 0             # shortcut for a common 2-phase pattern
+anneal_weights    = {}
+```
+
+See [Configuration § `[data]` — DataConfig](../configuration/config-sections.md)
+for the per-field reference.
+
+## Pages
+
+```{toctree}
+:maxdepth: 1
+
+memory-mapped
+huggingface
+mixing-and-annealing
+stateful-dataloader
+sampler
+```
+
+## See also
+
+- [Checkpointing § Train state](../checkpointing/train-state.md) —
+  dataloader state *infrastructure* exists but the shipped training
+  loop doesn't wire it into the save; resume restarts the epoch.
+- [Training § Training loop](../training/training-loop.md) — where
+  the dataloader is consumed step by step.
+- [Configuration § `[data]` — DataConfig](../configuration/config-sections.md) —
+  every knob on this page.

--- a/docs/data/memory-mapped.md
+++ b/docs/data/memory-mapped.md
@@ -1,0 +1,133 @@
+# Memory-mapped dataset
+
+[`MemoryMappedDataset`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/data/dataset.py)
+is the fastest training path — tokens live on disk as flat `uint16`
+or `uint32` arrays, and training reads them via `numpy.memmap` without
+copying into user memory.
+
+Use this whenever your dataset is pre-tokenized.
+
+## Expected layout
+
+A directory of shard files, one flat 1-D array per file:
+
+```
+/path/to/tokens/
+├── shard_00000.npy     # or .bin
+├── shard_00001.npy
+├── ...
+└── metadata.yaml       # optional — produced by tatm
+```
+
+Supported formats:
+
+- **`.npy`** — standard numpy array. Dtype is read from the header.
+- **`.bin`** — raw binary, flat array of tokens. Dtype is inferred:
+  `uint32` if the file size is a multiple of 4, else `uint16`.
+
+The shipped tokenization workflow is external (`tatm`); KempnerForge
+ships a validator, not a tokenizer:
+
+```bash
+# After tatm produces a directory
+uv run python scripts/prepare_data.py /path/to/tokens
+
+# Prints the exact --data flags for scripts/train.py
+```
+
+## How sequences are carved out
+
+On construction the dataset:
+
+1. Globs `data_dir/<file_pattern>` and sorts the result — deterministic
+   ordering across nodes.
+2. Memory-maps every file.
+3. Computes a cumulative sample count: each file contributes
+   `len(file) // seq_len` samples.
+
+At training time, `__getitem__(idx)`:
+
+1. Binary-searches the cumulative offsets to find which shard the
+   global `idx` falls into.
+2. Slices `seq_len` tokens starting at `local_idx * seq_len`.
+3. Returns `{"input_ids": tokens[:-1], "labels": tokens[1:]}`.
+
+Note: `scripts/train.py` passes `seq_len + 1` to the constructor so
+the sliced window contains one extra token, and the `[:-1]` / `[1:]`
+split produces inputs and next-token labels of length `seq_len` each.
+
+Partial remainders at the end of a file are simply unused — no
+padding, no cross-file concatenation at the sample level.
+
+## Config
+
+```toml
+[data]
+dataset_path = "/path/to/tokens"
+file_pattern = "*.npy"            # or "*.bin"
+pack_sequences = false            # see below
+tokenizer_path = ""               # only required when pack_sequences=true
+```
+
+`scripts/train.py` picks this path when `data.dataset_path` is set
+and `data.datasets` is empty.
+
+## Sequence packing
+
+Set `pack_sequences = true` to enable document-aware label masking.
+This requires:
+
+- `tokenizer_path` — to look up the EOS token ID.
+- Shards that actually contain EOS tokens between documents (typical
+  for tatm output).
+
+With packing on, `__getitem__` returns an extra field and masks
+cross-document label positions:
+
+```python
+{
+    "input_ids": LongTensor[seq_len],
+    "labels":    LongTensor[seq_len],   # -100 at cross-doc boundaries
+    "doc_ids":   LongTensor[seq_len],   # per-token doc index for attention masking
+}
+```
+
+The `-100` values are the standard PyTorch "ignore" index for
+`CrossEntropyLoss` — the loss function simply skips those positions.
+The `doc_ids` tensor is what the attention layer uses to prevent
+attending across document boundaries (see
+[Model § Attention](../architecture/index.md)).
+
+Implementation: [`_compute_packed_output`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/data/dataset.py)
+detects boundaries by incrementing a running `doc_id` whenever it
+sees `eos_token_id`; then the cross-boundary mask is
+`input_doc_ids != label_doc_ids`.
+
+## Resumption
+
+`state_dict()` captures `{"epoch", "total_samples"}`; `load_state_dict`
+restores the epoch. The actual intra-epoch position is tracked by the
+sampler and dataloader, not the dataset itself (see
+[Sampler](sampler.md) and [Stateful dataloader](stateful-dataloader.md)).
+
+## Performance notes
+
+- mmap is read-only and shared across workers — every DataLoader
+  worker process sees the same kernel page cache.
+- The first pass through a shard pays for page faults; subsequent
+  passes are RAM-speed as long as the working set fits.
+- Since sampling is shuffled across the full dataset every epoch,
+  expect cold-cache reads for the first epoch on corpora larger than
+  system RAM. A 1-2% warmup overhead is typical.
+- `uint16` halves the on-disk footprint vs `uint32` and works for any
+  vocabulary ≤ 65535. Llama-3 / Mixtral-class tokenizers (vocab
+  ~128k) need `uint32`.
+
+## See also
+
+- [Stateful dataloader](stateful-dataloader.md) — resumption logic.
+- [Mixing and annealing](mixing-and-annealing.md) — how multiple mmap
+  datasets compose via `MixtureDataset`.
+- [Sampler](sampler.md) — rank partitioning for this dataset type.
+- [`scripts/prepare_data.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/prepare_data.py) —
+  validator that prints the right `--data.*` flags.

--- a/docs/data/mixing-and-annealing.md
+++ b/docs/data/mixing-and-annealing.md
@@ -1,0 +1,231 @@
+# Mixing and annealing
+
+Two orthogonal features that work together:
+
+- **Mixing** — sample from several datasets in one epoch, each with
+  its own weight. Built on `MixtureDataset` + `MixtureSampler`.
+- **Annealing / phase scheduling** — at user-specified steps, switch
+  the mixing weights and optionally scale the learning rate. Used
+  for data curriculum (e.g. "70% web + 30% code until step 100k,
+  then 20% web + 80% books").
+
+Both are opt-in. Ignore this page unless you want multiple data
+sources in the same run.
+
+## Enabling mixing
+
+Set one or more `[[data.datasets]]` tables in your TOML:
+
+```toml
+[data]
+tokenizer_path  = "meta-llama/Llama-3-8B"
+mix_temperature = 1.0          # 1.0 = use weights as-is, >1 = flatten
+
+[[data.datasets]]
+path   = "/data/web_tokens"    # MemoryMappedDataset
+weight = 1.0
+name   = "web"                 # shows up in per-dataset metrics
+
+[[data.datasets]]
+hf_name = "bigcode/the-stack-v2"
+weight  = 0.3
+name    = "code"
+
+[[data.datasets]]
+path   = "/data/books_tokens"
+weight = 0.5
+name   = "books"
+```
+
+Each source can be either a mmap directory (`path`) or a HuggingFace
+dataset (`hf_name`). `DataConfig.__post_init__` rejects a
+`DatasetSource` that has neither.
+
+When `data.datasets` is non-empty, it overrides `data.dataset_path`
+and `data.hf_dataset_name` — the single-source paths are ignored.
+
+## What happens at construction
+
+In `scripts/train.py`:
+
+1. Each `DatasetSource` builds a sub-dataset — `MemoryMappedDataset`
+   or `HuggingFaceDataset` — with the global `tokenizer_path` and
+   `pack_sequences` setting.
+2. `MixtureDataset(sub_datasets, names)` concatenates them:
+
+   ```python
+   # kempnerforge/data/dataset.py — MixtureDataset
+   self._cumulative: list[int] = [0]
+   for ds in datasets:
+       self._cumulative.append(self._cumulative[-1] + len(ds))
+   ```
+
+   Global index `idx` maps to `(ds_idx, local_idx)` via
+   `bisect.bisect_right(self._cumulative, idx) - 1`. Each sample gets
+   a `dataset_idx` field added for per-source metric attribution.
+
+3. `MixtureSampler(cumulative_sizes, weights, ...)` computes:
+   - Per-dataset per-rank available samples.
+   - A target draw count per dataset per epoch, proportional to the
+     normalized weights.
+   - Rounds to integers, then fixes the total to match the full
+     per-rank budget.
+
+## Weights, temperature, and oversampling
+
+The sampler normalizes raw `weights` into probabilities. Temperature
+`> 1` flattens the distribution:
+
+```python
+# kempnerforge/data/sampler.py — MixtureSampler.__init__
+if temperature != 1.0:
+    log_w = [math.log(max(w, 1e-12)) / temperature for w in weights]
+    max_lw = max(log_w)
+    scaled = [math.exp(lw - max_lw) for lw in log_w]
+    self._probs = [s / sum(scaled) for s in scaled]
+else:
+    self._probs = [w / sum(weights) for w in weights]
+```
+
+After normalization, each dataset contributes `round(p * total) `
+samples per epoch. If a dataset has fewer samples than its target
+(high weight on a tiny source), the sampler wraps around and
+oversamples:
+
+```python
+if target <= len(rank_indices):
+    drawn = rank_indices[:target]
+else:
+    reps = target // len(rank_indices) + 1
+    drawn = (rank_indices * reps)[:target]
+```
+
+This is standard practice for upsampling small curated sources
+alongside a large crawl; just know that the same physical sample
+will reappear within one epoch.
+
+## Phase scheduling (annealing)
+
+Two equivalent ways to express step-triggered weight changes:
+
+### Multi-phase
+
+```toml
+[[data.phases]]
+start_step       = 100_000
+dataset_weights  = { web = 0.4, code = 0.3, books = 0.3 }
+lr_scale         = 1.0
+
+[[data.phases]]
+start_step       = 180_000
+dataset_weights  = { web = 0.1, code = 0.2, books = 0.7 }
+lr_scale         = 0.3                 # anneal LR alongside the data shift
+```
+
+Constraints (enforced in `DataConfig.__post_init__`):
+
+- `start_step` is strictly monotonically increasing across phases.
+- `lr_scale` > 0.
+- Any dataset named in a phase but *not* listed in the phase's
+  `dataset_weights` falls back to its original weight from
+  `[[data.datasets]]`.
+
+### Annealing shortcut
+
+For the common "run normally, then switch for the last N steps"
+pattern:
+
+```toml
+[data]
+anneal_start_step = 180_000
+anneal_weights    = { books = 1.0 }    # everything else drops to its default
+```
+
+This is just syntactic sugar that the training loop compiles into a
+single-phase list at startup. Using both `data.phases` and
+`data.anneal_start_step` is rejected.
+
+## How phases execute
+
+Inside `scripts/train.py`:
+
+```python
+# --- Phase activation in the training loop ---
+while (current_phase_idx < len(active_phases)
+       and step >= active_phases[current_phase_idx].start_step):
+    phase = active_phases[current_phase_idx]
+    new_weights = [
+        phase.dataset_weights.get(name, original_weights_dict[name])
+        for name in dataset_names
+    ]
+    sampler.update_weights(new_weights, temperature=config.data.mix_temperature)
+    phase_lr_scale = phase.lr_scale
+    current_phase_idx += 1
+```
+
+Two effects:
+
+- **Sampler re-weighting** — `MixtureSampler.update_weights` recomputes
+  probabilities and target counts. Takes effect on the *next*
+  `__iter__()` call (so within the current epoch, the previous weights
+  are still in play; phase changes are clean at epoch boundaries).
+- **LR scale** — `phase_lr_scale` is applied to every optimizer param
+  group on each step: `pg["lr"] *= phase_lr_scale`. The base LR comes
+  from the scheduler; the phase scale is an overlay.
+
+### Resume into the right phase
+
+On auto-resume, `scripts/train.py` replays the phase activations
+against the current `step` so the sampler and LR scale are correct
+before the training loop starts:
+
+```python
+# On load — re-derive phase state
+for i, phase in enumerate(active_phases):
+    if step >= phase.start_step:
+        sampler.update_weights([...], temperature=...)
+        phase_lr_scale = phase.lr_scale
+        current_phase_idx = i + 1
+```
+
+`current_phase_idx` itself is saved in the checkpoint's `extra` dict
+so the resume logic matches what was live at save time — see
+[Checkpointing § Train state](../checkpointing/train-state.md).
+
+## Per-source metrics
+
+Each `MixtureDataset` sample has a `dataset_idx` field. The training
+loop breaks the loss down per source so you can see which dataset is
+contributing what:
+
+```
+loss/total  = 2.41
+loss/web    = 2.18    (0.5 of samples)
+loss/code   = 3.02    (0.3 of samples)
+loss/books  = 2.22    (0.2 of samples)
+```
+
+Exposed names come from `DatasetSource.name` (auto-derived from
+`path` / `hf_name` if left blank).
+
+## Limitations
+
+- Sampler weight changes are per-epoch: `update_weights` takes effect
+  on the next iteration, not mid-epoch.
+- `MixtureSampler` doesn't expose a true `load_state_dict` for
+  skip-ahead — `StatefulDataLoader` calls `set_skip()` on it, which
+  the sampler honors, but mid-epoch exact reproducibility across
+  weight changes is not guaranteed.
+- All sub-datasets share the same global `tokenizer_path` and
+  `pack_sequences` setting. Multiple tokenizers in one run is not
+  supported.
+
+## See also
+
+- [Memory-mapped](memory-mapped.md) and [HuggingFace](huggingface.md) —
+  the sub-dataset types you can mix.
+- [Sampler](sampler.md) — `MixtureSampler` rank partitioning details.
+- [Checkpointing § Train state](../checkpointing/train-state.md) —
+  `phase_idx` in the `extra` dict and why it's saved.
+- [Training § Schedulers](../training/schedulers.md) — the base LR
+  that `phase_lr_scale` multiplies.

--- a/docs/data/sampler.md
+++ b/docs/data/sampler.md
@@ -1,0 +1,166 @@
+# Sampler
+
+Two sampler classes in
+[`kempnerforge/data/sampler.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/data/sampler.py):
+
+- **`DistributedSampler`** — rank-partitioned, deterministic shuffle,
+  skip-ahead for resume. The default.
+- **`MixtureSampler`** — weighted sampling over a `MixtureDataset`,
+  partitioned per rank.
+
+Both expose `set_epoch(epoch)`, `set_skip(samples)`, and `state_dict()`
+/ `load_state_dict()` — the contract that `StatefulDataLoader`
+assumes.
+
+## `DistributedSampler`
+
+Indices are partitioned across DP ranks with a stride pattern, not a
+contiguous block. Rank `r` of `N` ranks gets indices
+`perm[r], perm[r+N], perm[r+2N], ...`:
+
+```python
+# kempnerforge/data/sampler.py — DistributedSampler.__iter__
+if self.shuffle:
+    g = torch.Generator()
+    g.manual_seed(self.seed + self._epoch)
+    indices = torch.randperm(len(self.dataset), generator=g).tolist()
+else:
+    indices = list(range(len(self.dataset)))
+
+if self.drop_last:
+    indices = indices[: self.total_size]   # total = num_samples * num_replicas
+else:
+    padding = self.total_size - len(indices)
+    indices += indices[:padding]
+
+# Stride partition
+indices = indices[self.rank : self.total_size : self.num_replicas]
+```
+
+Why stride, not contiguous? With stride, changing `num_replicas`
+between runs *does* change which rank sees which samples — but every
+sample is still seen exactly once per epoch and the seed-derived
+shuffle is identical. Contiguous block partitions are more sensitive
+to dataset-size / rank-count interactions.
+
+### Shuffle seeding
+
+The shuffle is keyed on `seed + epoch`, where `seed` is
+`TrainConfig.seed` (default 42) and `epoch` is set via
+`set_epoch(self._epoch)` at the top of every `StatefulDataLoader.__iter__`.
+Two runs with the same seed and the same number of ranks produce
+identical shuffle orders every epoch.
+
+### Drop-last vs pad-wrap
+
+```python
+if drop_last:
+    self.num_samples = total // num_replicas
+    self.total_size  = self.num_samples * num_replicas      # shorter than total
+else:
+    self.num_samples = math.ceil(total / num_replicas)
+    self.total_size  = self.num_samples * num_replicas      # padded by wrap-around
+```
+
+KempnerForge defaults to `drop_last=True` in every call site. Losing
+a handful of samples per epoch at world sizes of 16-64 is a
+rounding-error effect at pretraining scale; the upside is every rank
+does exactly the same amount of work, every step.
+
+### Skip-ahead
+
+```python
+# At the end of __iter__
+if self._skip > 0:
+    indices = indices[self._skip :]
+    self._skip = 0   # one-shot — resets after being applied
+```
+
+`set_skip(k)` tells the sampler "drop the first `k` samples from
+this epoch's index list". `StatefulDataLoader` computes
+`k = batches_yielded * batch_size` on resume and passes it in. The
+reset after application is important: on the *next* epoch, no skip
+is applied, and iteration starts from index 0.
+
+## `MixtureSampler`
+
+Used when `data.datasets` contains multiple sources. The pipeline
+splits between construction and per-epoch iteration.
+
+In `__init__` (and re-run by `update_weights`):
+
+1. **Probabilities** — `weights` normalized, with optional temperature
+   scaling — see [Mixing and annealing](mixing-and-annealing.md).
+2. **Per-rank budget** — sum of `size // num_replicas` across all
+   sub-datasets (or `ceil` if `drop_last=False`).
+3. **Target counts** — `round(p * total_per_rank)` per dataset, with
+   a rounding-fix pass that adds or subtracts 1 from datasets in
+   probability order until the total matches exactly.
+
+Each `__iter__()` then does:
+
+4. **Shuffled indexes** — per sub-dataset, `torch.randperm(size)`
+   with the same `seed + epoch` trick, then the rank's stride slice.
+5. **Oversample if needed** — if the target exceeds per-rank available
+   indices, the index list is repeated until it's long enough.
+6. **Global offset** — each sub-dataset's local index is added to its
+   offset so the final list indexes into the parent `MixtureDataset`.
+7. **Final shuffle** — the assembled index list is shuffled once more
+   so samples from different sources are interleaved, not grouped.
+
+### `update_weights(weights, temperature)`
+
+Called by the training loop at phase boundaries. Recomputes
+probabilities and `_target_counts`; takes effect on the next
+`__iter__()` call. The sampler's internal `seed + epoch` behavior is
+unchanged — weight changes don't re-seed.
+
+### Skip-ahead behavior
+
+Same as `DistributedSampler`: `set_skip(k)` drops the first `k`
+entries of the assembled (final, shuffled) index list. Resumes are
+robust if the weights and `num_replicas` match between save and load;
+a phase change between save and load would shift the index list.
+
+## What's in `state_dict`
+
+Both samplers return the same keys:
+
+```python
+{
+    "epoch": self._epoch,
+    "seed": self.seed,
+    "num_replicas": self.num_replicas,
+    "rank": self.rank,
+}
+```
+
+`load_state_dict` restores **only** `epoch`. The other fields are
+recorded for diagnostic purposes — `num_replicas` and `rank` are
+local to this process and must be re-derived from the current world
+size, not transplanted from the save. `seed` is already in
+`TrainConfig` and doesn't change across resume.
+
+## Eval sampler
+
+Evaluation uses `DistributedSampler(eval_dataset, shuffle=False)`:
+
+```python
+# scripts/train.py
+eval_sampler = DistributedSampler(
+    eval_dataset, num_replicas=dp_size, rank=dp_rank,
+    shuffle=False, seed=tc.seed,
+)
+```
+
+`shuffle=False` makes the order deterministic (no permutation),
+which is what you want for reproducible eval loss numbers.
+
+## See also
+
+- [Stateful dataloader](stateful-dataloader.md) — the caller that
+  drives `set_epoch`, `set_skip`, and the state dict.
+- [Mixing and annealing](mixing-and-annealing.md) — `update_weights`
+  and how phase transitions interact with the sampler.
+- [Checkpointing § Train state](../checkpointing/train-state.md) —
+  the sampler state is captured inside the dataloader state dict.

--- a/docs/data/stateful-dataloader.md
+++ b/docs/data/stateful-dataloader.md
@@ -1,0 +1,153 @@
+# Stateful dataloader
+
+[`StatefulDataLoader`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/data/dataloader.py)
+wraps `torch.utils.data.DataLoader` with three additions:
+
+1. Tracks `(epoch, batches_yielded)` across iterator boundaries.
+2. Exposes `state_dict()` / `load_state_dict()` that capture sampler
+   state alongside position.
+3. On resume, calls `sampler.set_skip(...)` to fast-forward past
+   already-seen batches within the current epoch.
+
+## Construction
+
+```python
+# scripts/train.py
+dataloader = StatefulDataLoader(
+    dataset,
+    batch_size=tc.batch_size,
+    sampler=sampler,             # DistributedSampler or MixtureSampler
+    config=config.data,
+)
+```
+
+Internally it builds a plain `DataLoader` with these options wired
+from `DataConfig`:
+
+```python
+DataLoader(
+    dataset,
+    batch_size=batch_size,
+    sampler=self.sampler,
+    num_workers=config.num_workers,
+    pin_memory=config.pin_memory,
+    prefetch_factor=config.prefetch_factor if config.num_workers > 0 else None,
+    persistent_workers=config.num_workers > 0,
+    drop_last=True,
+)
+```
+
+Two choices worth calling out:
+
+- **`drop_last=True`** — ensures all DP ranks see the same number of
+  batches per epoch. The `DistributedSampler` already trims the
+  per-rank index list for this case, so `drop_last` is effectively
+  double-insurance.
+- **`persistent_workers=num_workers > 0`** — workers are kept alive
+  across epochs. This avoids re-importing the tokenizer and
+  re-mapping shards every epoch, but means any mutable state in a
+  worker process persists too.
+
+## Iteration
+
+```python
+def __iter__(self):
+    self.sampler.set_epoch(self._epoch)
+    self._iterator = iter(self._dataloader)
+    self._batches_yielded = 0
+    return self
+
+def __next__(self):
+    batch = next(self._iterator)
+    self._batches_yielded += 1
+    return batch
+```
+
+On `StopIteration`, `_epoch` increments, `_batches_yielded` resets,
+and the next `__iter__` call rebuilds the underlying iterator (and
+reseeds the sampler via `set_epoch`).
+
+## State capture
+
+```python
+def state_dict(self) -> dict:
+    return {
+        "epoch": self._epoch,
+        "batches_yielded": self._batches_yielded,
+        "sampler": self.sampler.state_dict(),
+    }
+```
+
+`load_state_dict` reads these back, restores sampler state via its
+own `load_state_dict`, then — if `batches_yielded > 0` — tells the
+sampler to skip:
+
+```python
+self.sampler.set_skip(batches_yielded * self.batch_size)
+```
+
+Effect: on the next `__iter__()`, the sampler yields its index list
+minus the first `batches_yielded * batch_size` elements. Training
+picks up at the exact same sample boundary.
+
+## The wiring gap
+
+The infrastructure works, but `scripts/train.py` **does not currently
+pass the dataloader to `ckpt_mgr.save()`**:
+
+```python
+# scripts/train.py
+ckpt_mgr.save(
+    step=step,
+    tokens_seen=tokens_seen,
+    scheduler=scheduler,
+    extra=ckpt_extra,
+    # no dataloader=...
+)
+```
+
+Consequence: on resume, the dataloader restarts from batch 0 of the
+current epoch. With deterministic seeding and a shuffled sampler, this
+means a few batches get replayed but the loss trajectory is otherwise
+indistinguishable from an uninterrupted run.
+
+For exact-batch-level reproducibility, pass `dataloader=dataloader`
+into `ckpt_mgr.save` yourself — `build_train_state` picks it up
+automatically. See
+[Checkpointing § Train state](../checkpointing/train-state.md#dataloader-state).
+
+## Worker RNG
+
+PyTorch's `DataLoader` seeds worker RNGs deterministically from the
+parent process RNG at worker init. Because
+[Checkpointing § Train state](../checkpointing/train-state.md#rng-capture)
+snapshots all four parent-process generators, workers see the same
+seeds after resume — as long as `num_workers` doesn't change.
+
+Changing `num_workers` across a resume means different worker seeds
+and different downstream shuffling, even though the sampler state is
+restored. Keep the count stable through a run.
+
+## Eval dataloader
+
+The eval path uses a plain `torch.utils.data.DataLoader` (not
+`StatefulDataLoader`), because eval is stateless — the full eval set
+is replayed from the top at every evaluation interval:
+
+```python
+eval_dataloader = TorchDataLoader(
+    eval_dataset,
+    batch_size=tc.batch_size,
+    sampler=eval_sampler,          # DistributedSampler with shuffle=False
+)
+```
+
+## See also
+
+- [Sampler](sampler.md) — `set_epoch`, `set_skip`, and how the
+  sampler actually carries out the resume-aware iteration.
+- [Checkpointing § Train state](../checkpointing/train-state.md) —
+  why `dataloader=` isn't wired by default and what you gain by
+  opting in.
+- [Checkpointing § Auto-resume](../checkpointing/auto-resume.md) —
+  the symlink-based restart that triggers this load path.

--- a/docs/distributed/device-mesh.md
+++ b/docs/distributed/device-mesh.md
@@ -1,0 +1,154 @@
+# Device mesh
+
+Every parallelism family in KempnerForge composes through a single
+`torch.distributed.device_mesh.DeviceMesh`. `init_distributed` builds
+it once, then the `apply_*` functions pull sub-meshes from it. The
+shape and dimension order of that mesh are load-bearing.
+
+## Dimension order
+
+```python
+# scripts/train.py
+device_mesh = init_distributed(config.distributed, seed=config.train.seed)
+```
+
+Inside
+[`init_distributed`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/setup.py)
+the order is fixed:
+
+```python
+dim_map = [
+    ("pp",           resolved.pp),
+    ("dp_replicate", resolved.dp_replicate),
+    ("dp_shard",     resolved.dp_shard),
+    ("ep",           resolved.ep),
+    ("tp",           resolved.tp),
+]
+```
+
+Only dimensions with size > 1 go into the mesh — a `pp=1, dp_replicate=1,
+dp_shard=32, ep=1, tp=4` config produces a 2D mesh with dim names
+`("dp_shard", "tp")` and sizes `(8, 4)`.
+
+**Special case — TP or EP active:** when `tp > 1` or `ep > 1` and
+`dp_shard` would otherwise be dropped (size 1), it is inserted anyway,
+before `ep` and `tp` in the dimension list. FSDP2 needs every
+parameter as a DTensor for the fused optimizer path to work; if TP has
+already made some params DTensors, FSDP2 has to upgrade the rest —
+which requires an (even trivial) `dp_shard` dimension.
+
+If every dimension is `1`, the mesh degenerates to a flat
+`("dp_shard",)` mesh of size `world_size` — still present, still what
+`get_dp_mesh()` returns.
+
+## Parallelism arithmetic
+
+```
+dp_replicate × dp_shard × tp × pp × cp × ep == world_size
+```
+
+[`DistributedConfig.validate_world_size`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/distributed.py)
+enforces this. The default `dp_shard = -1` is a sentinel meaning
+"fill the remaining mesh slots", resolved by `config.resolve(world_size)`
+at setup time:
+
+```python
+dp_shard = world_size // (dp_replicate * tp * pp * cp * ep)
+```
+
+So most configs leave `dp_shard = -1` and let it auto-size — the
+arithmetic above then holds by construction. See
+[Validation rules § Parallelism arithmetic](../configuration/validation-rules.md#parallelism-arithmetic).
+
+## Extracting sub-meshes
+
+Every apply function reads the sub-mesh it needs:
+
+| Getter | Returns | Used by |
+|--------|---------|---------|
+| `get_dp_mesh(mesh)` | `mesh["dp_replicate", "dp_shard"]` (HSDP) or whichever single DP dim is present | [`apply_fsdp2`](fsdp2.md) |
+| `get_tp_mesh(mesh)` | `mesh["tp"]` or `None` | [`apply_tensor_parallel`](tensor-parallelism.md) |
+| `get_pp_mesh(mesh)` | `mesh["pp"]` or `None` | [`build_pipeline_schedule`](pipeline-parallelism.md) |
+| `get_pp_rank(mesh)` / `get_pp_size(mesh)` | `pp_mesh.get_local_rank()` / `.size()` or `0` / `1` | `build_stage_module`, training loop |
+| `mesh["ep"]` directly | 1D EP mesh | [`apply_expert_parallel`](expert-parallelism.md) |
+
+`get_dp_info(mesh)` (in
+[`kempnerforge.distributed.utils`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/utils.py))
+collapses the DP axes into `(dp_rank, dp_size)` — the numbers the
+metrics tracker uses for "tokens seen across DP ranks".
+
+## Example meshes
+
+### 7B on 32 GPUs, pure FSDP (`7b_32gpu_fsdp.toml`)
+
+```
+dp_replicate=1, dp_shard=32, tp=1, pp=1, cp=1, ep=1
+
+mesh: ("dp_shard",) — size (32,)
+```
+
+Only FSDP fires. `get_tp_mesh` / `get_pp_mesh` return `None`.
+
+### 70B on 32 GPUs, TP+FSDP (`70b_32gpu_tp4.toml`)
+
+```
+dp_replicate=1, dp_shard=8, tp=4, pp=1, cp=1, ep=1
+
+mesh: ("dp_shard", "tp") — size (8, 4)
+```
+
+`apply_tensor_parallel` uses the `tp` dim (size 4);
+`apply_fsdp2` uses `dp_shard` (size 8).
+
+### 70B on 32 GPUs, TP+PP+FSDP (`70b_32gpu_tp4_pp4.toml`)
+
+```
+dp_replicate=1, dp_shard=2, tp=4, pp=4, cp=1, ep=1
+
+mesh: ("pp", "dp_shard", "tp") — size (4, 2, 4)
+```
+
+`pp` rank selects the stage, `tp` shards within the stage, `dp_shard`
+replicates the remaining across 2 ranks.
+
+### MoE on 32 GPUs, TP+EP+FSDP (`moe_ep_32gpu.toml`)
+
+```
+dp_replicate=1, dp_shard=4, tp=4, pp=1, cp=1, ep=2
+
+mesh: ("dp_shard", "ep", "tp") — size (4, 2, 4)
+```
+
+`ep` (size 2) splits 8 experts across two groups of 4 ranks each; TP
+shards attention within each EP group; FSDP shards the rest across
+the `dp_shard` axis. See
+[Parallelism recipes § MoE](../reference/parallelism-recipes.md#moe-mixtral-style-8-experts-top-2).
+
+## Context parallelism
+
+`cp` appears in the parallelism arithmetic and the config schema but
+there is no `apply_context_parallel` function yet — CP is declared
+for validation but not wired. Attempting `cp > 1` passes the
+arithmetic check but produces no actual sequence parallelism. See the
+[planning issue](https://github.com/KempnerInstitute/KempnerForge/issues)
+for status.
+
+## One mesh, one barrier
+
+`init_distributed` calls `dist.barrier()` after `init_device_mesh`
+returns, so all ranks complete mesh construction before the training
+loop starts. This is the only synchronization point guaranteed during
+setup — subsequent `apply_*` calls assume the mesh is already
+populated.
+
+## See also
+
+- [FSDP2](fsdp2.md) — how `apply_fsdp2` consumes `get_dp_mesh(mesh)`.
+- [Tensor parallelism](tensor-parallelism.md) — how `apply_tensor_parallel`
+  consumes the `tp` sub-mesh.
+- [Pipeline parallelism](pipeline-parallelism.md) — how the `pp`
+  sub-mesh selects each rank's stage.
+- [Configuration § DistributedConfig](../configuration/config-sections.md) —
+  the dataclass with `dp_replicate`, `dp_shard`, `tp`, `pp`, `cp`, `ep`.
+- [Environment variables](../reference/environment-variables.md) — how
+  `RANK` / `LOCAL_RANK` / `WORLD_SIZE` feed into `get_world_info()`.

--- a/docs/distributed/expert-parallelism.md
+++ b/docs/distributed/expert-parallelism.md
@@ -1,0 +1,191 @@
+# Expert parallelism
+
+Expert parallelism (EP) partitions MoE experts across an EP process
+group — each rank holds `num_experts / ep` experts and tokens are
+shuffled between ranks by all-to-all so every token reaches its
+assigned expert. With `ep=1` (the default), experts are replicated on
+every rank and EP is a no-op.
+
+Entry points:
+
+- [`apply_expert_parallel(model, device_mesh)`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/expert_parallel.py)
+  — prunes each `MoEMLP` to the local expert slice and stores EP
+  metadata (`ep_group`, `ep_world_size`, `local_expert_start`,
+  `num_local_experts`).
+- `ep_dispatch_and_compute(x, weights, indices, moe, ...)` — runs
+  inside `MoEMLP.forward()` when `ep_world_size > 1` and implements the
+  all-to-all dispatch / local compute / all-to-all combine.
+
+## When EP kicks in
+
+```python
+# kempnerforge/model/moe.py, MoEMLP.forward
+if self.ep_world_size > 1:
+    output = ep_dispatch_and_compute(
+        x, weights, indices, self,
+        self.ep_group, self.local_expert_start,
+        self.num_local_experts, self.ep_world_size,
+        gradient_scale=self.gradient_scale,
+    )
+```
+
+With `ep=1`, `ep_world_size` stays at 1 (the default set in
+`MoEMLP.__init__`) and the forward path runs experts locally. With
+`ep>1`, `apply_expert_parallel` bumps `ep_world_size` to the EP mesh
+size and populates the other metadata.
+
+## Dispatch / combine flow
+
+`ep_dispatch_and_compute` is a seven-step sequence:
+
+| # | Step | What it does |
+|---|------|--------------|
+| 1 | Expand | `(num_tokens, top_k)` → flat `(num_tokens · top_k,)` list of `(token_id, expert_id, weight)` entries |
+| 2 | Sort | Stable-sort entries by target EP rank so same-destination tokens are contiguous |
+| 3 | Exchange counts | `dist.all_to_all_single` on `send_counts` → every rank learns `recv_counts` |
+| 4 | Dispatch | `_AllToAll` sends `x_sorted` to expert-owning ranks; a second all-to-all ships the expert IDs |
+| 5 | Local compute | Grouped GEMM over received tokens (sorted by local expert) when `torch._grouped_mm` is available; fallback is per-expert masked forward |
+| 6 | Combine | Reverse all-to-all sends processed tokens back to the originating ranks |
+| 7 | Weighted sum | `scatter_add_` combines the `top_k` expert outputs per token with their router weights |
+
+The dispatch all-to-all is wrapped in
+[`_AllToAll`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/expert_parallel.py)
+— a custom `torch.autograd.Function` whose backward is the same
+all-to-all with send/recv counts swapped. That's what makes the
+forward path differentiable.
+
+## Unused-expert kludge
+
+If a local expert receives **zero tokens** in a step, its parameters
+never enter the autograd graph — and FSDP2's reduce-scatter, which
+fires only after every param in a unit has accumulated a gradient,
+hangs forever.
+
+`ep_dispatch_and_compute` forces an
+`AccumulateGrad` hook to fire on each unused expert by adding a
+zero-valued sum of its parameters into the output:
+
+```python
+for i in range(num_local_experts):
+    if tokens_per_expert[i] == 0:
+        for p in moe.experts[i].parameters():
+            local_output = local_output + p.sum() * 0
+```
+
+Similar zero-contributions handle the packed-expert path and the
+case where the dispatch all-to-all would otherwise have no gradient
+edge back from `local_output` to `received_tokens` (which would
+cause the backward all-to-all to be skipped on one side —
+positional mismatch in NCCL → deadlock).
+
+## Apply step
+
+[`apply_expert_parallel`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/expert_parallel.py):
+
+```python
+for module in model.modules():
+    if not isinstance(module, MoEMLP):
+        continue
+    assert num_experts % ep_size == 0
+    start = ep_rank * (num_experts // ep_size)
+    end   = start + (num_experts // ep_size)
+    if module.packed_experts:
+        # replace Parameter with sliced view (can't resize in place)
+        module.up_w   = Parameter(module.up_w.data[start:end].clone())
+        module.down_w = Parameter(module.down_w.data[start:end].clone())
+        ...
+    else:
+        module.experts = ModuleList([module.experts[i] for i in range(start, end)])
+    module.ep_world_size = ep_size
+    module.ep_group = ep_group
+    module.local_expert_start = start
+    module.num_local_experts = num_experts // ep_size
+```
+
+The router (`moe.router`) is **not** sharded — every rank keeps the
+full router weights so it can make the routing decision locally
+before dispatch. Shared experts (`moe.shared_expert`) are also kept
+on every rank.
+
+## Composition with other parallelisms
+
+EP runs after TP and before FSDP2 — see
+[Parallelism order](../architecture/parallelism-order.md).
+
+- **EP + TP**: TP shards the non-MoE Linears (attention q/k/v/o and
+  shared-expert gate/up/down) along the `tp` mesh dim. EP shards the
+  routed experts along `ep`. Dense TP layers are untouched by
+  `apply_expert_parallel`.
+- **EP + FSDP2**: FSDP2 wraps the MoE layer's `attention` and `mlp`
+  **separately** (per-sub-module wrapping) rather than the whole
+  block — see [FSDP2 § EP-MoE](fsdp2.md#ep-moe-per-sub-module-wrapping).
+  Per-block wrapping would cause FSDP2's reduce-scatter to fire
+  between the two EP all-to-alls in backward, deadlocking.
+- **EP + FP8**: expert Linears are excluded from the Float8 pass
+  (`"experts" in fqn → False` in the filter). The grouped GEMM path
+  (`torch._grouped_mm`) doesn't go through `Float8Linear.forward`, so
+  FP8 applied there is ineffective and adds surprise failures.
+  See [FP8 § Exclusion rules](fp8.md#exclusion-rules).
+
+## Config
+
+```toml
+[distributed]
+ep = 2                           # expert parallelism degree
+
+[model]
+num_experts = 8                  # global expert count
+moe_top_k   = 2                  # experts per token
+moe_shared_experts = 1           # optional always-on expert
+moe_packed_experts = false       # grouped GEMM with packed weights (opt-in)
+moe_gradient_scale = false       # per-expert gradient normalization (opt-in)
+```
+
+`num_experts % ep == 0` is checked at apply time. The parallelism
+arithmetic (see [DistributedConfig](../configuration/config-sections.md))
+requires `dp_replicate · dp_shard · tp · pp · cp · ep == world_size`.
+
+## Example: `moe_ep_32gpu.toml`
+
+```
+dp_shard=4, tp=4, ep=2, pp=1
+num_experts=8, moe_top_k=2
+
+mesh: ("dp_shard", "ep", "tp") → (4, 2, 4)
+```
+
+- Each EP group (size 2) splits the 8 experts as `experts 0-3` on
+  rank 0 and `experts 4-7` on rank 1.
+- Within each EP group, TP shards the per-expert Linears along `tp=4`.
+- FSDP shards the remaining params across the `dp_shard=4` axis with
+  per-sub-module wrapping.
+
+Benchmark and reproducer: [Benchmarks § MoE Expert
+Parallelism](../reference/benchmarks.md#moe-expert-parallelism).
+
+## Gradient scaling (optional)
+
+When `moe_gradient_scale = true`, the output of each local expert is
+multiplied by `avg_tokens / tokens_for_this_expert` so high-traffic
+experts don't dominate the gradient. The scaling happens on
+`local_output` before the combine all-to-all, so the adjusted
+gradient flows back through the dispatch all-to-all to the router
+and expert params correctly. Disabled by default — it changes
+gradient magnitudes and should be validated against a baseline run
+before flipping on.
+
+## See also
+
+- [MoE overview](../moe/index.md) — architecture, routers, auxiliary
+  losses. This distributed/ page is the canonical EP reference; the
+  MoE pages link here.
+- [FSDP2 § EP-MoE](fsdp2.md#ep-moe-per-sub-module-wrapping) — the
+  per-sub-module wrapping pattern.
+- [FP8 § Exclusion rules](fp8.md#exclusion-rules) — why experts +
+  router + shared_expert are skipped by `apply_float8`.
+- [Parallelism order](../architecture/parallelism-order.md) —
+  EP's place in the apply sequence.
+- [Validation rules § Expert parallel](../configuration/validation-rules.md#expert-parallel) —
+  the `num_experts % ep == 0` check.
+- [Benchmarks § MoE Expert Parallelism](../reference/benchmarks.md#moe-expert-parallelism) —
+  measured EP speedup.

--- a/docs/distributed/fp8.md
+++ b/docs/distributed/fp8.md
@@ -1,0 +1,197 @@
+# FP8
+
+FP8 training converts `nn.Linear` modules to `torchao.float8.Float8Linear`,
+which runs E4M3 forward / E5M2 backward matmuls with dynamic
+tensorwise scaling. Master weights stay in bf16 — FP8 is a compute
+mode, not a storage dtype.
+
+Entry point:
+[`apply_float8(model, enable_fsdp_float8_all_gather=True)`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/parallel.py)
+from `kempnerforge/distributed/parallel.py`. Gated by
+`TrainConfig.mixed_precision = "fp8"`.
+
+## What gets converted
+
+`torchao.float8.convert_to_float8_training` walks the model and
+replaces `nn.Linear` with `Float8Linear`. A filter function selects
+which modules to convert:
+
+```python
+def _filter_fn(module, fqn):
+    if "experts" in fqn or "shared_expert" in fqn:
+        return False
+    return "router" not in fqn
+```
+
+So the converted set is:
+
+| Module | Converted | Reason |
+|--------|:---------:|--------|
+| Attention `q_proj`, `k_proj`, `v_proj`, `o_proj` | yes | Standard `Linear` call path |
+| Dense MLP `gate_proj`, `up_proj`, `down_proj` | yes | Standard `Linear` call path |
+| Final `output_head.proj` | yes | Standard `Linear` call path |
+| MoE `experts.*.{gate,up,down}_proj` | **no** | Bypass — uses `torch._grouped_mm` |
+| `shared_expert.*` | **no** | Same expert GEMM codepath |
+| `router.gate` | **no** | Small output dim, not compute-bound |
+| `token_embedding` | no | Not a `Linear` — `nn.Embedding` |
+| Norms (RMSNorm) | no | Not a `Linear` |
+
+## Exclusion rules
+
+**`"experts"` / `"shared_expert"` in fqn**: the MoE forward uses
+`torch._grouped_mm` (grouped GEMM over stacked expert weights) when
+available. That call bypasses `Float8Linear.forward`, so wrapping
+the expert Linears does nothing useful and would surprise debugging.
+See [Expert parallelism § Local compute](expert-parallelism.md#dispatch--combine-flow).
+
+**`"router"` in fqn**: the router gate's output dim is
+`num_experts`, typically 8-64. `torch._scaled_mm` (used inside
+`Float8Linear`) requires output dim divisible by 16 and gives no
+speedup on such small matmuls. The router is also routing-decision
+logic, not a compute bottleneck.
+
+**Embeddings & norms**: not `Linear` — `convert_to_float8_training`
+skips them automatically (no filter entry needed).
+
+## `enable_fsdp_float8_all_gather`
+
+```python
+apply_float8(model, enable_fsdp_float8_all_gather=True)  # default
+```
+
+With this flag, FSDP2's all-gather communicates **FP8** weights
+instead of bf16 — halves the all-gather bandwidth per layer. The
+scale factors travel separately in a second tensor.
+
+Default is `True` when FP8 is enabled. `build_parallel_model`
+currently hard-codes the default (see
+[`parallel.py` § apply_float8](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/parallel.py)).
+
+### TP incompatibility
+
+```python
+# Must be False when TP is active — the float8 weight wrapper calls
+# aten.is_pinned on DTensors, which has no sharding strategy yet.
+```
+
+(Comment from `apply_float8`.) When TP is on, the float8 all-gather
+path triggers `aten.is_pinned` on DTensor, which PyTorch doesn't
+have a sharding rule for and which errors out. Workaround: set
+`enable_fsdp_float8_all_gather=False` manually if combining TP + FP8
+— the conversion still applies, only the FP8 all-gather optimization
+is disabled.
+
+See [Validation rules](../configuration/validation-rules.md) (the
+**FP8 + TP** section) for the config-level check.
+
+## Application order
+
+FP8 conversion runs **after** TP / EP (so it sees the already-TP-wrapped
+DTensors) and **before** AC / FSDP2:
+
+```
+apply_tensor_parallel(model, mesh)
+apply_expert_parallel(model, mesh)
+apply_float8(model)                 # ← here
+apply_ac(model, ac_mode)
+apply_fsdp2(model, mesh, ...)
+```
+
+Rationale: AC needs to recompute through `Float8Linear.forward` (not
+the plain `Linear` it replaced), and FSDP2 needs to know each
+parameter's true dtype (FP8 for converted Linears, bf16 for the
+rest). See [Parallelism order](../architecture/parallelism-order.md)
+(the **Float8 before AC and FSDP** section).
+
+## Master weights vs compute dtype
+
+The confusing part of FP8 training is that parameters are still
+stored in bf16 — FP8 quantization happens at the matmul boundary:
+
+- Parameter storage: `bfloat16` (matches `mixed_precision: "bf16"`
+  master weights).
+- Forward matmul: quantize to `E4M3` → `torch._scaled_mm` →
+  dequantize output.
+- Backward matmul: quantize to `E5M2` → `torch._scaled_mm` →
+  dequantize output.
+- Gradient: accumulate in `float32`, reduce-scatter in `float32`
+  (same as standard FSDP2 mixed precision).
+
+So from FSDP2's perspective, FP8 params look the same as bf16 params
+— except when `enable_fsdp_float8_all_gather=True`, in which case
+FSDP2's all-gather collective receives an FP8 tensor + a scale
+tensor (torchao handles the interop).
+
+`TrainConfig.param_dtype` returns `bfloat16` for `"fp8"`:
+
+```python
+_DTYPE_MAP = {
+    "bf16": torch.bfloat16,
+    "fp16": torch.float16,
+    "fp32": torch.float32,
+    "fp8":  torch.bfloat16,  # FP8 compute with bf16 master weights
+}
+```
+
+## Config
+
+```toml
+[train]
+mixed_precision = "fp8"           # bf16 master weights, E4M3/E5M2 matmul
+```
+
+That's the entire surface. The recipe is always `TENSORWISE`
+(per-tensor scaling), and the filter rules are hard-coded. Custom
+recipes / filters require editing `apply_float8` directly.
+
+## Hardware
+
+FP8 requires H100 / H200 or newer (Hopper+ with fourth-gen Tensor
+Cores). On Ampere (A100), `torch._scaled_mm` falls back and the
+speedup disappears — usually with an explicit PyTorch warning.
+
+## Example: `7b_16gpu_fp8.toml`
+
+```toml
+[train]
+mixed_precision = "fp8"
+batch_size = 8
+compile_model = true
+
+[distributed]
+dp_shard = -1                     # auto — fills the mesh
+tp = 1
+```
+
+With 16× H200 and TP off, `enable_fsdp_float8_all_gather=True` is the
+full FP8 path — FSDP2 all-gathers ride FP8, matmuls run on Hopper
+tensor cores, master weights stay bf16. Benchmark in
+[Benchmarks § MFU scaling](../reference/benchmarks.md#mfu-scaling-dense).
+
+## Accuracy notes
+
+Tensorwise FP8 has measurable loss-curve divergence from bf16 for
+the first few hundred steps — usually catches up to within noise
+by step 1000. For production runs, the standard pattern is:
+
+1. Warmup in bf16 for `warmup_steps` (LR ramp-up).
+2. Hand off to FP8 for the bulk of training.
+3. (Optional) last-mile bf16 for the final cooldown if the min
+   loss matters.
+
+KempnerForge doesn't automate this switch — you'd restart with a
+different `mixed_precision` to transition phases.
+
+## See also
+
+- [FSDP2 § Mixed precision policy](fsdp2.md#mixed-precision-policy) —
+  how `MixedPrecisionPolicy` interacts with FP8 (it doesn't — FSDP2
+  sees FP8 as bf16 with an attached scale).
+- [Tensor parallelism](tensor-parallelism.md) — the TP + FP8 +
+  `enable_fsdp_float8_all_gather=False` interaction.
+- [Parallelism order](../architecture/parallelism-order.md) (see
+  **Float8 before AC and FSDP**) — why FP8 runs between EP and AC.
+- [Validation rules](../configuration/validation-rules.md) (see
+  **FP8 + TP**) — the config-level `tp > 1 + fp8` check.
+- [Benchmarks](../reference/benchmarks.md) — measured FP8 MFU
+  numbers.

--- a/docs/distributed/fsdp2.md
+++ b/docs/distributed/fsdp2.md
@@ -1,0 +1,171 @@
+# FSDP2
+
+KempnerForge uses PyTorch's composable `fully_shard()` API (FSDP2),
+not the older `FullyShardedDataParallel` module. Entry point:
+`apply_fsdp2(model, device_mesh, mp_policy=None, reshard_after_forward=True)`
+in
+[`kempnerforge/distributed/parallel.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/parallel.py).
+
+## What it shards
+
+Two levels:
+
+1. **Per-block** — each `TransformerBlock` in `model.layers` is
+   wrapped with its own `fully_shard()` call.
+2. **Top-level** — the whole model is wrapped once more. This covers
+   parameters that live outside the blocks: the token embedding, the
+   final norm, the output head, and (for EP-MoE blocks) the layer
+   norms that don't get swept up by the sub-module wrap below.
+
+Both wraps share the same `MixedPrecisionPolicy` and
+`reshard_after_forward` setting.
+
+## Mixed precision policy
+
+```python
+default_mp_policy(param_dtype=torch.bfloat16)
+# returns
+MixedPrecisionPolicy(param_dtype=bfloat16, reduce_dtype=float32)
+```
+
+- **`param_dtype`** — the dtype FSDP2 casts parameters to during
+  all-gather. `bfloat16` is the default. If `mixed_precision = "fp8"`,
+  the param dtype stays `bfloat16` and FP8 is applied as a separate
+  layer on top (see [FP8](fp8.md)); FSDP2 never sees FP8 types
+  directly.
+- **`reduce_dtype = float32`** — gradient reductions happen in fp32
+  regardless of param dtype. This is the standard "bf16 compute, fp32
+  reduce" policy and the source of FSDP2's numerical stability
+  advantage over bare bf16 training.
+
+Pass a custom `MixedPrecisionPolicy` as the `mp_policy` kwarg if you
+need a different combination — most of the time the default is what
+you want.
+
+## `reshard_after_forward`
+
+```python
+apply_fsdp2(model, device_mesh, reshard_after_forward=True)
+```
+
+| Value | Behavior | When to use |
+|-------|----------|-------------|
+| `True` (default) | All-gather on forward, reshard after, all-gather again on backward | Maximum memory savings; every forward pass reshards |
+| `False` | All-gather once, keep gathered across the step | Pipeline parallel: `1F1B` schedule sends many microbatches through each stage; resharding between them would be wasted work |
+| `int` | Rate-limit concurrency: keep at most `N` blocks gathered at once | Rarely used; middle-ground for memory tuning |
+
+[`scripts/train.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/train.py)
+calls `apply_fsdp2(model, device_mesh, mp_policy=mp_policy)` on all
+paths without overriding `reshard_after_forward`, so both dense and
+PP runs default to `True`. The docstring on `pipeline_parallel.py`
+recommends `False` for PP (to amortize the all-gather over
+microbatches), but that's not currently wired through the training
+script — pass it manually if you need it.
+
+## EP-MoE: per-sub-module wrapping
+
+The MoE+EP path needs a wrapping pattern that the dense path does not:
+
+```python
+if _has_ep_moe(layer):
+    fully_shard(layer.attention, ...)
+    fully_shard(layer.mlp, ...)          # MoE MLP wrapped separately
+else:
+    fully_shard(layer, ...)               # whole block wrapped together
+```
+
+Why: under EP, the MoE MLP's backward pass issues **two** all-to-all
+calls (unpermute + backward dispatch). If FSDP2's reduce-scatter for
+the whole block fires between them, different ranks end up in different
+communication phases — deadlock.
+
+Wrapping `attention` and `mlp` separately means attention's reduce-
+scatter fires after attention's backward, and MLP's reduce-scatter
+fires after both all-to-alls complete. All dp_shard peers share the
+same EP rank and so reach each phase together.
+
+This fix is why
+[the MoE benchmark](../reference/benchmarks.md#moe-expert-parallelism)
+calls out "per-sub-module FSDP wrapping" as the load-bearing
+optimization.
+
+## Activation checkpointing
+
+`apply_ac(model, mode)` runs **before** `apply_fsdp2` — the FSDP2
+wrap sees the already-checkpointed block as its unit.
+
+Three modes from
+[`ActivationCheckpointing`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/training.py):
+
+| `act_ckpt` | What gets rematerialized |
+|------------|--------------------------|
+| `"none"` | Nothing; fastest; uses most memory |
+| `"full"` | Every `TransformerBlock` — entire block is recomputed on backward |
+| `"selective"` | Only the `Attention` module within each block — MLP activations stay materialized |
+
+All three use `CheckpointImpl.NO_REENTRANT` — the modern
+`torch.utils.checkpoint` implementation that composes cleanly with
+FSDP2 and `torch.compile`.
+
+`"selective"` is the right default when memory is tight but you still
+want MLP's full forward — attention is both the biggest activation
+consumer (O(seq_len^2)) and cheap to recompute (SDPA fused kernel).
+`"full"` is the fallback when even selective doesn't fit.
+
+## Application order inside `build_parallel_model`
+
+Non-PP path:
+
+```
+model = build_model(...)                   # on device, not meta
+apply_expert_parallel(model, mesh)          # MoE only — partitions experts
+apply_float8(model)                         # optional — converts nn.Linear
+apply_ac(model, mode)                       # optional — wraps blocks / attention
+apply_fsdp2(model, mesh, mp_policy)         # shards remaining params
+```
+
+TP-enabled path:
+
+```
+with torch.device("meta"): model = build_model(...)
+apply_tensor_parallel(model, mesh)          # shards Linears with DTensor
+apply_expert_parallel(model, mesh)
+apply_float8(model)
+apply_ac(model, mode)
+apply_fsdp2(model, mesh, mp_policy)
+model.to_empty(device=device)               # materialize on GPU
+model.init_weights_and_freqs()              # init RoPE + weights
+model.to(dtype=param_dtype)                 # cast to bf16
+```
+
+The meta-device init is required when TP is active: parameters must
+already be DTensors before they're materialized, so FSDP2 can wrap
+them correctly. For non-TP runs, meta-device init is skipped — the
+model is built directly on the target device.
+
+See the full breakdown in [Parallelism order](../architecture/parallelism-order.md).
+
+## Fused optimizer compatibility
+
+When TP or EP are active, `apply_fsdp2` always runs with a `dp_shard`
+dimension in the mesh — even if that dimension has size 1. Why: the
+fused AdamW kernel requires every parameter to be a DTensor (not a
+mix of DTensor and plain tensor). If TP has already wrapped some
+Linears as DTensors, FSDP2 has to upgrade the rest — which requires
+an (even trivial) `dp_shard` axis to wrap along.
+
+This is handled automatically in `init_distributed` — see
+[Device mesh § Special case](device-mesh.md#dimension-order).
+
+## See also
+
+- [Device mesh](device-mesh.md) — how the mesh that `apply_fsdp2`
+  consumes is built.
+- [Tensor parallelism](tensor-parallelism.md) — what `apply_tensor_parallel`
+  does before FSDP2 runs.
+- [Expert parallelism § EP-MoE + FSDP2](expert-parallelism.md) — the
+  deadlock case that per-sub-module wrapping avoids.
+- [Parallelism order](../architecture/parallelism-order.md) — the
+  full sequence of passes with reasoning.
+- [Gradient utilities § `clip_grad_norm_`](../training/gradient-utilities.md#clip_grad_norm_) —
+  the DTensor-aware clipping FSDP2-sharded models need.

--- a/docs/distributed/index.md
+++ b/docs/distributed/index.md
@@ -1,0 +1,52 @@
+# Distributed
+
+The parallelism families — FSDP2, tensor parallelism, expert
+parallelism, pipeline parallelism, FP8 — and the `DeviceMesh` that
+composes them.
+
+```{toctree}
+:maxdepth: 1
+
+device-mesh
+fsdp2
+tensor-parallelism
+expert-parallelism
+pipeline-parallelism
+fp8
+```
+
+## What lives where
+
+| Page | Covers |
+|------|--------|
+| [Device mesh](device-mesh.md) | Mesh construction, dimension order, sub-mesh extraction (`get_dp_mesh` / `get_tp_mesh` / `get_pp_mesh`), example meshes from shipped configs |
+| [FSDP2](fsdp2.md) | Composable `fully_shard()`, per-block + top-level wrap, mixed-precision policy, `reshard_after_forward`, EP-MoE per-sub-module wrapping, activation checkpointing modes |
+| [Tensor parallelism](tensor-parallelism.md) | `ColwiseParallel` / `RowwiseParallel` / `SequenceParallel` plan, forward / post-hooks on embeddings + attention + MLP, meta-device init, head divisibility |
+| [Expert parallelism](expert-parallelism.md) | All-to-all dispatch + combine, unused-expert grad kludge, EP + TP + FSDP composition, gradient scaling |
+| [Pipeline parallelism](pipeline-parallelism.md) | Layer assignment, `PipelineStageModule`, 1F1B / GPipe / interleaved schedules, per-stage DCP checkpointing |
+| [FP8](fp8.md) | `torchao.float8` conversion, filter rules (no experts / router), `enable_fsdp_float8_all_gather`, TP incompatibility |
+
+## Cross-cutting references
+
+- [Architecture § Parallelism order](../architecture/parallelism-order.md)
+  — the five-step apply sequence and the reasoning behind it.
+- [Configuration § DistributedConfig](../configuration/config-sections.md)
+  — the dataclass with `dp_replicate`, `dp_shard`, `tp`, `pp`, `cp`,
+  `ep`, `pp_schedule`.
+- [Configuration § Validation rules](../configuration/validation-rules.md)
+  — arithmetic checks, head divisibility, FP8 + TP, MoE + PP,
+  tie-embeddings + PP.
+- [Reference § Parallelism recipes](../reference/parallelism-recipes.md)
+  — which combinations work at which scales.
+- [Reference § Benchmarks](../reference/benchmarks.md) — measured MFU
+  and the MoE per-sub-module FSDP fix.
+
+## Not covered here
+
+- **NCCL health / liveness** — the all-reduce heartbeat and NaN
+  detection are in [Resilience](../resilience/index.md).
+- **Checkpointing under PP / TP / FSDP** — mesh-scoped DCP groups
+  and resharding are in [Checkpointing](../checkpointing/index.md).
+- **Context parallelism** — `cp` is declared in config and checked in
+  validation but has no `apply_context_parallel` yet; see
+  [Device mesh § Context parallelism](device-mesh.md#context-parallelism).

--- a/docs/distributed/pipeline-parallelism.md
+++ b/docs/distributed/pipeline-parallelism.md
@@ -1,0 +1,240 @@
+# Pipeline parallelism
+
+Pipeline parallelism (PP) splits the Transformer across stages so each
+rank in the `pp` mesh dimension holds a contiguous chunk of layers —
+plus the embedding on stage 0 and the final norm + output head on the
+last stage. Activations flow forward through the pipeline in
+microbatches; `torch.distributed.pipelining` handles the schedule.
+
+Entry points, all in
+[`kempnerforge/distributed/pipeline_parallel.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/pipeline_parallel.py):
+
+- `compute_layer_assignment(n_layers, pp_size)` — list of
+  `(start, end)` tuples, one per stage.
+- `build_stage_module(config, pp_rank, pp_size)` — instantiates a
+  `PipelineStageModule` with only the params for this rank.
+- `build_pipeline_stage(stage_module, ...)` — wraps it in
+  `torch.distributed.pipelining.PipelineStage`.
+- `build_pipeline_schedule(stage, n_microbatches, loss_fn, schedule)`
+  — creates `Schedule1F1B`, `ScheduleGPipe`, or
+  `ScheduleInterleaved1F1B`.
+
+## Stage layout
+
+Given `n_layers` and `pp_size`,
+`compute_layer_assignment` distributes layers evenly. Remainder layers
+go to the **earlier** stages:
+
+```python
+base = n_layers // pp_size
+remainder = n_layers % pp_size
+# stage i gets base + 1 layers if i < remainder else base
+```
+
+For Llama-3 70B (80 layers) with `pp=4`: stages 0-3 each get 20
+layers. For Llama-3 8B (32 layers) with `pp=3`: stage 0 and 1 get
+11 each, stage 2 gets 10.
+
+### What each stage holds
+
+| Stage | Token embed | Transformer blocks | Final norm | Output head |
+|-------|:-----------:|:------------------:|:----------:|:-----------:|
+| 0 (first) | yes | `layers[0:k]` | no | no |
+| middle | no | `layers[k:m]` | no | no |
+| N-1 (last) | no | `layers[m:n_layers]` | yes | yes |
+
+The layer keys in `PipelineStageModule.layers` match the full
+`Transformer` — stage 1 has keys `"11", "12", ..."21"`, not
+`"0", "1", ...`. This keeps the DCP checkpoint layout
+consistent across PP sizes, so you can checkpoint from a `pp=4` run
+and resume with `pp=2`.
+
+## Application order with PP
+
+The non-PP path goes through `build_parallel_model`. PP has its own
+path in `scripts/train.py`:
+
+```python
+# PP + TP
+with torch.device("meta"):
+    stage_mod = build_stage_module(config.model, pp_rank, pp_size)
+model = stage_mod
+apply_tensor_parallel(model, device_mesh)
+if tc.is_fp8:
+    apply_float8(model)
+apply_ac(model, tc.activation_checkpointing)
+apply_fsdp2(model, device_mesh, mp_policy=mp_policy)
+model.to_empty(device=device)
+model.init_weights_and_freqs()
+
+# PP without TP
+stage_mod = build_stage_module(config.model, pp_rank, pp_size)
+model = stage_mod.to(device=device, dtype=tc.param_dtype)
+if tc.is_fp8:
+    apply_float8(model)
+apply_ac(model, tc.activation_checkpointing)
+apply_fsdp2(model, device_mesh, mp_policy=mp_policy)
+```
+
+After that, `build_pipeline_stage` wraps the model in a
+`PipelineStage` (using a zero-filled example input for shape
+inference — token IDs on stage 0, hidden states elsewhere), and
+`build_pipeline_schedule` picks the 1F1B / GPipe / interleaved
+schedule.
+
+## Schedules
+
+`pp_schedule` is a `DistributedConfig` enum with three values:
+
+| Value | Class | Behavior |
+|-------|-------|----------|
+| `"1f1b"` (default) | `Schedule1F1B` | Warmup fills the pipe with `pp_size` forwards, then alternates `1F, 1B, 1F, 1B, ...` — steady-state memory is `pp_size` activations, same as GPipe but lower peak |
+| `"gpipe"` | `ScheduleGPipe` | All forwards first, then all backwards — simpler, higher peak activation memory |
+| `"interleaved_1f1b"` | `ScheduleInterleaved1F1B` | Virtual pipeline stages: each rank holds **multiple** non-contiguous chunks. Reduces pipeline bubble at the cost of extra communication |
+
+Interleaved 1F1B requires passing a list of stages to
+`build_pipeline_schedule` — the builder currently raises if you pass
+a single stage:
+
+```python
+if schedule == "interleaved_1f1b":
+    if not isinstance(stage, (list, tuple)):
+        raise ValueError(
+            "interleaved_1f1b schedule requires a list of PipelineStage objects"
+        )
+```
+
+The virtual-stage construction isn't wired through the rest of
+`train.py` yet — if you want interleaved, you have to build stage
+list manually. 1F1B is the default for shipped configs.
+
+## `n_microbatches`
+
+`build_pipeline_schedule` takes `n_microbatches=tc.grad_accum_steps`
+— gradient accumulation and PP microbatches are the same number.
+Every value in a step's `grad_accum_steps` corresponds to one
+microbatch entering the pipeline.
+
+**Constraint**: `n_microbatches >= pp_size` for 1F1B to fill the
+pipeline. With `n_microbatches = pp_size`, there is no steady-state
+phase (only warmup and drain) and the bubble overhead is maximal;
+`2x` or `4x` is the practical range for amortizing the bubble.
+
+## Training step under PP
+
+The PP branch in
+[`scripts/train.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/train.py)
+looks very different from the non-PP step:
+
+```python
+full_input  = torch.cat(input_ids_list, dim=0)    # concat microbatches
+full_labels = torch.cat(labels_list, dim=0)
+
+if is_first:
+    pp_schedule.step(full_input, target=full_labels, losses=pp_losses)
+elif is_last:
+    pp_schedule.step(target=full_labels, losses=pp_losses)
+else:
+    pp_schedule.step()
+
+# Loss lives only on the last stage
+avg_loss = sum(l.item() for l in pp_losses) / len(pp_losses) if is_last else 0.0
+
+# Broadcast loss + grad_norm to every PP stage for consistent logging
+dist.broadcast(loss_tensor, group_src=pp_size - 1, group=pp_group)
+```
+
+`schedule.step()` handles forward, backward, and gradient accumulation
+across all microbatches internally. The training loop skips
+`maybe_no_sync`, `loss_fn`, and the manual microbatch loop — the
+schedule owns all of that. See
+[Training loop § PP step](../training/training-loop.md).
+
+## FSDP2 interaction
+
+When PP is on, the training loop calls `apply_fsdp2(model, device_mesh,
+mp_policy=mp_policy)` without overriding `reshard_after_forward`, so
+FSDP2 uses its default (`True`).
+
+That's not ideal: 1F1B sends many microbatches through each stage, and
+resharding between them triggers a fresh all-gather every
+microbatch. The docstring on `pipeline_parallel.py` recommends
+`reshard_after_forward=False` for PP to amortize the all-gather over
+`n_microbatches`, but the current `scripts/train.py` doesn't thread
+the flag through. If you're running PP at scale and can't fit the
+extra all-gathers, pass it manually. See [FSDP2](fsdp2.md) — the
+**`reshard_after_forward`** section.
+
+## Checkpointing
+
+DCP needs a process group scoped to ranks that share the **same
+parameters** — which is every non-PP mesh axis. `train.py` builds
+this with:
+
+```python
+non_pp_dims = [d for d in device_mesh.mesh_dim_names if d != "pp"]
+ckpt_pg = device_mesh[non_pp_dims[0]].get_group()  # 1D case
+# or a flat subgroup for multi-dim DP/TP/EP meshes
+```
+
+Each stage then saves its own DCP shard subdirectory
+(`checkpoints/step_N/stage_0/`, `stage_1/`, …) so different stages'
+files don't collide. See [Checkpointing](../checkpointing/index.md).
+
+## Config
+
+```toml
+[distributed]
+pp = 4                                    # pipeline stages
+pp_schedule = "1f1b"                      # "1f1b", "gpipe", "interleaved_1f1b"
+
+[train]
+grad_accum_steps = 16                     # = n_microbatches; must be >= pp
+```
+
+Validation checks (from
+[`DistributedConfig`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/distributed.py)
+and [JobConfig](../configuration/validation-rules.md)):
+
+- `pp_size <= n_layers` — enforced in `compute_layer_assignment`.
+- `pp > 1` is incompatible with `tie_embeddings=True` — the tied
+  weights live on both stage 0 and the last stage, which PP can't
+  reconcile. See [Tie embeddings vs pipeline parallel](../configuration/validation-rules.md#tie-embeddings-vs-pipeline-parallel).
+- `pp > 1` + MoE requires the MoE layer to fit on one stage — see
+  [Validation rules](../configuration/validation-rules.md) (the
+  **MoE + PP** section).
+
+## Example: `70b_32gpu_tp4_pp4.toml`
+
+```
+dp_shard=2, tp=4, pp=4
+n_layers=80, grad_accum_steps=4
+
+mesh: ("pp", "dp_shard", "tp") → (4, 2, 4)
+```
+
+- `pp=4` splits 80 layers into `[0:20]`, `[20:40]`, `[40:60]`,
+  `[60:80]`.
+- `tp=4` shards each stage's Linears within a single node.
+- `dp_shard=2` doubles the throughput by splitting the batch
+  across two pipeline replicas.
+- `grad_accum_steps=4` → 4 microbatches per step. With `pp=4`, that
+  exactly fills the 1F1B pipeline (no steady-state phase) — the
+  minimum allowed. Bumping to `8` or `16` would amortize the bubble
+  further at the cost of extra activation memory.
+
+See [Parallelism recipes § 70B](../reference/parallelism-recipes.md).
+
+## See also
+
+- [Device mesh](device-mesh.md) — see the 70B TP+PP+FSDP example for
+  how the `pp` sub-mesh is extracted.
+- [FSDP2](fsdp2.md) — the **`reshard_after_forward`** section
+  covers why PP sets it to `False`.
+- [Training loop § PP step](../training/training-loop.md) — the
+  `schedule.step()` path.
+- [Checkpointing](../checkpointing/index.md) — per-stage DCP shards.
+- [Validation rules](../configuration/validation-rules.md) (see
+  **MoE + PP**) — MoE / PP compatibility constraint.
+- [Parallelism recipes](../reference/parallelism-recipes.md) —
+  which model sizes need PP.

--- a/docs/distributed/tensor-parallelism.md
+++ b/docs/distributed/tensor-parallelism.md
@@ -1,0 +1,160 @@
+# Tensor parallelism
+
+`apply_tensor_parallel(model, device_mesh)` in
+[`kempnerforge/distributed/tensor_parallel.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/tensor_parallel.py)
+shards attention and MLP weights across the `tp` mesh dimension using
+PyTorch's `parallelize_module` + DTensor.
+
+## What gets sharded
+
+Per `TransformerBlock`:
+
+| Module | Style | Reason |
+|--------|-------|--------|
+| `attention.q_proj`, `k_proj`, `v_proj` | `ColwiseParallel` | Split attention heads across TP ranks |
+| `attention.o_proj` | `RowwiseParallel` | Gather heads, reduce-scatter back to sequence-sharded |
+| `mlp.gate_proj`, `mlp.up_proj` (SwiGLU) | `ColwiseParallel` | Split hidden dim |
+| `mlp.down_proj` | `RowwiseParallel` | Gather hidden, reduce-scatter |
+| `attention_norm`, `mlp_norm` | `SequenceParallel` | Norm computed on sequence-sharded input (see below) |
+
+MoE blocks omit the MLP entries: experts are replicated across TP
+(TP doesn't shard expert weights), EP handles that dimension
+separately.
+
+At the model level:
+
+| Module | Style | When |
+|--------|-------|------|
+| `token_embedding` | Forward hook wraps output as `DTensor(Replicate())` | When sequence parallel is on |
+| `norm` (final) | `SequenceParallel` | When sequence parallel is on |
+| `output_head.proj` | `ColwiseParallel(input_layouts=Shard(1), output_layouts=Replicate())` | When sequence parallel is on and embeddings not tied |
+
+## SequenceParallel
+
+When enabled, norms operate on the **sequence-sharded** tensor (each
+TP rank holds `seq_len / tp` positions) rather than the
+replicated one. Activations flow like this through a block:
+
+```
+residual:          Shard(1)                       (seq-sharded)
+  attention_norm:  Shard(1) → Shard(1)            (SequenceParallel)
+  q/k/v_proj:      Shard(1) → Shard(2)            (Colwise all-gathers seq, shards heads)
+  attention:       Shard(2) compute
+  o_proj:          Shard(2) → Shard(1)            (Rowwise gathers heads, reduce-scatters seq)
+  + residual:      Shard(1)
+  mlp_norm:        Shard(1) → Shard(1)
+  gate/up_proj:    Shard(1) → Shard(2)
+  down_proj:       Shard(2) → Shard(1)
+  + residual:      Shard(1)
+```
+
+Net effect: activations are kept sequence-sharded everywhere *except*
+inside attention and MLP compute. Memory for activations drops by
+`tp`× at block boundaries, and the extra all-gathers are overlapped
+with compute.
+
+### When SequenceParallel is disabled
+
+Three cases, all handled automatically by `apply_tensor_parallel`:
+
+| Condition | Why SP is off |
+|-----------|---------------|
+| `is_pp_stage` (model has `stage_id` attribute) | DTensor state at PP stage boundaries causes type-coercion issues |
+| `config.tie_embeddings` | ColwiseParallel on the tied output head needs a different sharding than the embedding forward hook can provide |
+| `config.is_moe` | Boolean indexing in MoE dispatch (`indices == expert_i`) breaks `Shard(1)` DTensors, and SP-on/SP-off block mixing creates DTensor transition errors |
+
+In these cases the block gets "basic TP" — column/row parallel on the
+Linears, no sharding of the sequence dimension. Activations are fully
+replicated across the TP group, which costs more memory but works.
+
+## Token embedding hook
+
+With SequenceParallel on, the final norm expects its input to be
+`Replicate()`-placed (so it can redistribute to `Shard(1)` internally).
+The token embedding output is a plain tensor by default — without a
+hook, `SequenceParallel` would reinterpret it as `Shard(1)` without
+actually scattering, inflating the global sequence dim by `tp`.
+
+`apply_tensor_parallel` installs a forward hook on `token_embedding`:
+
+```python
+def _embed_hook(module, input, output):
+    return DTensor.from_local(output, mesh, placements=[Replicate()])
+```
+
+Effect: the embedding output is labeled as already-replicated, so
+`SequenceParallel` redistributes to `Shard(1)` correctly.
+
+## Post-hooks on attention and MLP
+
+Operations inside attention (SDPA, `view`, `contiguous`) and MLP
+strip DTensor metadata on their outputs — you get a plain `Tensor`
+where the next `+ residual` expects a `Shard(1)` DTensor.
+
+`apply_tensor_parallel` wraps the outputs back into DTensors via
+forward post-hooks:
+
+```python
+def _wrap_shard1(module, input, output):
+    return DTensor.from_local(output, mesh, placements=[Shard(1)])
+```
+
+Without this, you get "mixed Tensor and DTensor" errors at the
+residual add. With it, DTensor metadata is restored and the rest of
+the block flows correctly.
+
+## Meta-device init
+
+When TP is active, the model is built on `torch.device("meta")`
+first — no storage is allocated yet. `apply_tensor_parallel` wraps
+the (still-meta) parameters as DTensors, then `apply_fsdp2` further
+shards them, and only `model.to_empty(device=device)` allocates real
+storage afterward.
+
+The sequence is in [FSDP2 § Application order](fsdp2.md#application-order-inside-build_parallel_model).
+
+## Head divisibility
+
+`n_heads % tp == 0` and `n_kv_heads % tp == 0` are required —
+`ColwiseParallel` splits heads evenly across TP ranks, and uneven
+splits are rejected.
+
+For Llama-3 70B (`n_heads=64, n_kv_heads=8`), `tp` must be in `{1, 2,
+4, 8}` — and `tp=8` means 1 KV head per TP rank, which is usually
+where the GQA sharing stops paying off.
+
+See
+[Validation rules § Tensor-parallel head divisibility](../configuration/validation-rules.md#tensor-parallel-head-divisibility).
+
+## TP across vs within nodes
+
+- **Within a node** (NVLink): TP's all-gathers and reduce-scatters
+  are on 900 GB/s links — fast enough to overlap with compute.
+- **Across nodes** (InfiniBand): TP over IB is slow; you'll see
+  it in the MFU numbers as soon as `tp > GPUs_per_node`.
+
+Shipped recipes keep `tp ≤ 4` (single-node TP on 4×H200 per node) —
+see [Parallelism recipes](../reference/parallelism-recipes.md).
+
+## When to use TP
+
+| Situation | Use TP? |
+|-----------|---------|
+| FSDP alone fits | No — at 7B on 4 GPUs, `tp=4` loses ~18 MFU points vs pure FSDP |
+| `n_layers` blocks FSDP (e.g. 70B on 32 GPUs) | Yes — memory forces it |
+| Need to shard attention weights (huge `dim`, few layers) | Yes |
+| MoE | Yes, for attention only — TP on experts is replaced by EP |
+
+The rule of thumb and supporting benchmarks are in
+[Parallelism recipes § Choosing a parallelism combination](../reference/parallelism-recipes.md#choosing-a-parallelism-combination).
+
+## See also
+
+- [Device mesh](device-mesh.md) — how the `tp` sub-mesh is built.
+- [FSDP2](fsdp2.md) — runs after TP and shards the remaining params.
+- [Expert parallelism](expert-parallelism.md) — what happens to MoE
+  experts (TP replicates, EP shards).
+- [Parallelism order](../architecture/parallelism-order.md) — the
+  full sequence with reasoning.
+- [Configuration § Validation rules](../configuration/validation-rules.md#tensor-parallel-head-divisibility) —
+  the head-divisibility check.

--- a/docs/getting-started/first-training-run.md
+++ b/docs/getting-started/first-training-run.md
@@ -1,0 +1,110 @@
+# Your First Training Run
+
+{doc}`quickstart` gave you the commands. This page slows down the single-GPU
+debug run and explains what the log line means, what ends up in the
+checkpoint directory, and how to resume.
+
+## Run it
+
+```bash
+uv run python scripts/train.py configs/train/debug.toml \
+  --checkpoint.dir=/tmp/kf_first_run
+```
+
+This loads
+[`configs/train/debug.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/debug.toml):
+a 256-dim, 4-layer model (~20M params), synthetic data, batch size 4,
+sequence length 512, 100 steps, cosine schedule with 10 warmup steps,
+AdamW at `lr=3e-4`. It runs in under a minute on a single H100.
+
+## What the log line means
+
+You will see one metrics line every 5 steps (controlled by
+`metrics.log_interval`):
+
+```
+[step 10] loss=9.1800 | lr=3.00e-04 | grad_norm=1.340 | tok/s=42,000 | mfu=18.2% | mem=2.1/80GB | step_time=0.15s
+```
+
+| Field | What it is |
+|-------|------------|
+| `step` | Optimizer step count. Matches checkpoint filenames. |
+| `loss` | Training cross-entropy for this step. |
+| `lr` | Current learning rate after the scheduler applies. Ramps up for 10 steps, then cosine-decays. |
+| `grad_norm` | L2 norm of gradients before clipping (returned by `clip_grad_norm_`). Clipping to `train.grad_clip_norm` (default 1.0) is applied in-place before the optimizer step. |
+| `tok/s` | Tokens per second throughput, this step. |
+| `mfu` | Model FLOPs Utilization — achieved FLOPs / theoretical peak for the GPU. |
+| `mem` | Peak GPU memory this step / total GPU memory. |
+| `step_time` | Wall-clock time spent on this step, in seconds. |
+
+Synthetic data means loss starts near `log(vocab_size) ≈ 10.4` and falls
+slowly because the "dataset" is random tokens — there is no real signal to
+fit. The point of this run is to exercise the pipeline, not to learn
+anything.
+
+## What's in the checkpoint directory
+
+With `checkpoint.interval=50` and `checkpoint.keep_last_n=2` from `debug.toml`,
+after the run you'll have:
+
+```
+/tmp/kf_first_run/
+├── step_50/               # Full DCP checkpoint at step 50
+├── step_100/              # Full DCP checkpoint at step 100
+└── latest → step_100/     # Symlink to the most recent checkpoint
+```
+
+Each `step_N/` is a directory (not a single file) because DCP shards
+parameters across ranks. On a single-GPU run there is one shard; on
+multi-GPU FSDP there is one shard per rank.
+
+`latest` is a symlink updated atomically after each save. Auto-resume reads
+this symlink; if it's missing and `checkpoint.load_path` isn't set, the run
+starts from scratch.
+
+## Resume
+
+Kill the run partway (`Ctrl-C`) and re-launch the same command:
+
+```bash
+uv run python scripts/train.py configs/train/debug.toml \
+  --checkpoint.dir=/tmp/kf_first_run
+```
+
+`train.py` detects the `latest` symlink, loads model + optimizer + scheduler
++ RNG + dataloader position, and continues from the next step. No flags
+needed — auto-resume is the default when `checkpoint.dir` contains a valid
+checkpoint.
+
+To explicitly point at a different checkpoint:
+
+```bash
+uv run python scripts/train.py configs/train/debug.toml \
+  --checkpoint.load_path=/tmp/kf_first_run/step_50
+```
+
+## Change something and re-run
+
+Pick one and re-run with a **fresh `--checkpoint.dir`** (shape changes break
+auto-resume). Start with:
+
+- **More steps, same model**: `--train.max_steps=500`. Watch MFU stabilize
+  past the warmup region.
+- **Bigger model**: `--model.dim=512 --model.n_layers=8`. You'll see loss
+  curves change and memory go up.
+- **Longer context**: `--train.seq_len=2048 --model.max_seq_len=2048`. tok/s
+  drops (attention is quadratic) but MFU typically rises.
+- **Real data**: point `--data.dataset_path` at pre-tokenized `.npy` shards.
+  See {doc}`quickstart` step 4.
+- **Different optimizer**: `--optimizer.name=muon`. Note the LR is not
+  transferable between optimizers — Muon expects different LRs than AdamW.
+
+## What's next
+
+- {doc}`quickstart` covers multi-GPU, MoE, and hooks if you skipped them.
+- {doc}`notebooks` has interactive examples for model inspection,
+  activation extraction, and MoE routing diagnostics.
+- Production configs (7B, 13B, 70B) live in
+  [`configs/train/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/configs/train);
+  scale them up with
+  [`scripts/slurm/multinode.sh`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/slurm/multinode.sh).

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,42 @@
+# Getting Started
+
+Four pages that take you from a fresh clone to a running model. Read in order if
+you're new; skip around if you know what you're looking for.
+
+```{toctree}
+:maxdepth: 1
+
+install
+quickstart
+first-training-run
+notebooks
+```
+
+## What each page covers
+
+**{doc}`install`** — prerequisites, `uv sync`, environment verification, and
+SLURM-specific module setup for Kempner clusters.
+
+**{doc}`quickstart`** — a 5-minute walkthrough: debug run on one GPU, then
+multi-GPU, then point at your own data, then swap optimizer, then enable MoE,
+then extend via hooks. Every step is a single command.
+
+**{doc}`first-training-run`** — slows down and explains what the debug run
+actually does: what the log line means, what's in the checkpoint directory,
+how auto-resume finds the latest step, and what to change next.
+
+**{doc}`notebooks`** — summaries of the six interactive notebooks under
+`examples/notebooks/` and when to open each.
+
+## Prerequisites before you start
+
+- A Linux host with Python 3.12+ and at least one NVIDIA GPU (H100/H200/A100).
+  CPU-only also works for the inspection notebooks; training steps will be
+  slow.
+- [uv](https://docs.astral.sh/uv/) installed. All commands in these pages use
+  `uv run`, which activates the project venv automatically — you do not need
+  to `source .venv/bin/activate` yourself.
+- For multi-node runs on Kempner clusters: SLURM account and partition names
+  from your PI or cluster admin.
+
+If any of those are missing, start at {doc}`install`.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -1,0 +1,92 @@
+# Install
+
+KempnerForge uses [uv](https://docs.astral.sh/uv/) for dependency management.
+There is no `pip install kempnerforge` — you work from a clone.
+
+## Prerequisites
+
+- **Python 3.12+** — `pyproject.toml` pins the target interpreter.
+- **CUDA 12.8 toolkit** — PyTorch wheels are pulled from the CUDA 12.8 index.
+- **NVIDIA GPU** for any training or distributed test (H100, H200, or A100).
+  Unit tests and the inspection notebooks run on CPU.
+- **uv** — install once per machine:
+
+  ```bash
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  ```
+
+## Clone and sync
+
+```bash
+git clone git@github.com:KempnerInstitute/KempnerForge.git
+cd KempnerForge
+
+# Creates .venv, installs runtime + dev dependencies, resolves torch from the
+# CUDA 12.8 index pinned in pyproject.toml.
+uv sync
+```
+
+The `.venv` is project-local. Every command in the docs runs through
+`uv run` so the venv is activated automatically — you do not need to
+`source .venv/bin/activate`.
+
+## Verify
+
+Run the same checks CI runs on every PR:
+
+```bash
+uv run ruff check kempnerforge/ tests/ scripts/
+uv run ruff format --check kempnerforge/ tests/ scripts/
+uv run pyright kempnerforge/
+uv run pytest tests/unit/ -v --timeout=60
+```
+
+If all four pass, your environment is ready.
+
+## Optional: docs dependencies
+
+If you plan to preview docs locally, add the `docs` dependency group:
+
+```bash
+uv sync --group docs
+uv run make -C docs live  # live-reload server on http://127.0.0.1:8000
+```
+
+See the "Writing Docs" section of
+[`CONTRIBUTING.md`](https://github.com/KempnerInstitute/KempnerForge/blob/main/CONTRIBUTING.md#writing-docs)
+for the full editor loop.
+
+## SLURM clusters (Kempner and similar)
+
+Unit tests run on CPU login nodes. Anything that needs a GPU (integration,
+distributed, end-to-end tests, and actual training) has to run inside a SLURM
+allocation.
+
+### Interactive allocation for development
+
+```bash
+# 1 node, 4 GPUs — enough for integration + distributed tests
+salloc --partition=<partition-name> --account=<account-name> \
+  --nodes=1 --gpus-per-node=4 --cpus-per-task=16 --mem=256G --time=2:00:00
+```
+
+Replace `<partition-name>` and `<account-name>` with values your PI gave
+you. Once the prompt returns, you are on a compute node and can run
+`uv run torchrun ...` directly.
+
+### Modules and environment
+
+On Kempner clusters, the provided `scripts/slurm/*.sh` wrappers detect the
+InfiniBand interface and export `NCCL_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME`
+before invoking `torchrun` or `srun`. They do not `module load` anything —
+`uv sync` brings in the CUDA-enabled PyTorch wheel, and the CUDA driver is
+already present on compute nodes.
+
+If you launch bare `torchrun` from an interactive shell, the venv from
+`uv sync` is all you need.
+
+## Next steps
+
+- {doc}`quickstart` — run a tiny model end-to-end in under a minute.
+- {doc}`first-training-run` — understand what that run actually did.
+- [`CONTRIBUTING.md`](https://github.com/KempnerInstitute/KempnerForge/blob/main/CONTRIBUTING.md#environment-setup) for the contributor workflow (branch naming, PR template, pre-push checklist).

--- a/docs/getting-started/notebooks.md
+++ b/docs/getting-started/notebooks.md
@@ -1,0 +1,68 @@
+# Notebooks
+
+Six interactive Jupyter notebooks under
+[`examples/notebooks/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/examples/notebooks)
+for single-GPU exploration. All use tiny 1–5M-param configs sized for
+interactive use — each runs end-to-end in well under a minute, except
+notebook 5 (optimizer comparison, ~2 min).
+
+Every notebook opens with the same header:
+
+- **Objectives** — what you'll learn
+- **Requirements** — hardware, data, prerequisites
+- **Runtime** — approximate wall time for *Run All*
+
+## Running
+
+From the repo root:
+
+```bash
+uv run jupyter lab examples/notebooks/
+```
+
+Or execute a single notebook non-interactively:
+
+```bash
+uv run jupyter nbconvert --to notebook --execute \
+  examples/notebooks/01_inspect_model.ipynb
+```
+
+## Catalogue
+
+| # | Notebook | What it shows |
+|---|----------|---------------|
+| 1 | [`01_inspect_model.ipynb`](https://github.com/KempnerInstitute/KempnerForge/blob/main/examples/notebooks/01_inspect_model.ipynb) | Build a model from `ModelConfig`, inspect layer shapes, run a forward pass |
+| 2 | [`02_attention_visualization.ipynb`](https://github.com/KempnerInstitute/KempnerForge/blob/main/examples/notebooks/02_attention_visualization.ipynb) | Capture attention weights per layer and head, plot heatmaps |
+| 3 | [`03_activation_extraction.ipynb`](https://github.com/KempnerInstitute/KempnerForge/blob/main/examples/notebooks/03_activation_extraction.ipynb) | Extract intermediate activations via `ActivationStore` and `extract_representations()`, save to `.npz` |
+| 4 | [`04_checkpoint_analysis.ipynb`](https://github.com/KempnerInstitute/KempnerForge/blob/main/examples/notebooks/04_checkpoint_analysis.ipynb) | Train a tiny model, save a checkpoint, load it back, generate text |
+| 5 | [`05_optimizer_comparison.ipynb`](https://github.com/KempnerInstitute/KempnerForge/blob/main/examples/notebooks/05_optimizer_comparison.ipynb) | Train the same model with AdamW / Muon / Lion / Schedule-Free AdamW, plot loss curves |
+| 6 | [`06_moe_routing.ipynb`](https://github.com/KempnerInstitute/KempnerForge/blob/main/examples/notebooks/06_moe_routing.ipynb) | Build an MoE model, visualize per-layer expert utilization |
+
+## When to open which
+
+- **Debugging a config**: start with notebook 1 — it builds the model from
+  your config and prints every layer's shape.
+- **Interpretability setup**: notebooks 2 and 3 cover the attention-capture
+  and activation-extraction APIs you'll use in a larger probing pipeline.
+- **Checkpoint round-trips**: notebook 4 is the minimal reproduction of
+  "train → save → load → generate" that you can adapt for evaluating any
+  checkpoint.
+- **Optimizer ablations**: notebook 5 is the reference pattern for a
+  controlled comparison with per-optimizer LR sweeps.
+- **MoE diagnostics**: notebook 6 shows how to read `get_expert_counts()`
+  output and spot dead or hot experts.
+
+## Requirements
+
+- 1 GPU (falls back to CPU where possible, but attention and training are
+  slow).
+- Project dev dependencies installed via `uv sync` from the repo root.
+
+Notebook outputs are stripped on commit (via the `nbstripout` pre-commit
+hook) to keep diffs clean, so you'll always see empty outputs until you
+run them.
+
+```{note}
+These notebooks are meant to be **run**, not just **read**. The Sphinx site
+does not execute them or embed their outputs — open them in JupyterLab.
+```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,122 @@
+# Quickstart
+
+A 5-minute walkthrough that trains a tiny model so you can
+verify your install and see the training loop end-to-end.
+
+```{tip}
+When you change `model.vocab_size`, `model.dim`, or any other shape-affecting
+field between runs, use a fresh `--checkpoint.dir` or delete the old one
+first. `train.py` auto-resumes from the latest checkpoint in the directory,
+which will fail with a shape mismatch if the architecture changed. Examples
+below use `/tmp/` paths so runs don't collide.
+```
+
+## 1. Install
+
+```bash
+git clone git@github.com:KempnerInstitute/KempnerForge.git
+cd KempnerForge
+uv sync
+```
+
+If you want more detail on this step, see {doc}`install`.
+
+## 2. Run a 20M-parameter debug model on a single GPU
+
+```bash
+uv run python scripts/train.py configs/train/debug.toml \
+  --checkpoint.dir=/tmp/kf_quickstart/step2
+```
+
+You should see per-step loss / MFU / step_time logs. The run takes under a
+minute. It uses synthetic data (no dataset download) — useful for
+sanity-checking the install before pointing at real data.
+
+For a slower walkthrough of what this run does, what the log line means, and
+what ends up in the checkpoint directory, see {doc}`first-training-run`.
+
+## 3. Multi-GPU on a single node (FSDP2)
+
+```bash
+uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/debug.toml \
+  --distributed.dp_shard=4 \
+  --checkpoint.dir=/tmp/kf_quickstart/step3
+```
+
+## 4. Point at your own tokenized data
+
+Pre-tokenized `.bin` or `.npy` shards work directly:
+
+```bash
+uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/debug.toml \
+  --data.dataset_path=/path/to/your/shards \
+  --data.file_pattern='tokenized_*.bin' \
+  --model.vocab_size=128256 \
+  --checkpoint.dir=/tmp/kf_quickstart/step4
+```
+
+Or stream from HuggingFace:
+
+```bash
+uv run python scripts/train.py configs/train/hf_wikitext.toml \
+  --checkpoint.dir=/tmp/kf_quickstart/step4_hf
+```
+
+## 5. Try a different optimizer
+
+Swap AdamW for Muon without touching code:
+
+```bash
+uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/debug.toml \
+  --optimizer.name=muon \
+  --checkpoint.dir=/tmp/kf_quickstart/step5
+```
+
+Available: `adamw`, `muon`, `lion`, `schedule_free_adamw`.
+
+## 6. Enable MoE
+
+```bash
+uv run python scripts/train.py configs/train/debug_moe.toml \
+  --checkpoint.dir=/tmp/kf_quickstart/step6
+```
+
+Or turn on MoE via CLI on the dense debug config:
+
+```bash
+uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/debug.toml \
+  --model.num_experts=8 --model.moe_top_k=2 --model.moe_router=sigmoid_topk \
+  --checkpoint.dir=/tmp/kf_quickstart/step6_cli
+```
+
+## 7. Extend the training loop without forking `train.py`
+
+See [`examples/custom_hook.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/examples/custom_hook.py)
+for four example hooks:
+
+- `GradNormHistogramHook` — per-layer gradient norms to WandB
+- `LearningDynamicsHook` — weight norms and gradient SNR
+- `EarlyStoppingHook` — stop if eval loss plateaus
+- `ExpertLoadBalanceHook` — MoE expert utilization metrics
+
+Register them in your own script by subclassing `TrainingHook`.
+
+## Next steps
+
+- **Understand the run**: {doc}`first-training-run` explains the log line,
+  the checkpoint directory layout, and auto-resume.
+- **Interactive exploration**: {doc}`notebooks` lists six Jupyter notebooks
+  (model inspection, attention visualization, activation extraction,
+  checkpoint analysis, optimizer comparison, MoE routing).
+- **Scale up**: see
+  [README § Training Configurations](https://github.com/KempnerInstitute/KempnerForge#training-configurations)
+  for 7B / 13B / 70B configs.
+- **Run on SLURM**: see
+  [README § Quick Start](https://github.com/KempnerInstitute/KempnerForge#quick-start)
+  for single- and multi-node launch scripts.
+- **Measured performance**: see
+  [`benchmarks/mfu_scaling/mfu_scaling.md`](https://github.com/KempnerInstitute/KempnerForge/blob/main/benchmarks/mfu_scaling/mfu_scaling.md)
+  for MFU / throughput numbers across 1–32 GPUs.
+- **Contribute**:
+  [CONTRIBUTING.md](https://github.com/KempnerInstitute/KempnerForge/blob/main/CONTRIBUTING.md)
+  walks through the issue → branch → PR flow.

--- a/docs/how-to/build-a-model.md
+++ b/docs/how-to/build-a-model.md
@@ -1,0 +1,242 @@
+# Build a model
+
+KempnerForge builds a `Transformer` from a `ModelConfig` via a
+component registry. Seven sub-component categories are swappable by
+name — `mlp`, `router`, `norm`, `model`, `optimizer`, `scheduler`,
+`loss`. This page walks through the common cases: choose the
+activation, flip on MoE, toggle QK-norm, and register your own MLP
+variant.
+
+## The minimal model
+
+```python
+from kempnerforge.config import load_config
+from kempnerforge.distributed import init_distributed
+from kempnerforge.distributed.parallel import build_parallel_model
+
+config  = load_config("configs/train/debug.toml")
+mesh    = init_distributed(config.distributed)
+model   = build_parallel_model(config.model, device="cuda", device_mesh=mesh)
+```
+
+[`build_parallel_model`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/parallel.py)
+looks up `config.model.model_type` (default `"transformer"`) in the
+`model` registry, constructs a `Transformer`, and applies parallelism
+in the canonical
+[5-step order](../architecture/parallelism-order.md). The
+`Transformer` itself is composition:
+
+```
+TokenEmbedding
+→ [TransformerBlock × n_layers]          # attention + MLP (or MoE)
+→ RMSNorm
+→ OutputHead (tied or separate)
+```
+
+Every sub-component it uses is pulled from a registry at import time.
+
+## Registry categories
+
+```python
+# Every category follows the same register(cat, name, fn) pattern
+# kempnerforge/config/registry.py
+registry.register("norm",      "rmsnorm",    _build_rmsnorm)
+registry.register("norm",      "layernorm",  _build_layernorm)
+registry.register("mlp",       "swiglu",     _build_swiglu)
+registry.register("mlp",       "standard_gelu", _build_standard_gelu)
+registry.register("mlp",       "standard_relu", _build_standard_relu)
+registry.register("router",    "softmax_topk",  _build_softmax_topk)
+registry.register("router",    "sigmoid_topk",  _build_sigmoid_topk)
+registry.register_model("transformer")(Transformer)
+# + optimizer, scheduler, loss (see Registry reference)
+```
+
+Full list and the registration mechanics:
+[Registry](../configuration/registry.md).
+
+## Swap the activation / MLP flavor
+
+```toml
+[model]
+activation = "silu"    # "silu" (SwiGLU), "gelu", or "relu"
+```
+
+The activation string maps to an MLP registry key:
+
+| `activation` | MLP class | Projections |
+|--------------|-----------|:-----------:|
+| `silu` | `SwiGLUMLP` | 3 (gate + up + down) |
+| `gelu` | `StandardMLP` | 2 (up + down) |
+| `relu` | `StandardMLP` | 2 (up + down) |
+
+```python
+# kempnerforge/model/mlp.py — build_mlp
+_ACTIVATION_TO_MLP = {"silu": "swiglu", "gelu": "standard_gelu", "relu": "standard_relu"}
+
+def build_mlp(dim, hidden_dim, activation="silu"):
+    key = _ACTIVATION_TO_MLP.get(activation, activation)
+    return registry.get("mlp", key)(dim, hidden_dim)
+```
+
+No other config knob decides the MLP — change `activation` and the
+right class gets built.
+
+## Flip a model to MoE
+
+```toml
+[model]
+num_experts   = 8     # >0 enables MoE layers
+moe_top_k     = 2
+moe_router    = "sigmoid_topk"   # or "softmax_topk"
+moe_frequency = 1                # every layer; 2 = alternating dense/MoE
+```
+
+`TransformerBlock.__init__` picks MoE per-layer based on
+`config.is_moe` and `moe_frequency`:
+
+```python
+# kempnerforge/model/transformer.py — TransformerBlock.__init__
+use_moe = config.is_moe and ((layer_idx + 1) % config.moe_frequency == 0)
+if use_moe:
+    self.mlp = build_moe(...)
+else:
+    self.mlp = build_mlp(...)
+```
+
+With `moe_frequency = 2`, odd-indexed layers (1, 3, 5…) are MoE and
+the rest are dense. See [MoE § overview](../moe/index.md).
+
+## Toggle QK-norm
+
+```toml
+[model]
+qk_norm = true    # Gemma / DeepSeek-V3 style per-head RMSNorm on Q/K before RoPE
+```
+
+When set, `Attention.__init__` adds `self.q_norm` and `self.k_norm`
+(RMSNorm on `head_dim`) and applies them per-head before RoPE:
+
+```python
+# kempnerforge/model/attention.py — Attention.__init__
+if qk_norm:
+    self.q_norm = RMSNorm(head_dim)
+    self.k_norm = RMSNorm(head_dim)
+```
+
+Default is `false` (plain Llama / Mixtral). Flip it on for
+reproductions of Gemma or DeepSeek-V3.
+
+## Swap the norm
+
+```toml
+[model]
+norm_type = "rmsnorm"    # or "layernorm"
+norm_eps  = 1e-5
+```
+
+Used by both the attention pre-norm and the MLP pre-norm on every
+block, plus the final norm before the output head. Same two keys
+(`rmsnorm`, `layernorm`) — flip via config, no code change.
+
+## Register a new MLP variant
+
+All four component categories pulled from the registry at block
+construction (`mlp`, `router`, `norm`, `model`) accept new entries at
+import time. Example — a gated MLP with a custom gate function:
+
+```python
+# my_project/mlp_variants.py
+import torch.nn as nn
+from kempnerforge.config import registry
+
+class MyCustomMLP(nn.Module):
+    def __init__(self, dim: int, hidden_dim: int) -> None:
+        super().__init__()
+        self.up   = nn.Linear(dim, hidden_dim, bias=False)
+        self.down = nn.Linear(hidden_dim, dim, bias=False)
+        # ... whatever you want ...
+
+    def forward(self, x):
+        return self.down(self.up(x).tanh())   # or your gate
+
+def _build_my_mlp(dim: int, hidden_dim: int) -> MyCustomMLP:
+    return MyCustomMLP(dim, hidden_dim)
+
+registry.register("mlp", "my_mlp", _build_my_mlp)
+```
+
+Import it before training starts (in `scripts/train.py` or a plugin
+module), then:
+
+```toml
+[model]
+activation = "my_mlp"   # matches the registry key
+```
+
+The activation-name → MLP-key mapping covers `silu`/`gelu`/`relu`; any
+other string is looked up directly in the `"mlp"` category, so your
+key just works.
+
+```{note}
+The registry is a global singleton; `registry.get("mlp", "my_mlp")`
+raises `ValueError` if the module containing the `register()` call
+wasn't imported. Import it at the top of `scripts/train.py` or in your
+package's `__init__.py`.
+```
+
+## What's *not* registered
+
+`TransformerBlock` itself is **hardcoded**, not registered. There's no
+`"block"` category. If you want a new block variant (e.g., parallel
+attention+MLP à la PaLM, or a different residual pattern), you fork
+`kempnerforge/model/transformer.py` and edit `TransformerBlock`.
+
+Similarly, attention is hardcoded — the QK-norm toggle is the only
+attention variant reachable from config.
+
+This is deliberate: block-level topology changes are rare and touch
+the forward signature (e.g., what gets passed between attention and
+MLP), so a config toggle would leak into every block. If you find
+yourself wanting a new block registered, open an issue — it's a
+design question, not a quick registry addition.
+
+## Full model-construction path
+
+```
+load_config()  → JobConfig with a ModelConfig
+    ↓
+build_parallel_model(model_config, device, mesh, ...)
+    ├─ registry.get_model(config.model_type)       → Transformer
+    ├─ Transformer(config)
+    │     └─ TransformerBlock(config, layer_idx)   × n_layers
+    │           ├─ build_norm(norm_type, dim)      ← registry["norm"]
+    │           ├─ Attention(..., qk_norm=...)     ← hardcoded class
+    │           └─ MLP per block (choice by config.is_moe and moe_frequency):
+    │                 build_mlp(activation, ...)   ← registry["mlp"]
+    │              OR build_moe(router_type, ...)  ← registry["router"] for the
+    │                                                router + registry["mlp"] for
+    │                                                each expert
+    ├─ apply_tensor_parallel(...)   [if tp > 1]
+    ├─ apply_expert_parallel(...)   [if ep > 1]
+    ├─ apply_float8(...)            [if mixed_precision == "fp8"]
+    ├─ apply_ac(...)                [if activation_checkpointing]
+    └─ fully_shard(...)             [FSDP2]
+```
+
+Every box that isn't "hardcoded class" goes through a registry lookup.
+Pipeline parallelism (not shown) is applied outside this flow — it
+splits the model into stages in `scripts/train.py` *before*
+`build_parallel_model` runs on each stage.
+
+## See also
+
+- [Registry](../configuration/registry.md) — the singleton itself,
+  registration semantics, `get_model` / `get_optimizer` shortcuts.
+- [Configuration § `[model]`](../configuration/config-sections.md) —
+  every `ModelConfig` field with its default.
+- [Architecture § Model](../architecture/model.md) — what the
+  Transformer actually does at forward time.
+- [Parallelism order](../architecture/parallelism-order.md) — what
+  `build_parallel_model` does after it constructs the `Transformer`.
+- [MoE § overview](../moe/index.md) — the full MoE wiring when
+  `num_experts > 0`.

--- a/docs/how-to/compare-optimizers.md
+++ b/docs/how-to/compare-optimizers.md
@@ -1,0 +1,209 @@
+# Compare optimizers
+
+KempnerForge ships four optimizers. Each is registered under a name
+that goes in `optimizer.name`, and each reads a different subset of
+`[optimizer]` fields. This page explains what those subsets are, what
+the LR conventions imply, and how to run a fair head-to-head.
+
+| `optimizer.name` | Class | Extra `[optimizer]` fields | Typical LR |
+|------------------|-------|----------------------------|------------|
+| `adamw` | `torch.optim.AdamW` (fused) | — | 1e-4 – 3e-4 |
+| `lion` | [`Lion`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/optimizer.py) | — (uses `betas`) | ~3–10× smaller than AdamW |
+| `muon` | [`Muon`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/optimizer.py) | `muon_momentum`, `muon_ns_steps`, `muon_adam_lr` | ~0.003 (see below) |
+| `schedule_free_adamw` | [`ScheduleFreeAdamW`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/optimizer.py) | `schedule_free_warmup_steps` | ~0.025 (constant, see below) |
+
+Each is a single-line swap:
+
+```toml
+[optimizer]
+name = "muon"    # or "adamw", "lion", "schedule_free_adamw"
+lr = 0.003
+```
+
+## What they share
+
+All four go through
+[`build_optimizer`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/optimizer.py),
+which splits parameters into two groups before handing them to the
+chosen builder:
+
+- **Decay group** — 2D+ parameters without `"bias"` in the name get
+  `weight_decay = config.weight_decay`.
+- **No-decay group** — 1D parameters (norm scales, biases) and any
+  parameter whose name contains `"bias"` get `weight_decay = 0.0`.
+
+So `weight_decay` and `lr` mean the same thing across optimizers;
+`betas` is shared by AdamW, Lion (interpretation differs), Muon's
+internal AdamW fallback, and Schedule-Free AdamW.
+
+## AdamW
+
+```toml
+[optimizer]
+name = "adamw"
+lr = 3e-4
+weight_decay = 0.1
+betas = [0.9, 0.95]
+eps = 1e-8
+fused = true
+```
+
+Standard PyTorch fused AdamW. Two state tensors per parameter (first
+and second moment). The default for KempnerForge —
+[`configs/train/7b_16gpu_adamw.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_adamw.toml)
+is the reference 7B recipe.
+
+## Lion
+
+```toml
+[optimizer]
+name = "lion"
+lr = 3e-5      # ~10× smaller than the AdamW LR you'd use
+weight_decay = 0.1
+betas = [0.9, 0.99]
+```
+
+Sign-based momentum — the update direction is
+`sign(beta1 * m + (1 - beta1) * grad)`. Only **one** state tensor per
+parameter (vs two for AdamW), so optimizer memory is roughly halved.
+
+The class docstring recommends an LR 3–10× smaller than AdamW's. If you
+port a run from AdamW, scale `lr` down and leave `weight_decay`
+alone — Lion's decoupled weight-decay term keeps the same meaning.
+
+`eps` is unused by Lion; it's only in the shared config because other
+optimizers read it.
+
+## Muon
+
+```toml
+[optimizer]
+name = "muon"
+lr = 0.003            # for 2D matrices (Newton-Schulz orthogonalized)
+weight_decay = 0.1
+muon_momentum = 0.95
+muon_ns_steps = 5
+muon_adam_lr = 3e-4   # Optional: LR for 1D params. Default = same as `lr`.
+```
+
+Muon orthogonalizes the 2D momentum update via a 5-step Newton-Schulz
+iteration, then scales by `sqrt(max(1, m/n))`. This keeps the update
+direction independent of parameter scale, so the effective LR is
+much larger than an AdamW LR on the same model.
+[`configs/train/7b_16gpu_muon.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_muon.toml)
+uses `lr = 0.003` as a working reference.
+
+**Split under the hood.** `build_optimizer` routes each parameter
+based on [`_is_muon_eligible`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/optimizer.py):
+
+- **Muon group**: 2D+ parameters with a reasonable aspect ratio
+  (`max(m, n) / min(m, n) <= 10`). Transformer blocks' weight matrices
+  qualify.
+- **AdamW fallback group**: 1D params (biases, norm scales) and
+  highly-rectangular matrices (embeddings, output heads — where
+  `X @ X^T` would be `vocab_size × vocab_size`).
+
+The builder logs the two counts:
+
+```
+Muon: 6,390,525,952 params (NS-orthogonalized), 525,336,576 params (AdamW fallback)
+```
+
+**LR coupling.** Muon's scheduler sees only the Muon param groups.
+Before every Muon `step()`, the internal AdamW LR is rescaled by
+`muon_current_lr / muon_initial_lr` so both groups follow the same
+warmup/decay curve. If you set `muon_adam_lr`, it's the *initial* LR
+for the 1D group, then tracks the Muon schedule shape.
+
+**FSDP2 interaction.** Newton-Schulz runs on each rank's local shard
+of the weight matrix rather than the fully gathered matrix — an
+approximation documented in the
+[`Muon` docstring](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/optimizer.py).
+Works in practice at 16+ GPU scale; the reference Muon config has been
+validated there.
+
+## Schedule-Free AdamW
+
+```toml
+[optimizer]
+name = "schedule_free_adamw"
+lr = 0.025                      # constant — no scheduler decay
+weight_decay = 0.1
+betas = [0.9, 0.999]
+schedule_free_warmup_steps = 200
+
+[scheduler]
+name = "none"                   # required — see below
+```
+
+Schedule-Free AdamW (Defazio & Mishchenko, 2024) maintains two iterates
+per parameter — `z` (descent point) and `x` (Polyak average) — and
+evaluates gradients at an interpolation `y`. The internal averaging
+replaces an LR schedule, so **the training-loop scheduler must be
+`none`** (the corresponding registered scheduler that leaves LR
+constant):
+
+```python
+# kempnerforge/config/scheduler.py
+none = "none"  # constant LR (for schedule-free optimizers)
+```
+
+Internal LR warmup is controlled by `schedule_free_warmup_steps`
+(default 0 = no warmup). Use a few hundred to stabilize early training.
+
+**Memory.** Three state tensors per parameter (`z`, `v` = second
+moment, `x` = Polyak average) + the `weight_sum` scalar — larger
+footprint than AdamW's two.
+
+**Eval quirk.** Best downstream numbers come from evaluating the
+Polyak-averaged `x` rather than the training point `y`. The class
+exposes `eval_params()` and `train_params()` to swap the parameters
+in place, but the training loop does **not** call them automatically.
+If you run `scripts/eval.py` on a schedule-free checkpoint, you're
+evaluating `y` unless you patch in those calls — usually close, but
+not optimal.
+
+## Running a fair comparison
+
+No benchmark utility ships — you run the comparisons yourself. The
+minimum protocol:
+
+1. **Fix everything except the optimizer.** Copy
+   [`configs/train/7b_16gpu_adamw.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_adamw.toml)
+   twice and only change `[optimizer]` (and `[scheduler]` for
+   schedule-free). Same seed, same data, same `max_steps`, same
+   `batch_size × grad_accum_steps × world_size`.
+2. **Use one LR per optimizer, not the same LR across optimizers.**
+   The conventions are different: a 3e-4 LR for AdamW is roughly
+   3e-5 for Lion and 3e-3 for Muon. Using AdamW's LR with Muon makes
+   Muon look catastrophic; using Muon's LR with AdamW NaNs out.
+3. **Turn on per-optimizer warmup.** AdamW / Lion / Muon use the
+   training-loop scheduler's warmup; Schedule-Free has
+   `schedule_free_warmup_steps` instead.
+4. **Measure steady-state loss after warmup.** Plot loss vs steps from
+   at least `max(warmup_steps × 3, 200)`. The first few hundred steps
+   are dominated by warmup transients and aren't diagnostic.
+5. **Log enough to diagnose.** `train/grad_norm` for instability,
+   `gpu/peak_gb` for memory footprint (especially for Schedule-Free vs
+   Lion), `tok/s` for throughput. See
+   [Metrics § Metrics tracker](../metrics-and-profiling/metrics-tracker.md)
+   for the fields.
+
+A realistic short-horizon pilot is ~500–1,000 steps on the
+[`configs/train/hf_wikitext.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/hf_wikitext.toml)
+recipe — small model, no dataset setup. Rankings there don't
+necessarily transfer to a 7B run, but large discrepancies in memory
+or divergence behavior will.
+
+## See also
+
+- [Training § Optimizers](../training/optimizers.md) — class-level
+  reference for each optimizer's update rule.
+- [Configuration § `[optimizer]`](../configuration/config-sections.md) —
+  every `OptimizerConfig` field and its validation rule.
+- [Training § Schedulers](../training/schedulers.md) — the `"none"`
+  scheduler and why Schedule-Free needs it.
+- [Scaling guide](scaling-guide.md) — context for the reference
+  configs this page points at.
+- [`kempnerforge/training/optimizer.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/optimizer.py)
+  — source for all four optimizers.

--- a/docs/how-to/data-mixing-annealing.md
+++ b/docs/how-to/data-mixing-annealing.md
@@ -1,0 +1,247 @@
+# Mix datasets and anneal data weights
+
+Training on more than one corpus at once — and shifting the mix mid-run
+— is common practice. KempnerForge supports both through three
+orthogonal config controls: multi-dataset sources in `[data]`, a
+temperature knob on the mixture weights, and optional `[data.phases]`
+that retarget the mix (and the LR) at fixed steps. This page explains
+each and shows how they compose.
+
+## The three controls
+
+```toml
+[data]
+mix_temperature = 1.0            # knob on the weights; 1.0 = as-declared
+
+[[data.datasets]]                # multi-dataset mixture
+name   = "web"
+path   = "/data/tokenized/web"
+weight = 0.7
+
+[[data.datasets]]
+name    = "code"
+hf_name = "bigcode/the-stack-dedup"
+weight  = 0.3
+
+[[data.phases]]                  # phase transitions
+start_step      = 10_000
+dataset_weights = { web = 0.3, code = 0.7 }
+lr_scale        = 0.5
+```
+
+- **`[[data.datasets]]`** turns mixing on. Without it, `[data]` falls
+  back to the single-dataset fields (`dataset_path` or
+  `hf_dataset_name`).
+- **`mix_temperature`** rescales declared weights before sampling.
+- **`[[data.phases]]`** swaps weights (and scales LR) at specific
+  steps during training.
+
+A fourth control, `anneal_start_step` / `anneal_weights`, is sugar for
+the common "change the mix once, late in training" pattern — see
+[Annealing shortcut](#annealing-shortcut) below.
+
+## Multi-dataset mixture
+
+Each `[[data.datasets]]` block is a
+[`DatasetSource`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/data.py):
+
+| Field | Meaning |
+|-------|---------|
+| `name`   | Label for per-dataset metrics and phase overrides. Auto-filled from `path`/`hf_name` if empty. |
+| `path`   | Pre-tokenized directory (use with `file_pattern`). |
+| `hf_name` | HuggingFace dataset ID (alternative to `path`). |
+| `hf_config` | HF dataset config (e.g. `"wikitext-103-raw-v1"`). |
+| `weight` | Relative sampling weight (must be positive). Normalized internally. |
+
+At least one of `path` / `hf_name` must be set per source, enforced by
+`DataConfig.__post_init__`.
+
+When any `[[data.datasets]]` is present, `scripts/train.py` builds a
+[`MixtureDataset`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/data/dataset.py)
+over the sub-datasets and drives it with a
+[`MixtureSampler`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/data/sampler.py).
+The sampler:
+
+- Partitions each sub-dataset's indices across data-parallel ranks
+  (stride-based, like `DistributedSampler`).
+- Allocates `target_counts[i] = round(prob[i] × total_per_rank)` indices
+  per epoch from each source and over- or undersamples to match
+  the target.
+- Interleaves the drawn indices with one final shuffle so the model
+  sees a randomly mixed order, not source-blocked batches.
+
+Every sample returned by `MixtureDataset.__getitem__` includes a
+`dataset_idx` key so the training loop can slot the per-batch loss into
+per-dataset metrics.
+
+### Per-dataset metrics
+
+When the mixture is active and the metrics interval fires,
+`scripts/train.py` emits two series per dataset name:
+
+- `loss/{name}` — mean loss of samples from that dataset in the
+  accumulation window.
+- `data/{name}/tokens` — running token count consumed from that
+  dataset.
+
+Plot these in WandB / TensorBoard to see whether a dataset is
+contributing normally or drifting. A rising `loss/code` while
+`loss/web` stays flat is a signal.
+
+## Temperature
+
+`mix_temperature` rescales the declared `weight` values before
+normalization. The math in
+[`MixtureSampler.__init__`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/data/sampler.py)
+is:
+
+```python
+log_w  = [log(max(w, 1e-12)) / temperature for w in weights]
+probs  = softmax(log_w)           # after subtracting the max for stability
+```
+
+So the three interesting regimes are:
+
+- **`temperature = 1.0`** (default) — probabilities are just the
+  declared weights, normalized.
+- **`temperature > 1.0`** — weights are *flattened* toward uniform. At
+  `temperature → ∞`, every source has probability `1/N` regardless of
+  its declared weight.
+- **`temperature < 1.0`** — weights are *sharpened*. At
+  `temperature → 0`, the heaviest source takes everything.
+
+The common setting is `temperature > 1` when the declared weights
+reflect corpus size but you want to undersample the largest corpus so
+a small, high-quality source isn't drowned out. A typical value is in
+the 1.3–2.0 range; the right number depends on the relative size of
+your corpora.
+
+## Phase transitions
+
+A `[[data.phases]]` entry is a
+[`TrainingPhase`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/data.py):
+
+| Field | Meaning |
+|-------|---------|
+| `start_step`      | Step at which this phase activates (must be non-negative). |
+| `dataset_weights` | `{name: weight}` — any source not listed keeps its original weight. |
+| `lr_scale`        | Multiplier applied to *every* param group's LR once this phase fires. |
+
+Constraints (validated in `DataConfig.__post_init__`):
+
+- Phase `start_step` values must be strictly monotonically increasing.
+- You can use either `[[data.phases]]` **or** the annealing shortcut
+  below — not both.
+- All `dataset_weights` values must be non-negative; `lr_scale > 0`.
+
+### What happens on a phase transition
+
+On the first training step where `step >= phase.start_step`, the loop
+in
+[`scripts/train.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/train.py)
+does two things:
+
+1. Builds a new `weights` list by overriding the original declared
+   weights with `phase.dataset_weights` entries where specified, then
+   calls `sampler.update_weights(new_weights, temperature=config.data.mix_temperature)`
+   — the next `__iter__()` call on the sampler uses the new mix.
+2. Sets `phase_lr_scale = phase.lr_scale`. From this step forward,
+   the training loop multiplies every parameter group's LR by
+   `phase_lr_scale` after the scheduler has computed the base LR. The
+   scheduler still runs; `phase_lr_scale` is an additional factor on
+   top.
+
+So if your scheduler is driving `lr` from `3e-4` down to `3e-5` via
+cosine decay, a phase with `lr_scale = 0.5` means the optimizer sees
+`1.5e-4 → 1.5e-5` while that phase is active. Later phases overwrite
+`phase_lr_scale` with their own value; there's no compounding across
+phases.
+
+### Resume behavior
+
+At startup, the training loop walks the phase list and applies every
+phase whose `start_step <= current_step`, logging
+`"Resumed into phase K, lr_scale=S"`. The checkpoint itself tracks
+the current phase index (stored in the `ckpt_extra` field), so a
+mid-phase resume lands on the correct weights without re-firing older
+phases.
+
+`mixture_dataset.dataset_names` is the key into `phase.dataset_weights`
+— keep `name` stable across checkpoint / resume or you'll silently
+revert to the original declared weights for any name that no longer
+matches.
+
+## Annealing shortcut
+
+For the very common "one change, late" pattern, you can skip the
+verbose `[[data.phases]]` block:
+
+```toml
+[data]
+anneal_start_step = 40_000
+anneal_weights    = { web = 0.1, code = 0.9 }
+```
+
+`scripts/train.py` converts this into a one-element `TrainingPhase`
+list internally:
+
+```python
+TrainingPhase(
+    start_step=config.data.anneal_start_step,
+    dataset_weights=dict(config.data.anneal_weights),
+    # lr_scale defaults to 1.0 — no LR change
+)
+```
+
+Default `lr_scale` is **1.0** — the LR curve doesn't change unless you
+say so. If you want both weight annealing **and** an LR drop on
+transition, use `[[data.phases]]` explicitly.
+
+## Sanity checks
+
+Before committing to a long run, verify the mix is what you think:
+
+```bash
+uv run python scripts/train.py configs/train/your_mix.toml \
+    --train.max_steps=100 --metrics.log_interval=1
+```
+
+Inspect the `data/{name}/tokens` counters after 100 steps. The ratios
+should roughly match your target probabilities.
+
+```
+data/web/tokens        ≈ (web_prob)  × total_tokens
+data/code/tokens       ≈ (code_prob) × total_tokens
+```
+
+If the numbers are off by much more than one batch's worth of tokens,
+double-check:
+
+- `name` values in `[[data.datasets]]` vs any `phase.dataset_weights`
+  overrides (case-sensitive, exact match).
+- That phase `start_step` values haven't already fired before step
+  100 (phase transitions change what you're measuring).
+- That `mix_temperature` is what you intended — a temperature other
+  than 1.0 changes sampling probabilities away from the declared
+  weights.
+
+For a phase transition specifically, watch the log for the
+`"Phase transition at step N: phase=K, lr_scale=S"` line — it fires
+exactly once per transition, and the `data/{name}/tokens` slopes
+should visibly change immediately after.
+
+## See also
+
+- [Data § Mixing and annealing](../data/mixing-and-annealing.md) —
+  `MixtureDataset` internals and the non-mixing dataset classes.
+- [Data § Sampler](../data/sampler.md) — `MixtureSampler` and
+  `update_weights` internals.
+- [Configuration § `[data]`](../configuration/config-sections.md) —
+  every `DataConfig` field and its validation rule.
+- [Training § Training loop](../training/training-loop.md) — where
+  `phase_lr_scale` is applied and how phase checkpoint state is
+  persisted.
+- [Compare optimizers](compare-optimizers.md) — LR conventions matter
+  when you combine `lr_scale` with non-AdamW optimizers.
+- [Prepare tokenized data](prepare-tokenized-data.md) — how to produce
+  the per-source `path` directories this page consumes.

--- a/docs/how-to/debug-training-regressions.md
+++ b/docs/how-to/debug-training-regressions.md
@@ -1,0 +1,273 @@
+# Debug training regressions
+
+Training failures cluster into five shapes: loss goes NaN, memory
+creeps up to OOM, a rank hangs without error, throughput silently
+halves, and the loss curve looks plausible but downstream eval is
+worse. This page chains the tools the codebase already ships to
+diagnose each.
+
+## The diagnostic toolbox
+
+| Tool | What it catches | Config | Enabled by default? |
+|------|------------------|:------:|:-------------------:|
+| [`NaNDetector`](../resilience/nan-detection.md) | NaN/Inf in loss | hardcoded in `scripts/train.py` | yes (warn mode) |
+| [`MetricsTracker`](../metrics-and-profiling/metrics-tracker.md) | loss, grad-norm, tok/s, MFU, memory | `[metrics]` | yes |
+| [`DeviceMemoryMonitor`](../metrics-and-profiling/memory-monitor.md) | per-interval peak memory, snapshot export | manual instantiation | no |
+| [`torch.profiler` wrapper](../metrics-and-profiling/profiler.md) | kernel traces, efficiency breakdown | `[profiling]` | no |
+| [`check_nccl_health`](../resilience/nccl-liveness.md) | dead/deadlocked rank | `train.nccl_health_check_interval` | no |
+| [`check_gpu_health`](../resilience/gpu-health.md) | dead GPU, alloc fail | on-demand | no |
+
+Default-on tools give you signal for free. The rest you reach for
+when default-on signals point at a specific failure mode.
+
+## Shape 1: loss goes NaN
+
+**Symptom:** one step shows `loss NaN`, the next might too, training
+keeps running.
+
+**What the codebase does:** `scripts/train.py` instantiates
+`NaNDetector(action="warn", max_consecutive=10)` at startup. Each
+step's `avg_loss` flows through
+[`check_loss()`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/health.py),
+which all-reduces a NaN flag across ranks and returns `False` on NaN.
+The training loop reacts:
+
+- Logs a warning on every NaN/Inf (from `check_loss`)
+- Zeros gradients and skips the optimizer step (in the loop, right
+  after `check_loss` returns False — preserves last-good weights)
+- When `nan_detector.should_rollback` becomes true (consecutive count
+  ≥ `max_consecutive`), rank 0 logs `"Too many consecutive NaNs — stopping"`
+  and breaks the loop
+
+You still need to act — the detector doesn't roll back, it just keeps
+you from optimizing into garbage. The usual flow:
+
+1. Grep the log for the first NaN step → get `N`.
+2. Identify the last clean checkpoint at `step_M` where `M < N`.
+3. Restart with `--checkpoint.load_path=checkpoints/<run>/step_M` and
+   a lower LR or a reduced spike-prone feature (e.g., turn off FP8 if
+   you were testing it).
+
+### Configuration caveat
+
+`action` and `max_consecutive` are **hardcoded** in
+`scripts/train.py:85` — there's no TOML knob. If you need
+`action="raise"` (fail fast) or `action="skip"` without the warning,
+edit the source. See
+[Resilience § NaN detection § Limitations](../resilience/nan-detection.md#limitations).
+
+### Related signals
+
+Check `train/grad_norm` in your metrics dashboard before the NaN — a
+visible spike (orders of magnitude above baseline) usually precedes it.
+If you see one, that's the real signal; the NaN is a consequence.
+
+## Shape 2: memory creeps toward OOM
+
+**Symptom:** step 1 uses `X` GB, step 1000 uses `X + Y` GB, step 3000
+OOMs.
+
+**What the codebase does:** `MetricsTracker` calls
+`get_memory_stats()` every step and logs `gpu/allocated_gb`,
+`gpu/peak_gb`, `gpu/reserved_gb`, `gpu/mem_utilization` to WandB /
+TensorBoard. Start there — plot `peak_gb` over step count.
+
+```
+[step   50] gpu/peak_gb=78.4 | ...
+[step  100] gpu/peak_gb=78.4 | ...
+[step  500] gpu/peak_gb=78.4 | ...
+[step 1000] gpu/peak_gb=78.6 | ...     ← +200 MB
+[step 2000] gpu/peak_gb=79.1 | ...     ← +500 MB over another 1k steps
+```
+
+A flat curve is healthy; a staircase is a leak, and a steady slope is
+fragmentation. For the staircase pattern, a snapshot is the fastest
+way to identify the source:
+
+```python
+# In your training script, before `trainer.train()` or equivalent:
+from kempnerforge.metrics.memory import DeviceMemoryMonitor
+
+monitor = DeviceMemoryMonitor(
+    device=torch.cuda.current_device(),
+    snapshot_step=2000,
+    snapshot_dir="memory_snapshots",
+)
+
+# Then after each step:
+monitor.report(step)
+```
+
+At step 2000 it dumps a pickle you upload to
+[pytorch.org/memory_viz](https://pytorch.org/memory_viz) for an
+interactive flamegraph — stack traces to allocation sites, so leaks
+reveal themselves. See
+[Metrics § Memory snapshot export](../metrics-and-profiling/memory-monitor.md#memory-snapshot-export)
+for the file layout.
+
+### Fragmentation vs genuine leaks
+
+If `reserved_gb - allocated_gb` grows over time, that's
+fragmentation — PyTorch's allocator holds memory even after tensors
+are freed. Usually fixable via:
+
+```bash
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+```
+
+This is the same flag the 32-GPU MoE benchmark needs — see
+[Scaling guide § Mis-sized activation memory](scaling-guide.md#mis-sized-activation-memory).
+
+## Shape 3: a rank hangs without error
+
+**Symptom:** logs stop advancing, no Python traceback, `py-spy
+dump --pid <rank0>` shows threads blocked in NCCL.
+
+**What the codebase does:** enable the periodic NCCL liveness probe
+in your TOML:
+
+```toml
+[train]
+nccl_health_check_interval = 100   # all-reduce sanity every 100 steps
+```
+
+Every 100 steps, every rank contributes a tensor of ones to a tiny
+all-reduce. If the sum ≠ `world_size`, the training loop logs
+`"NCCL health check failed at step <N> — stopping"` and breaks.
+See
+[Resilience § NCCL liveness](../resilience/nccl-liveness.md#periodic-check-in-the-loop).
+
+The check catches **partial-participation bugs**, not true deadlocks —
+the all-reduce itself hangs forever if one rank is genuinely dead
+(which is why SLURM's `NCCL_TIMEOUT` is load-bearing). Combine both:
+
+```bash
+# In the SLURM script
+export NCCL_TIMEOUT=1800   # 30 min — kills the job if NCCL hangs
+```
+
+### When it fires
+
+Symptoms of a live check failure (sum mismatch): one rank returns a
+different result, usually because it went through an unexpected code
+branch (e.g., skipped a step due to NaN while others didn't). Hunt
+for rank-specific behavior in the training loop.
+
+## Shape 4: throughput silently halves
+
+**Symptom:** steady-state `tok/s` drops, MFU drops, no error, loss
+curve looks fine.
+
+**What the codebase does:** start by reading
+`train/step_time_sec` from the metrics backend. If it jumps from,
+say, 0.5 s/step to 1.0 s/step and stays there, fire up the profiler:
+
+```toml
+[profiling]
+enable     = true
+start_step = 100        # wait for steady state
+end_step   = 108        # 8 active steps (warmup + 7 recorded)
+trace_dir  = "profiler_traces/"
+```
+
+Run for enough steps to cross `end_step`. When the profiler stops,
+rank 0 prints a summary and writes `summary.md` into `trace_dir` with
+a kernel breakdown:
+
+```
+| Category              | Time (s) |    % |
+|-----------------------|---------:|-----:|
+| MatMul/GEMM           |    1.245 | 62.4 |
+| Communication (NCCL)  |    0.312 | 15.6 |
+| Memory ops            |    0.186 |  9.3 |
+| Other kernels         |    0.253 | 12.7 |
+| **Total**             |    1.996 |100.0 |
+```
+
+[`print_profiler_summary`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/profiling/profiler.py)
+does the classification via substring match on kernel names (see
+`_analyze_profiler` for the GEMM / NCCL / memcpy patterns). See
+[Metrics § Profiler](../metrics-and-profiling/profiler.md) for what
+the table columns mean and how efficiency is computed.
+
+Typical findings:
+
+- **Communication (NCCL) share climbs** → network degraded (check IB
+  counters on affected nodes), or you changed parallelism and
+  collectives are now inter-node instead of intra-node.
+- **Memory ops share climbs** → host-device copies added somewhere (a
+  misplaced `.cpu()`, a fresh `numpy` conversion in the data loader).
+- **Other kernels share climbs** → framework overhead grew, often due
+  to a new Python loop over tensors.
+
+Chrome traces land in `trace_dir/` as JSON — open in
+`chrome://tracing` or `ui.perfetto.dev` for a timeline view. Look for
+gaps between kernels (exposed latency) and per-step regressions.
+
+## Shape 5: loss looks fine, downstream eval is worse
+
+**Symptom:** training loss curve matches a good run, but
+[`scripts/eval_harness.py`](run-evaluation.md#path-3-lm-eval-harness-for-downstream-tasks)
+reports lower HellaSwag / MMLU than expected.
+
+This is rarely a tool problem — it's a data or training-config
+issue. Quick checks:
+
+1. **Data mixing drift.** If you changed `[[data.datasets]]` weights
+   between runs, loss on the mixed distribution can match while
+   downstream behavior changes. Re-run the lost-run eval on the
+   previous config's checkpoint at the same step — if downstream
+   matches, data mix is the cause.
+2. **LR / schedule change.** A lower peak LR often gives lower loss
+   (training distribution is easier) but worse downstream (less
+   exploration). Check `[scheduler]` and `[optimizer.lr]` against the
+   reference run.
+3. **Tokenizer / vocab mismatch.** If `model.vocab_size` silently
+   changed between runs (wrong metadata.yaml, wrong
+   `--model.vocab_size`), training loss is still sensible but
+   generation and benchmarks rate as nonsense. See
+   [Prepare tokenized data](prepare-tokenized-data.md) § "Validate
+   with `prepare_data.py`".
+4. **Bias in sampling.** If you're comparing `--temperature 0`
+   (greedy) on lm-eval-harness to a checkpoint that trained with
+   different temperature scaling or repetition penalty assumptions —
+   the benchmark number is determined by decode settings you may not
+   be matching.
+
+No dedicated tool will catch #1–4; careful bookkeeping will.
+
+## Chaining the tools
+
+A debugging session usually follows this sequence:
+
+```
+Symptom
+   │
+   ├─ Loss NaN      → train/grad_norm + last-good checkpoint → restart lower LR
+   ├─ OOM           → peak_gb trace → snapshot → memory_viz
+   ├─ Rank hang     → NCCL liveness + NCCL_TIMEOUT → inspect rank-specific code
+   ├─ Slowdown      → step_time_sec → torch.profiler → kernel summary
+   └─ Bad eval      → re-run eval on baseline → audit data / LR / tokenizer
+```
+
+Most of these leave a trace in metrics; start there and narrow down.
+Reaching for the profiler or a memory snapshot without a symptom wastes
+time — the profiler adds startup overhead, and a snapshot dumps several
+hundred MB per rank.
+
+## See also
+
+- [Resilience § NaN detection](../resilience/nan-detection.md) —
+  detector internals and the three `action` modes.
+- [Resilience § NCCL liveness](../resilience/nccl-liveness.md) —
+  what the periodic probe checks and why `NCCL_TIMEOUT` matters.
+- [Resilience § GPU health](../resilience/gpu-health.md) — on-demand
+  compute/memory probe for a specific device.
+- [Metrics § Memory monitor](../metrics-and-profiling/memory-monitor.md)
+  — `DeviceMemoryMonitor` and snapshot export.
+- [Metrics § Profiler](../metrics-and-profiling/profiler.md) —
+  `torch.profiler` schedule and kernel classification.
+- [Metrics § Metrics tracker](../metrics-and-profiling/metrics-tracker.md)
+  — the per-step metrics that feed the workflows above.
+- [Scaling guide § Common pitfalls](scaling-guide.md#common-pitfalls)
+  — regression modes specific to parallelism changes.

--- a/docs/how-to/end-to-end-training-run.md
+++ b/docs/how-to/end-to-end-training-run.md
@@ -1,0 +1,212 @@
+# End-to-end training run
+
+This is the flagship how-to — the one that takes you from a clean
+checkout to a trained checkpoint and a sampled completion, using
+only what's in the repo. If you can finish this page, every other
+how-to is an expansion.
+
+Runnable plan:
+
+1. Install the environment.
+2. Cache the tokenizer.
+3. Launch a 1-GPU run to confirm the loop works.
+4. Scale to 4 GPUs on one node via `torchrun`.
+5. Kill the job; auto-resume from the last checkpoint.
+6. Generate text from the checkpoint.
+
+The reference config we use throughout is
+[`configs/train/hf_wikitext.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/hf_wikitext.toml)
+— a small (~40M-param) model that streams Wikitext-103 from
+HuggingFace. No dataset setup required.
+
+## 1. Install
+
+```bash
+git clone https://github.com/KempnerInstitute/KempnerForge.git
+cd KempnerForge
+uv sync           # creates .venv and installs all deps
+```
+
+`uv sync` installs PyTorch, transformers, datasets, and the rest. If
+`uv` isn't on the machine, install it:
+`curl -LsSf https://astral.sh/uv/install.sh | sh`.
+
+## 2. Cache the tokenizer
+
+The reference config uses the GPT-2 tokenizer. Compute nodes
+typically don't have internet access, so pre-cache it on the login
+node:
+
+```bash
+python -c "from transformers import AutoTokenizer; AutoTokenizer.from_pretrained('gpt2')"
+```
+
+Cached under `~/.cache/huggingface/`. See
+[Prepare tokenized data § Cache the tokenizer first](prepare-tokenized-data.md#cache-the-tokenizer-first).
+
+## 3. Single-GPU sanity check
+
+```bash
+uv run python scripts/train.py configs/train/hf_wikitext.toml
+```
+
+What this does:
+
+- `load_config` reads the TOML into a `JobConfig`.
+- `init_distributed` initializes process group (single-rank group on
+  1 GPU — still uses the distributed path).
+- `build_parallel_model` constructs the `Transformer` and applies
+  FSDP2 (`dp_shard = -1` auto-resolves to 1 on one rank).
+- The training loop streams Wikitext-103, computes cross-entropy,
+  steps AdamW with a cosine schedule, and checkpoints to
+  `checkpoints/hf_wikitext/step_N` every 100 steps.
+
+Expected output (first few lines):
+
+```
+[rank 0] step 10   loss 10.42  lr 6.0e-05  tok/s 8,420  mfu 2.1%
+[rank 0] step 20   loss 9.84   lr 1.2e-04  tok/s 8,510  mfu 2.1%
+...
+```
+
+Let it run ~50 steps (loss should drop below 10), then `Ctrl+C`.
+
+```{note}
+MFU is low (~2%) because this is a 40M-param model on a single H100
+— most of the runtime is framework + data loading, not matmul. MFU
+becomes meaningful at 7B+ scale. See
+[Scaling guide](scaling-guide.md).
+```
+
+## 4. Four-GPU run on one node
+
+```bash
+uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/hf_wikitext.toml
+```
+
+`torchrun` spawns 4 processes, each binding one GPU. The config's
+`dp_shard = -1` resolves to 4 — FSDP2 shards parameters + gradients
++ optimizer state across the 4 GPUs. Same loss curve, ~3.5× the
+tokens/sec (assumes 4× H100, bf16, Wikitext streaming fast enough to
+not bottleneck).
+
+Watch the log: every rank reports per-step metrics, but only rank 0
+writes checkpoints. By default, data appears in `checkpoints/hf_wikitext/`
+under the current working directory.
+
+## 5. Kill and auto-resume
+
+KempnerForge catches **SIGTERM** and **SIGUSR1** (the signals SLURM
+sends on preemption / timeout) and writes an emergency checkpoint
+before exiting. `Ctrl+C` sends SIGINT, which is **not** intercepted
+— the process dies immediately and the last durable state is
+whatever the interval-100 checkpoint saved.
+
+To exercise the emergency path manually:
+
+```bash
+# In another shell, find the rank-0 pid:
+kill -TERM <pid>
+```
+
+Expected rank-0 log:
+
+```
+Shutdown requested at step 247 — saving emergency checkpoint
+Emergency checkpoint written to checkpoints/hf_wikitext/step_247
+```
+
+If you just hit `Ctrl+C`, you'll resume from the last periodic save
+instead (e.g., `step_200`), which is usually fine for dev work.
+
+Relaunch the same command:
+
+```bash
+uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/hf_wikitext.toml
+```
+
+[`CheckpointManager`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/checkpoint/manager.py)
+follows the `checkpoints/hf_wikitext/latest` symlink (updated on
+every save) and falls back to the highest `step_N` directory if the
+symlink is missing. Training picks up at the next step with model,
+optimizer, scheduler, dataloader, and RNG state restored.
+
+The dataloader resumes from the exact sample via
+`StatefulDataLoader.load_state_dict` + `DistributedSampler.set_skip`
+(pre-tokenized path) or `_skip_rank_docs` (HF-streaming path), so no
+sample is replayed and none is skipped. See
+[Checkpointing § Auto-resume](../checkpointing/auto-resume.md) and
+[Resilience § SLURM preemption](../resilience/slurm-preemption.md).
+
+## 6. Generate from the checkpoint
+
+Once the loss is reasonable (`< 7` on Wikitext), try generation:
+
+```bash
+uv run python scripts/generate.py configs/train/hf_wikitext.toml \
+    --checkpoint.load_path=checkpoints/hf_wikitext/latest \
+    --data.tokenizer_path=gpt2 \
+    --prompt "The Kempner Institute" \
+    --max_tokens 64 \
+    --temperature 0.8 \
+    --top_p 0.9
+```
+
+[`scripts/generate.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/generate.py)
+is single-GPU, loads the DCP checkpoint into an un-sharded model,
+tokenizes the prompt, calls
+[`generate()`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/generate.py)
+with KV-cache, and prints the decoded output.
+
+Arguments:
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `config` (positional) | — | TOML path |
+| `--checkpoint.load_path` | — | Path to a `step_N` directory or `latest` symlink |
+| `--data.tokenizer_path` | from config | HF tokenizer ID or local path |
+| `--prompt` | `""` | Input text |
+| `--max_tokens` | `128` | Max new tokens |
+| `--temperature` | `1.0` | Sampling temperature (0 = greedy) |
+| `--top_k` | `0` | Top-k filtering (0 = off) |
+| `--top_p` | `1.0` | Nucleus threshold |
+| `--interactive` | `false` | REPL mode |
+
+For interactive exploration:
+
+```bash
+uv run python scripts/generate.py configs/train/hf_wikitext.toml \
+    --checkpoint.load_path=checkpoints/hf_wikitext/latest \
+    --data.tokenizer_path=gpt2 \
+    --interactive
+```
+
+## What you learned
+
+You ran the full pipeline: config-driven build, FSDP2 sharding,
+stateful resumption, and KV-cache generation — all on data streamed
+from the hub without a pre-tokenization step.
+
+Extensions from here:
+
+- Swap Wikitext for pre-tokenized shards → [Prepare tokenized data](prepare-tokenized-data.md).
+- Move to a bigger model and add TP / EP / PP → [Scaling guide](scaling-guide.md).
+- Launch from SLURM (single- or multi-node) → [SLURM distributed setup](slurm-distributed-setup.md).
+- Handle SLURM preemption → [Resilience § SLURM preemption](../resilience/slurm-preemption.md).
+- Go deeper on generation (KV cache, batching, samplers) → [Generate from a checkpoint](generate-from-checkpoint.md).
+- Debug NaN / OOM / hangs / slowdowns → [Debug training regressions](debug-training-regressions.md).
+- Run downstream benchmarks → [Run evaluation](run-evaluation.md).
+- Try FP8 → [Distributed § FP8](../distributed/fp8.md).
+
+## See also
+
+- [Getting started](../getting-started/index.md) — shorter install +
+  quickstart for someone who just wants `uv sync && uv run …`.
+- [Configuration overview](../configuration/index.md) — what the
+  TOML schema looks like and how CLI overrides compose.
+- [Checkpointing § Auto-resume](../checkpointing/auto-resume.md) —
+  the resumption mechanics in detail.
+- [Generation](../training/generation.md) — `generate()` internals
+  and KV-cache API.
+- [Training loop](../training/training-loop.md) — what
+  `scripts/train.py` actually does at each step.

--- a/docs/how-to/fp8-training.md
+++ b/docs/how-to/fp8-training.md
@@ -1,0 +1,197 @@
+# Turn on FP8 training
+
+FP8 trades some loss-curve noise for a throughput win on Hopper-class
+GPUs. On this codebase, enabling it is a one-line config change — the
+interesting questions are whether you *should*, how to verify it
+actually ran, and how to read the failure modes. The subsystem
+reference at
+[Distributed § FP8](../distributed/fp8.md) covers the internals; this
+page is the researcher-facing decision and workflow.
+
+## Decide whether FP8 is worth it
+
+| If… | FP8 is likely to help |
+|-----|:---------------------:|
+| You're on H100 / H200 | yes |
+| You're on A100 / V100 or older | no (falls back, no speedup) |
+| Model is dense (no MoE) or MoE with heavy attention | yes |
+| Model is tiny (dim < ~1024) | marginal |
+| You need TP (`distributed.tp > 1`) | **blocked** — see below |
+| You need the absolute-best eval loss at small step counts | maybe not — see [Accuracy tradeoff](#accuracy-tradeoff) |
+
+Expected gain on Hopper: the FSDP2 all-gather moves half the bytes,
+and matmuls run on fourth-gen tensor cores instead of bf16 tensor
+cores. Exact MFU numbers are workload-dependent; consult
+[Reference § Benchmarks](../reference/benchmarks.md#mfu-scaling-dense)
+for measured values.
+
+## Turn it on
+
+One field in `[train]`:
+
+```toml
+[train]
+mixed_precision = "fp8"
+```
+
+That's the whole surface. `scripts/train.py` picks it up via
+[`TrainConfig.is_fp8`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/training.py),
+`build_parallel_model` calls `apply_float8(model)` after TP/EP and
+before AC/FSDP2, and FSDP2 picks bf16 master weights (FP8 is a
+compute dtype only). No per-layer knobs.
+
+### Reference config
+
+[`configs/train/7b_16gpu_fp8.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_fp8.toml)
+is a production-ready 7B Llama-3 recipe on 16 H100s:
+
+```toml
+[train]
+mixed_precision = "fp8"
+batch_size = 8                      # larger M-dim → better TC saturation
+grad_accum_steps = 2                # keep effective batch matched
+activation_checkpointing = "full"   # full AC; selective OOMs at bs=8
+compile_model = true                # torch.compile pairs well with FP8
+
+[distributed]
+dp_shard = -1                       # FSDP over all 16 ranks
+# tp is absent → defaults to 1 (TP is not allowed with FP8)
+```
+
+The config header has the tuning rationale: doubling `batch_size` to
+saturate the M-dimension of the Float8 GEMM is what actually extracts
+the FP8 speedup, and full AC is needed at that batch size or MLP
+activations OOM.
+
+## Compatibility matrix
+
+| Pairing | Works? | Notes |
+|---------|:------:|-------|
+| FP8 + FSDP2 | yes | Primary path. `enable_fsdp_float8_all_gather=True` is on by default. |
+| FP8 + TP | **no** | Config validation rejects this — see [`JobConfig.__post_init__`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/job.py). |
+| FP8 + EP | yes | Experts and the router are excluded from FP8 conversion; attention and dense blocks still use FP8. |
+| FP8 + `torch.compile` | yes | Recommended combination. |
+| FP8 + PP | yes | PP stages compose with FP8 the same way as bf16. |
+
+The TP block is explicit and hard:
+
+```
+FP8 + Tensor Parallelism is not yet supported (torchao Float8Linear
+does not compose with DTensor sharding). Use FP8 with FSDP only, or
+TP without FP8.
+```
+
+## Verify it's actually running
+
+FP8 failures are silent by default — a misconfigured run still trains
+in bf16 and produces sensible loss curves. Check the rank-0 log at
+startup:
+
+```
+Applied Float8 training: recipe=TENSORWISE, fsdp_float8_all_gather=True
+Optimizer groups: ...
+Model: ...
+```
+
+The `Applied Float8 training` line (from
+[`apply_float8`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/parallel.py))
+is the confirmation. If it's missing, `mixed_precision` didn't resolve
+to `"fp8"`.
+
+For a deeper check, profile one step:
+
+```toml
+[profiling]
+enable     = true
+start_step = 10
+end_step   = 12
+trace_dir  = "profiler_traces/fp8_check"
+```
+
+The summary table should list kernels whose names contain `scaled_mm`
+(the FP8 GEMM) rather than only `gemm` / `cutlass_bf16`. See
+[Debug § Shape 4](debug-training-regressions.md#shape-4-throughput-silently-halves)
+for how to read the summary.
+
+## What gets converted, what doesn't
+
+Pulled from the filter in
+[`apply_float8`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/parallel.py):
+
+- **Converted** — attention (`q/k/v/o_proj`), dense MLP
+  (`gate/up/down_proj`), final `output_head.proj`.
+- **Excluded** — MoE experts (`experts.*`, `shared_expert.*`) because
+  they use `torch._grouped_mm` and bypass `Float8Linear.forward`;
+  the MoE router because its output dim is small and not compute-bound;
+  embeddings and norms because they aren't `nn.Linear`.
+
+For an MoE model this means attention is FP8, dense-block MLPs are FP8,
+but the expert blocks run in bf16 — typically fine, because attention
+and shared experts dominate FLOPs.
+
+## Accuracy tradeoff
+
+Tensorwise FP8 has a measurable early-step loss-curve divergence from
+bf16 — usually within noise by step ~1000 but visible before. Three
+operating patterns:
+
+1. **All-FP8**. Cheapest. Accept the early-step noise. Fine for most
+   long runs.
+2. **bf16 warmup → FP8 body**. Start with `mixed_precision = "bf16"`
+   for the LR warmup phase, resume with `mixed_precision = "fp8"` for
+   the bulk of training. Not automated — you checkpoint and relaunch
+   with the new flag.
+3. **FP8 body → bf16 cooldown**. Only worth it when you need the last
+   fraction of loss improvement for a final eval.
+
+The codebase doesn't automate any of these — they're all
+checkpoint-and-relaunch patterns.
+
+## Troubleshooting
+
+**"Applied Float8 training" missing from log, training still runs.**
+`mixed_precision` is wrong. Check
+`config.train.mixed_precision == "fp8"` (not `"FP8"` or `"float8"`).
+The `Literal[...]` type in the dataclass lets only four values through.
+
+**`ValueError: FP8 + Tensor Parallelism is not yet supported`.** The
+config validator ran. Either set `distributed.tp = 1` (and let FSDP
+handle sharding) or drop `mixed_precision = "fp8"`.
+
+**`torch._scaled_mm` warning about unsupported hardware.** You're on
+a pre-Hopper GPU. FP8 falls back to bf16 matmul and you get no
+speedup — disable FP8 for this cluster.
+
+**`aten.is_pinned` DTensor error at model build.** A TP + FP8
+combination slipped past the config check. The guard in
+[`apply_float8`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/parallel.py)
+is explicit about this.
+
+**Loss diverges in the first ~50 steps.** Expected early-step noise
+is subtle; an actual divergence usually means the LR is set for
+bf16-master-weight assumptions but FP8 is amplifying gradient noise.
+Start with a smaller `lr` or a longer `scheduler.warmup_steps` and
+check `train/grad_norm` — see
+[Debug § Shape 1](debug-training-regressions.md#shape-1-loss-goes-nan).
+
+**OOM on the first FP8 step but not on bf16.** FP8 all-gather saves
+bandwidth but not memory; matmul temporaries for `_scaled_mm` are
+slightly larger than bf16 matmul. Drop `batch_size` or switch to
+`activation_checkpointing = "full"`.
+
+## See also
+
+- [Distributed § FP8](../distributed/fp8.md) — full reference on what
+  `apply_float8` does, the E4M3/E5M2 math, and master weight handling.
+- [Distributed § FSDP2 § Mixed precision policy](../distributed/fsdp2.md#mixed-precision-policy)
+  — how FSDP2 sees FP8 (as bf16 with attached scale tensors).
+- [Architecture § Parallelism order](../architecture/parallelism-order.md)
+  — why FP8 runs between EP and AC.
+- [Configuration § Validation rules](../configuration/validation-rules.md)
+  — the `FP8 + TP` check.
+- [Debug training regressions](debug-training-regressions.md) — the
+  profiler workflow to verify FP8 kernels are firing.
+- [Reference § Benchmarks](../reference/benchmarks.md) — measured MFU
+  for FP8 runs at several model sizes.
+- [`configs/train/7b_16gpu_fp8.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_fp8.toml)
+  — the reference recipe this page points at.

--- a/docs/how-to/generate-from-checkpoint.md
+++ b/docs/how-to/generate-from-checkpoint.md
@@ -1,0 +1,258 @@
+# Generate from a checkpoint
+
+A DCP checkpoint + a tokenizer + a prompt →
+[`scripts/generate.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/generate.py)
+produces text. This page covers the CLI, the underlying
+[`generate()`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/generate.py)
+call, and the KV-cache mechanics so you can build your own generation
+loops when the script isn't enough.
+
+## Quick start
+
+```bash
+uv run python scripts/generate.py configs/train/7b.toml \
+    --checkpoint.load_path=checkpoints/7b/step_50000 \
+    --data.tokenizer_path=meta-llama/Llama-2-7b-hf \
+    --prompt "Once upon a time" \
+    --max_tokens 256 \
+    --temperature 0.8 \
+    --top_p 0.9
+```
+
+```
+Model: 6738M params on cuda:0 (torch.bfloat16)
+Loaded checkpoint: checkpoints/7b/step_50000
+
+--- Prompt ---
+Once upon a time
+
+--- Generated (256 tokens) ---
+, in a small village nestled between two mountains, there lived …
+```
+
+## CLI reference
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `config` (positional) | — | TOML config (required — used for model architecture) |
+| `--checkpoint.load_path` | from config | DCP directory to load (step_N or `latest` symlink) |
+| `--data.tokenizer_path` | from config | HuggingFace hub ID or local dir |
+| `--prompt` | `""` | Input text |
+| `--max_tokens` | `128` | Max new tokens to generate |
+| `--temperature` | `1.0` | Sampling temperature (0 = greedy) |
+| `--top_k` | `0` | Top-k filtering (0 = disabled) |
+| `--top_p` | `1.0` | Nucleus sampling threshold (1.0 = disabled) |
+| `--interactive` | `false` | REPL mode — enter prompts, see output |
+| `--device` | `cuda` if available | Target device |
+| `--dtype` | `bfloat16` | Parameter dtype (also: `float32`, `float16`) |
+
+The script uses `argparse.parse_known_args()` — flags it recognizes
+(the table above) are consumed as script arguments, and everything
+else (e.g. `--checkpoint.load_path=...`, `--model.dim=...`) is fed to
+`load_config` as a config override, just like `scripts/train.py`.
+Positional `config` must come first; the script flags and config
+overrides can otherwise appear in any order.
+
+### Interactive mode
+
+```bash
+uv run python scripts/generate.py configs/train/7b.toml \
+    --checkpoint.load_path=checkpoints/7b/step_50000 \
+    --data.tokenizer_path=meta-llama/Llama-2-7b-hf \
+    --interactive
+```
+
+A small REPL loop: enter a prompt, see generation, loop. Each call
+re-runs prefill from scratch — there's no conversation state between
+prompts. Handy for qualitative sanity checks while training is
+ongoing.
+
+## How it loads a DCP checkpoint without `dist.init_process_group`
+
+DCP files are multi-rank by default, but
+`torch.distributed.checkpoint.load` supports single-process loading
+without initializing a process group:
+
+```python
+# scripts/generate.py
+state_dict = {"model": model.state_dict()}
+dcp.load(state_dict, checkpoint_id=str(ckpt_path))
+model.load_state_dict(state_dict["model"])
+```
+
+This is why `generate.py` is single-GPU even for models that were
+trained with FSDP=N and TP=M — DCP handles the resharding on the read
+side, loading the full unsharded model onto one device. For a 70B
+model that means ~140 GB of bf16 parameters — run on a node with
+enough memory, or use FSDP via a multi-GPU loader (not covered by
+`scripts/generate.py`).
+
+## The `generate()` function
+
+```python
+from kempnerforge.model.generate import generate
+
+output_ids = generate(
+    model,
+    prompt_tokens,      # (batch, prompt_len)
+    max_new_tokens,
+    *,
+    temperature=1.0,
+    top_k=0,
+    top_p=1.0,
+    eos_token_id=None,  # stop when all batch entries emit this token
+)                       # returns (batch, prompt_len + generated_len)
+```
+
+Called with `@torch.no_grad()`, flips the model to `.eval()`, restores
+training mode on exit. The function does **not** call
+`dist.init_process_group` — it works on raw tensors, so you can use it
+both single-GPU (as `scripts/generate.py` does) and from within a
+training script after FSDP summons parameters (more complex).
+
+### Sampling details
+
+Temperature → top-k → top-p → multinomial. All in
+[`sample()`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/generate.py):
+
+```python
+if temperature == 0:
+    return logits.argmax(dim=-1)           # greedy
+logits = logits / temperature
+
+if top_k > 0:
+    threshold = logits.topk(top_k, dim=-1).values[:, -1:]
+    logits = logits.where(logits >= threshold, -inf)
+
+if top_p < 1.0:
+    sorted_logits, idx = logits.sort(dim=-1, descending=True)
+    probs = sorted_logits.softmax(dim=-1)
+    mask = (probs.cumsum(dim=-1) - probs) >= top_p
+    sorted_logits[mask] = -inf
+    logits = scatter back to original order
+
+probs = logits.softmax(dim=-1)
+return torch.multinomial(probs, 1).squeeze(-1)
+```
+
+`sample()` is exported — useful if you want to plug your own decoding
+loop with a custom sampler (contrastive, typical, etc.) while keeping
+the model + KV-cache wiring.
+
+## KV cache
+
+Without a cache, generating `N` tokens re-runs attention over the
+growing sequence `1, 2, …, N` times — O(N²) work for a problem that
+should be O(N). The
+[`KVCache`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/attention.py)
+stores per-layer keys and values so each new token only needs one
+attention pass over the cached history.
+
+### Layout
+
+```python
+KVCache(
+    batch_size,
+    max_seq_len,   # pre-allocated up to this length
+    n_kv_heads,    # GQA key heads (not query heads)
+    head_dim,
+    dtype,
+    device,
+)
+```
+
+Two pre-allocated tensors of shape
+`(batch, n_kv_heads, max_seq_len, head_dim)`. Keys are stored **after**
+RoPE but **before** GQA expansion — this saves memory by
+`n_heads / n_kv_heads` (4× for the default Llama-style config).
+
+### Update
+
+```python
+def update(k_new, v_new) -> (k_all, v_all):
+    end = self.seq_len + k_new.shape[2]
+    self.k[:, :, self.seq_len:end] = k_new
+    self.v[:, :, self.seq_len:end] = v_new
+    self.seq_len = end
+    return self.k[:, :, :end], self.v[:, :, :end]
+```
+
+`update` returns slices, not copies — the returned tensors alias
+into the pre-allocated buffer. Safe inside `@torch.no_grad()`.
+
+### Prefill vs decode
+
+`generate()` allocates one `KVCache` per transformer layer, then:
+
+1. **Prefill**: one forward pass with the full prompt. Each layer's
+   attention calls `kv_cache.update(k, v)` with the prompt's K/V
+   tensors, filling positions `[0, prompt_len)`.
+2. **Decode loop**: `max_new_tokens` steps, each a forward pass on
+   a single-token input. Attention's `k_new`, `v_new` are shape
+   `(batch, n_kv_heads, 1, head_dim)`; `update` appends at position
+   `seq_len` and advances it.
+
+If `prompt_len + max_new_tokens > model.config.max_seq_len` the call
+raises — the cache is pre-allocated up to that bound.
+
+## Batch generation from Python
+
+`scripts/generate.py` tokenizes one prompt. For many prompts at
+once, call `generate()` directly:
+
+```python
+import torch
+from transformers import AutoTokenizer
+from kempnerforge.model.generate import generate
+
+tokenizer = AutoTokenizer.from_pretrained("gpt2")
+prompts = ["Hello, my name is", "The best way to learn Python is"]
+
+# Pad to the same length (left-pad if you want all prompts to end
+# together; right-pad is fine if you just want them to start together)
+tokenizer.pad_token = tokenizer.eos_token
+batch = tokenizer(prompts, return_tensors="pt", padding=True).input_ids
+batch = batch.to(device)
+
+output = generate(model, batch, max_new_tokens=50, temperature=0.8, top_p=0.9)
+# output: (batch=2, prompt_len + 50)
+
+for row in output:
+    print(tokenizer.decode(row, skip_special_tokens=True))
+```
+
+Two caveats:
+
+- **Left-pad or right-pad consistently**. The KV cache assumes
+  position 0 is the start of every sequence in the batch, so if you
+  right-pad, the generation will treat pad tokens as a real prefix.
+  For Llama-style tokenizers this is usually fine (pad is excluded
+  from attention via the mask), but for greedy comparison runs,
+  left-pad to line up end positions.
+- **`eos_token_id` stops the whole batch when *all* sequences
+  emit EOS.** Individual sequences past EOS continue generating garbage
+  until every batch row hits it; filter post-hoc.
+
+## What `scripts/generate.py` doesn't do
+
+- **No beam search** — only sampling or argmax-greedy.
+- **No distributed inference** — single-GPU only. For 70B+ you need
+  to write your own FSDP-wrapped inference loop.
+- **No cache reuse across calls in interactive mode** — each prompt
+  re-prefills from scratch.
+- **No streaming output** — it generates all `max_new_tokens` before
+  printing. For streaming, loop `sample()` yourself and print after
+  each token.
+
+## See also
+
+- [Training § Generation](../training/generation.md) — the
+  `generate()` internals reference.
+- [Training § Generation § KV cache](../training/generation.md) —
+  `KVCache` class docs.
+- [End-to-end training run § Generate from the checkpoint](end-to-end-training-run.md#6-generate-from-the-checkpoint)
+  — the quickstart version of this page.
+- [Checkpointing § DCP model format](../checkpointing/dcp-model.md) —
+  why single-process DCP load works without `init_process_group`.
+- [`scripts/generate.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/generate.py)
+  — the script this page documents.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,72 @@
+# How-to Guides
+
+End-to-end researcher workflows. Each guide is a single coherent narrative
+with runnable code (or a link to a notebook, config, or script that runs it)
+— the reason most researchers come to the docs in the first place.
+
+## Core workflow
+
+- [Build a model](build-a-model.md) — compose a `Transformer` from
+  components; swap MLP for MoE; toggle QK-norm; register a new block
+  variant.
+- [Prepare tokenized data](prepare-tokenized-data.md) — two supported
+  paths: pre-tokenize offline (e.g. with `tatm`) and validate with
+  `scripts/prepare_data.py`, or stream from HuggingFace.
+- [End-to-end training run](end-to-end-training-run.md) — the flagship
+  walkthrough: tokenize → write a config → launch 1 GPU → launch 4 GPUs →
+  resume → generate.
+
+## Scale up
+
+- [Scaling guide](scaling-guide.md) — 1 → 32 GPU journey, when to add
+  TP / FSDP / EP / PP, batch-size scaling, MFU goals, common pitfalls.
+- [SLURM distributed setup](slurm-distributed-setup.md) — single-node →
+  multi-node, InfiniBand, NCCL env, preemption, auto-resume.
+
+## Operations
+
+- [Run evaluation](run-evaluation.md) — `run_eval()` during training,
+  standalone `scripts/eval.py`, `scripts/eval_harness.py` for
+  lm-eval-harness.
+- [Generate from checkpoint](generate-from-checkpoint.md) — load a DCP
+  checkpoint, call `generate()` with temperature / top-k / top-p,
+  interact with `KVCache`.
+- [Debug training regressions](debug-training-regressions.md) — NaN
+  detector, profiler, memory monitor, health checks, five failure
+  shapes and how to read them.
+
+## Research knobs
+
+- [Compare optimizers](compare-optimizers.md) — AdamW vs Muon vs Lion
+  vs Schedule-Free AdamW, LR conventions, fair-comparison protocol.
+- [Mix datasets and anneal data weights](data-mixing-annealing.md) —
+  weighted mixtures, temperature, phase transitions, LR scale on phase
+  boundaries.
+- [Turn on FP8 training](fp8-training.md) — E4M3 / E5M2, bf16 master
+  weights, FSDP2 float8 all-gather, exclusion rules, when FP8 doesn't
+  help.
+- [MoE experiments](moe-experiments.md) — router choice, aux loss
+  tuning, hot/cold expert diagnosis, when to turn on EP, shared
+  experts.
+- [Extract activations for interpretability](mechanistic-interpretability.md)
+  — `ActivationStore`, `extract_representations()`, save to `.npz`,
+  feed to probing / CKA / SVCCA.
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+build-a-model
+prepare-tokenized-data
+end-to-end-training-run
+scaling-guide
+slurm-distributed-setup
+run-evaluation
+generate-from-checkpoint
+debug-training-regressions
+compare-optimizers
+data-mixing-annealing
+fp8-training
+moe-experiments
+mechanistic-interpretability
+```

--- a/docs/how-to/mechanistic-interpretability.md
+++ b/docs/how-to/mechanistic-interpretability.md
@@ -1,0 +1,293 @@
+# Extract activations for interpretability
+
+Capture intermediate tensors from a trained checkpoint, save them to
+`.npz`, and feed them into a downstream analysis (linear probes, CKA,
+SVCCA, dictionary learning). KempnerForge ships the extraction plumbing
+in [`kempnerforge/model/hooks.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/hooks.py);
+the analysis itself is left to whatever external tooling you prefer.
+
+This page covers the three entry points — `ActivationStore`,
+`extract_representations`, and `save_activations` — and the workflow
+around them.
+
+## The three APIs
+
+| API | When to use |
+|-----|-------------|
+| [`ActivationStore`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/hooks.py) | You drive the forward passes yourself (custom prompts, interactive exploration, per-sample inspection). |
+| [`extract_representations()`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/hooks.py) | You have a `Dataset` and want one big tensor per layer across N samples. |
+| [`save_activations()`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/hooks.py) | Persist the result to `.npz` so analysis runs out-of-process. |
+
+`extract_representations` is built on top of `ActivationStore`. If the
+built-in loop doesn't match your needs (e.g., you want per-sample
+activations keyed by prompt ID, or you need to batch across different
+model states), use `ActivationStore` directly.
+
+## Pick the layers
+
+Module FQNs use `nn.ModuleDict` keys — index into
+[`Transformer.layers`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/transformer.py)
+with a string key, then into submodules:
+
+```
+layers.0.attention          # attention output (pre-residual)
+layers.0.mlp                # MLP output (pre-residual)
+layers.0.attention_norm     # pre-attention RMSNorm output
+layers.0                    # full block output (post-residual)
+layers.5.mlp                # e.g. layer 5's MLP output
+norm                        # final RMSNorm before output head
+output_head                 # lm head logits (batch, seq, vocab)
+token_embedding             # input embedding (batch, seq, dim)
+```
+
+Confirm what's actually there for your checkpoint by dumping the
+named modules:
+
+```python
+for name, _ in model.named_modules():
+    print(name)
+```
+
+A 7B Llama-3 has `n_layers = 32`, so you get `layers.0` through
+`layers.31`. The block's substructure is `attention_norm`, `attention`,
+`mlp_norm`, `mlp`.
+
+## Quick path: dataset in, `.npz` out
+
+```python
+from pathlib import Path
+
+import torch
+import torch.distributed.checkpoint as dcp
+from torch.utils.data import Subset
+
+from kempnerforge.config.loader import load_config
+from kempnerforge.config.registry import registry
+from kempnerforge.data.dataset import MemoryMappedDataset
+from kempnerforge.model.hooks import extract_representations, save_activations
+
+device = torch.device("cuda")
+dtype = torch.bfloat16
+config = load_config("configs/train/7b.toml")
+
+# Build model and load a DCP checkpoint — same pattern scripts/generate.py uses.
+model_builder = registry.get_model(config.model.model_type)
+model = model_builder(config.model).to(device=device, dtype=dtype)
+
+ckpt_path = Path("checkpoints/7b/step_50000")
+state_dict = {"model": model.state_dict()}
+dcp.load(state_dict, checkpoint_id=str(ckpt_path))
+model.load_state_dict(state_dict["model"])
+
+dataset = MemoryMappedDataset(
+    data_dir=config.data.dataset_path,
+    file_pattern=config.data.file_pattern,
+    seq_len=config.train.seq_len,
+)
+subset = Subset(dataset, list(range(2048)))   # bound the sample count
+
+acts = extract_representations(
+    model=model,
+    dataset=subset,
+    layers=["layers.0.mlp", "layers.15.mlp", "layers.31.mlp"],
+    device=device,
+    batch_size=16,
+    max_samples=2048,
+)
+
+# acts["layers.15.mlp"] has shape (2048, seq_len, dim) on CPU.
+# Cast to float32 first if the model ran in bf16 — see dtype caveat below.
+save_activations({k: v.float() for k, v in acts.items()}, "acts/7b_step50k_mlp.npz")
+```
+
+`extract_representations` does the right thing automatically: sets
+`eval()` mode, runs under `torch.no_grad()`, captures to CPU per batch,
+and restores the original training flag on exit. The `.npz` is a single
+file indexed by layer name, loadable from any numpy-aware downstream
+tool.
+
+Replace `MemoryMappedDataset` with a `HuggingFaceDataset` if you want
+streaming — any map-style `Dataset` that returns `{"input_ids": ...}`
+works.
+
+## Fine-grained: `ActivationStore` directly
+
+When you need interactive control — custom prompts, inspection between
+passes, or state that doesn't fit the dataset model — drive it yourself:
+
+```python
+from kempnerforge.model.hooks import ActivationStore
+
+store = ActivationStore(
+    model,
+    layers=["layers.0.attention", "layers.15.mlp", "norm"],
+)
+store.enable()
+
+with torch.no_grad():
+    prompt_a = tokenizer.encode("The quick brown fox", return_tensors="pt").to(device)
+    model(prompt_a)
+    act_a = {name: store.get(name).clone() for name in store.layer_names}
+
+    store.clear()
+    prompt_b = tokenizer.encode("The lazy dog", return_tensors="pt").to(device)
+    model(prompt_b)
+    act_b = {name: store.get(name).clone() for name in store.layer_names}
+
+store.disable()
+```
+
+Four rules to remember:
+
+- `enable()` / `disable()` register and remove the forward hooks. The
+  class also removes hooks from `__del__`, but relying on GC is fragile
+  — always disable explicitly.
+- `get(name)` returns the **last** captured activation for that layer.
+  Every new forward pass overwrites it. Call `clone()` if you need to
+  keep it across passes.
+- `clear()` empties the captured dict but keeps hooks registered.
+- Captured tensors are already on CPU (the hook calls
+  `output.detach().cpu()`). You can move them back with `.to(device)`
+  for in-place analysis without needing `.clone()`.
+
+### Tuple outputs
+
+A handful of modules return `(output, aux)` tuples instead of a single
+tensor. The hook handles this — it captures `output[0]`. If a module
+you're targeting returns something odder (a `dataclass`, a `dict`, a
+nested tuple), the store silently captures nothing. Verify with:
+
+```python
+store.enable()
+model(prompt)
+assert all(store.get(n) is not None for n in store.layer_names), \
+    "Some layer's forward returns a non-tensor — wrap it or target a child module."
+```
+
+## Performance and memory
+
+Activation extraction is expensive. A 7B model at `seq_len=4096`,
+`dim=4096`, batch 16, float32, one layer's output = `16 × 4096 × 4096 ×
+4 B = 1 GB`. Across 32 layers for 2 k samples, you're at
+256 GB — well beyond host RAM. Keep the capture budget bounded:
+
+- **Pick ≤ 3–5 layers.** Full-network sweeps are rarely the right first
+  experiment. Start with early / middle / late, expand from there.
+- **Cap `max_samples`.** A few thousand samples is enough for CKA or
+  probe training; tens of thousands is research-grade.
+- **Store as bf16 or float16 after capture** if you can — the hooks
+  capture whatever dtype the forward produces, which is
+  `bf16` during a normal `eval()` on a bf16-compiled model. See
+  dtype caveat below.
+- **Subsample the sequence dimension.** If you only care about the
+  final token, slice `acts[name][:, -1]` before saving.
+
+The CPU transfer is synchronous per batch inside the hook, so there's
+some overhead vs a hookless eval run — budget for ~1.5× eval wallclock.
+
+### Dtype caveat for `.npz`
+
+`save_activations` calls `v.numpy()`, which fails on `torch.bfloat16`
+(numpy has no bf16). If your model runs in bf16, cast before saving:
+
+```python
+acts_fp32 = {k: v.float() for k, v in acts.items()}
+save_activations(acts_fp32, "acts/…npz")
+```
+
+Or save to `.pt` directly with `torch.save(acts, "acts/…pt")` if you
+want to preserve the original dtype.
+
+## Load activations for analysis
+
+```python
+import numpy as np
+
+loaded = np.load("acts/7b_step50k_mlp.npz")
+print(list(loaded.keys()))            # ['layers.0.mlp', 'layers.15.mlp', ...]
+x = loaded["layers.15.mlp"]           # ndarray, shape (N, seq_len, dim)
+```
+
+From here, standard analysis is out-of-scope for this repo — but
+common next steps:
+
+- **Linear probing.** Flatten `(N, seq, dim) → (N*seq, dim)`, fit an
+  `sklearn` logistic regression against labels to measure how much of
+  a property is decodable from that layer.
+- **CKA / SVCCA.** Compare two sets of activations (e.g., same inputs
+  across a fine-tune vs base model) to quantify representational
+  similarity per layer. External libraries like
+  [`anatome`](https://github.com/moskomule/anatome) consume `.npz`
+  directly.
+- **Sparse autoencoders / dictionary learning.** Feed MLP or residual
+  stream activations into an SAE training run; the `.npz` is a
+  drop-in substitute for forwarding the model during SAE training.
+
+## Limitations
+
+**Output only.** The hook uses `register_forward_hook`, which captures
+a module's *output*. You cannot:
+
+- Capture attention weights (they're internal to SDPA; not exposed as
+  a module output). You'd need to rewrite
+  [`Attention.forward`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/attention.py)
+  to return them, or swap SDPA for an eager implementation.
+- Capture gradients or activations during the backward pass — no
+  `register_full_backward_hook` wrapper is provided. If you need
+  gradient-based analysis (integrated gradients, attribution methods),
+  extend `ActivationStore` or use PyTorch's hooks directly.
+
+**Compiled models.** If the model was compiled with `torch.compile`,
+forward hooks still fire — PyTorch preserves module-level hook
+semantics through compilation — but the hook itself is not compiled, so
+captures add eager-mode overhead.
+
+**FSDP2 / TP.** Extraction is meant for a single-process inference-time
+load (as shown in the quick path: build the model, `dcp.load` the
+weights, run on one GPU). Running it on a fully-sharded model works
+but captures per-rank shards of each tensor, which is almost never
+what you want for analysis.
+
+## Troubleshooting
+
+**`ValueError: Module 'layers.0.attention' not found in model.`**
+The FQN is wrong. The error message prints the first 20 available
+names — check capitalization and the `layers.{idx}.` prefix (integer
+keys are stringified by `ModuleDict`).
+
+**`store.get(name)` returns `None`.** The hook never fired. Either the
+forward pass didn't reach that layer (PP rank?), or the module returned
+a non-tensor/non-tuple. See [Tuple outputs](#tuple-outputs).
+
+**`RuntimeError: can't convert bfloat16 numpy()`.** `save_activations`
+was called on a bf16 tensor. Cast with `.float()` first — see
+[Dtype caveat](#dtype-caveat-for-npz).
+
+**Host RAM OOM mid-run.** You're capturing too many layers × samples.
+Cut `max_samples`, reduce `layers`, or slice the seq dim inside a
+custom extraction loop before appending to `results`.
+
+**Memory leak across repeated `extract_representations` calls.** Make
+sure `ActivationStore.disable()` is being called. The helper does this
+in a `finally` block, but if you're using the class directly and an
+exception fires before `disable()`, the hooks stick around on the
+model and every future forward captures into the stale store. Always
+wrap manual use in `try / finally`.
+
+## See also
+
+- [Generate from checkpoint](generate-from-checkpoint.md) — the
+  `registry.get_model` + `dcp.load` pattern used above to load a
+  checkpoint into a single-GPU model.
+- [Architecture § Model](../architecture/model.md) — the layer FQN
+  layout (`layers.{i}.attention`, `layers.{i}.mlp`, etc.).
+- [Data § Datasets](../data/memory-mapped.md) — the dataset class used
+  in the quick-path example; any map-style dataset yielding
+  `{"input_ids": ...}` works.
+- [Training § Hooks](../training/hooks.md) — the unrelated
+  *training-loop* hook interface (`TrainingHook`). Activation hooks
+  observe the model's forward pass; `TrainingHook` observes the
+  training loop.
+- [`kempnerforge/model/hooks.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/hooks.py)
+  — the ~180-line module that defines `ActivationStore`,
+  `extract_representations`, and `save_activations`.

--- a/docs/how-to/moe-experiments.md
+++ b/docs/how-to/moe-experiments.md
@@ -1,0 +1,292 @@
+# MoE experiments
+
+End-to-end workflow for running Mixture-of-Experts models in
+KempnerForge: pick a router, stand up a baseline, tune the balance
+signals, diagnose hot/cold experts, turn on Expert Parallelism when
+memory demands it, and know where the composition rules stop you.
+
+This guide assumes you've read [MoE § overview](../moe/index.md). The
+subsystem pages cover the mechanics; this page covers the *when* and
+*why*.
+
+## Start from a working config
+
+Two reference configs ship with the repo. Pick whichever matches the
+scale you're iterating at:
+
+```bash
+# 1-GPU sanity check (~1 min): 4 experts, top-2, alternating MoE layers
+uv run python scripts/train.py configs/train/debug_moe.toml
+
+# 32-GPU production profile: 8 experts, top-2, EP=2 + TP=4 + FSDP=4
+sbatch --nodes=8 scripts/slurm/multinode.sh configs/train/moe_ep_32gpu.toml
+```
+
+`debug_moe.toml` uses `dim=256, n_layers=4, num_experts=4` — small
+enough to run on a laptop-scale GPU in under a minute. Use it to
+validate config changes before launching a real run.
+
+## Pick a router
+
+```toml
+[model]
+num_experts    = 8
+moe_top_k      = 2
+moe_router     = "softmax_topk"   # or "sigmoid_topk"
+```
+
+The two routers have different balance strategies — start with
+`softmax_topk` if you're just getting a baseline up:
+
+| Goal | Router | Why |
+|------|--------|-----|
+| Mixtral reproduction | `softmax_topk` | Matches original recipe, aux-loss coefficient well-studied (0.01) |
+| First MoE run, any target | `softmax_topk` | Simpler: one knob (`moe_aux_loss_weight`) and balance is visible in the loss |
+| DeepSeek-V3 reproduction | `sigmoid_topk` | Bias-based balancer, matching paper |
+| Long runs where aux-loss coefficient is brittle | `sigmoid_topk` | Balance signal doesn't perturb the main loss gradient |
+
+See [Routers](../moe/routers.md) for the mechanics.
+
+## Tune the aux loss
+
+For `softmax_topk`, the coefficient `moe_aux_loss_weight` controls how
+hard the router is pushed toward uniform:
+
+```toml
+[model]
+moe_aux_loss_weight = 0.01    # Switch/Mixtral default — keep unless you see imbalance
+```
+
+- **0.01 (default)**: the Switch / Mixtral value. Start here.
+- **0.1**: over-regularizes — experts stay uniform but can't
+  specialize. Use only if you have a severe collapse problem and want
+  to force exploration early.
+- **0.001**: under-regularizes. Balance drifts. Only use if you
+  *also* turn on capacity factor or packed experts.
+
+For `sigmoid_topk`, the coefficient has no effect by default
+(`aux_loss` is 0). It only matters if you've enabled
+`moe_sequence_aux_loss_weight > 0`; see
+[Aux loss § Sequence-level](../moe/aux-loss-and-balancing.md#sequence-level-aux-loss-sigmoid-only).
+
+## Diagnose hot/cold experts
+
+The training loop logs two MoE-specific metrics when `num_experts > 0`:
+
+```
+moe/aux_loss        # scalar aux loss this step (dispatches to WandB/TB)
+moe/expert_balance  # min/max across (layer × expert) — 1.0 = perfect uniform
+```
+
+Interpretation:
+
+- **`expert_balance > 0.5`** — fine. Balance is within 2× across
+  experts; normal for softmax router.
+- **`expert_balance < 0.2`** — one or more experts are getting ≥ 5×
+  more tokens than the quietest. Router is specializing; check if
+  intentional.
+- **`expert_balance → 0`** — an expert got zero tokens this step.
+  If it happens for one step, ignore. If it persists across many
+  logging intervals, you have a dead expert.
+
+For per-layer detail, call `Transformer.get_expert_counts()` —
+returns `dict[layer_idx → tensor(num_experts,)]`. Useful to spot
+*which* layer is collapsing:
+
+```python
+# In a custom script or notebook
+counts = model.get_expert_counts()
+for layer_idx, c in counts.items():
+    pct = (c / c.sum() * 100).tolist()
+    print(f"layer {layer_idx}: {[f'{p:.1f}%' for p in pct]}")
+```
+
+A balanced 8-expert layer prints ~12.5% per expert. A collapsing one
+prints something like `[45%, 30%, 10%, 5%, 5%, 3%, 2%, 0%]`.
+
+Recovery options, in order of what to try first:
+
+1. **Raise `moe_aux_loss_weight`** from 0.01 → 0.02 (softmax) or turn
+   on `moe_sequence_aux_loss_weight = 0.001` (sigmoid).
+2. **Set `moe_capacity_factor = 1.25`** — caps hot experts at 25%
+   above average, spilling overflow to residual.
+3. **Enable `moe_gradient_scale = true`** — normalizes per-expert
+   gradient magnitudes so cold experts aren't starved of learning
+   signal.
+4. **Restart from a checkpoint** before the collapse with a different
+   seed. Balance issues that show up after many thousand steps often
+   don't reappear with a different initialization.
+
+## When to turn on EP
+
+Expert Parallelism splits experts across ranks. It's a memory-first
+feature: flip it on when experts dominate your parameter budget, not
+to go faster.
+
+Rule of thumb — turn on EP when:
+
+1. **Expert weights > 50% of total model memory.** For a 4B-total
+   MoE with 8 experts and `moe_frequency=1`, experts are typically
+   70-80% of parameters. EP=2 cuts that in half per rank.
+2. **You're OOMing with FSDP alone.** FSDP shards by tensor, but
+   experts live as `(E, dim, hidden)` parameters (packed) or as
+   `ModuleList`. FSDP wraps them but can't split across the expert
+   dimension; EP does.
+3. **Cross-node bandwidth is adequate.** EP adds two all-to-alls per
+   MoE layer (dispatch + combine). The measured 32-GPU EP=2 profile
+   assumes InfiniBand; commodity Ethernet interconnects have not been
+   benchmarked. See
+   [Benchmarks § MoE Expert Parallelism](../reference/benchmarks.md#moe-expert-parallelism)
+   for measured numbers on H200 + IB.
+
+Constraints:
+
+- `num_experts` must be divisible by `ep` (validated in
+  `JobConfig.__post_init__`).
+- `ep > 1` with `num_experts == 0` is rejected — EP requires MoE.
+- Typical combinations: `ep=2` for 8 experts, `ep=4` for 8-16 experts,
+  `ep=8` for 32+ experts.
+
+Minimal toggle:
+
+```toml
+[distributed]
+tp       = 4    # unchanged
+ep       = 2    # new
+dp_shard = 4    # unchanged
+```
+
+See [Expert parallelism](../distributed/expert-parallelism.md) for the
+all-to-all mechanics and throughput measurements.
+
+## Capacity factor: only when EP is on
+
+`moe_capacity_factor` caps tokens per expert. It's almost always the
+wrong knob to turn on without EP:
+
+- **Without EP**: capacity factor drops tokens (residual still flows),
+  which is wasted compute with no memory upside. Leave at `0.0`.
+- **With EP**: dispatch all-to-all buffers are sized for the
+  *worst-case* token distribution. Without a cap, one rank can
+  overflow its buffer when many tokens happen to prefer its experts.
+  `moe_capacity_factor = 1.25` (Switch default) bounds the buffer
+  predictably.
+
+```toml
+[model]
+moe_capacity_factor = 1.25   # only meaningful with distributed.ep > 1
+```
+
+Start at 1.25; raise to 1.5 if you see ~5%+ token drop in metrics,
+lower to 1.0 if throughput is buffer-bound. See
+[Capacity and dispatch § When to use capacity](../moe/capacity-and-dispatch.md#when-to-use-capacity).
+
+## Packed experts: on if `num_experts ≥ 16`
+
+```toml
+[model]
+moe_packed_experts = true
+```
+
+Replaces the `ModuleList` of experts with three packed
+`(num_experts, dim, hidden)` tensors. Measured speedups from
+[`benchmarks/moe_packed`](https://github.com/KempnerInstitute/KempnerForge/blob/main/benchmarks/moe_packed/moe_packed_benchmark.md):
+
+| `num_experts` | Unpacked | Packed | Speedup |
+|:---:|---:|---:|:---:|
+| 8  | 48,521 tok/s | 50,972 tok/s | +5.1% |
+| 16 | 26,994 tok/s | 36,860 tok/s | +36.5% |
+| 64 | 1,796 tok/s  | 2,204 tok/s  | +22.7% |
+
+At 8 experts the win is marginal; at 16+ it's worth the flag. Default
+is off because the EP integration (slicing packed tensors on the
+expert axis) is newer than the unpacked path.
+
+## Composition caveats
+
+### MoE + TP: fine, but TP doesn't touch experts
+
+TP applies to attention Q/K/V/O projections. In MoE layers, expert
+weights stay **replicated** across the TP group; TP gives you no
+memory savings on experts. Use EP for that.
+
+```python
+# kempnerforge/distributed/tensor_parallel.py — _apply_block_tp (trimmed)
+if isinstance(block.mlp, MoEMLP):
+    pass  # experts replicated, TP on attention only
+```
+
+Sequence-parallel is also disabled for MoE blocks (boolean indexing in
+expert dispatch breaks `Shard(1)` DTensors).
+
+### MoE + FP8: experts stay bf16
+
+FP8 conversion is applied to dense `Linear`s only. Three classes are
+excluded: routed experts, shared expert, router gate. See
+[MoE + FP8](../moe/moe-fp8.md) for the rationale. Practical consequence:
+FP8 throughput lift on an MoE model is smaller than on a dense model
+of the same active-parameter count, because expert-weight GEMMs run
+at bf16 regardless.
+
+FP8 + EP composes fine — they're orthogonal (EP moves experts across
+ranks, FP8 wouldn't touch them anyway).
+
+FP8 + TP does **not** compose — `JobConfig.__post_init__` rejects it
+because `Float8Linear`'s DTensor strategy is incomplete. See
+[FP8 § TP incompatibility](../distributed/fp8.md#tp-incompatibility).
+
+### MoE + PP: not supported
+
+```
+MoE + Pipeline Parallelism is not supported. MoE layers use
+all-to-all communication which conflicts with the pipeline schedule.
+```
+
+Raised in `JobConfig.__post_init__` when `num_experts > 0` and
+`pp > 1`. For very large MoE runs that need PP, you'd need a
+schedule that interleaves all-to-all with pipeline microbatches —
+not in KempnerForge today.
+
+## Minimal production recipe
+
+A reasonable starting point for a 4B-total / 1.8B-active MoE on
+32 H200 GPUs:
+
+```toml
+[model]
+num_experts             = 8
+moe_top_k               = 2
+moe_router              = "softmax_topk"    # or "sigmoid_topk" for DeepSeek-V3
+moe_frequency           = 1
+moe_aux_loss_weight     = 0.01
+moe_capacity_factor     = 1.25              # because EP is on
+moe_packed_experts      = false             # 8 experts: not worth it
+moe_gradient_scale      = false             # baseline only
+
+[distributed]
+tp       = 4
+ep       = 2
+dp_shard = 4
+
+[train]
+mixed_precision = "bf16"    # fp8 has limited lift on MoE; stay bf16 for this recipe
+```
+
+Copy from [`configs/train/moe_ep_32gpu.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/moe_ep_32gpu.toml)
+if you want to run it directly.
+
+## See also
+
+- [MoE § overview](../moe/index.md) — the subsystem pages this guide
+  pulls together.
+- [Routers](../moe/routers.md) — full mechanics of the two routers.
+- [Aux loss and balancing](../moe/aux-loss-and-balancing.md) —
+  coefficient tuning and bias schedules.
+- [Capacity and dispatch](../moe/capacity-and-dispatch.md) — drop
+  policy and grouped GEMM path.
+- [Expert parallelism](../distributed/expert-parallelism.md) — EP
+  mechanics and measured throughput.
+- [Benchmarks § MoE Expert Parallelism](../reference/benchmarks.md#moe-expert-parallelism)
+  — full 32-GPU measurement table.
+- [Validation rules](../configuration/validation-rules.md) — the MoE
+  cross-section config checks.

--- a/docs/how-to/prepare-tokenized-data.md
+++ b/docs/how-to/prepare-tokenized-data.md
@@ -1,0 +1,214 @@
+# Prepare tokenized data
+
+KempnerForge reads two kinds of data: pre-tokenized binary shards on
+disk, or text streamed from HuggingFace. Pick the first for production
+runs (faster, deterministic, works offline); pick the second for
+small experiments and prototyping.
+
+## Path A: pre-tokenized shards
+
+### On-disk format
+
+[`MemoryMappedDataset`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/data/dataset.py)
+reads a directory of shard files, each a flat 1-D array of token IDs:
+
+| File extension | Encoding | Dtype rule |
+|----------------|----------|------------|
+| `*.npy` | NumPy mmap | dtype stored in header |
+| `*.bin` | Raw packed integers | inferred from size (4-byte multiple → uint32, else uint16), or from `metadata.yaml` |
+
+One file is one flat array. The dataset concatenates shards logically
+and splits the concatenated stream into non-overlapping
+`seq_len`-token samples. `uint16` works for vocab ≤ 65,535 (GPT-2 at
+50,257 and Llama-2 / Mistral at 32,000 fit; Llama-3 at 128,256 and
+Gemma at 256,000 need `uint32`).
+
+### Tokenize with your tool of choice
+
+KempnerForge does **not ship a tokenizer** and does **not depend on
+`tatm`**. Any tokenizer that outputs `.bin` or `.npy` shards works.
+The workflow `scripts/prepare_data.py` documents is the one used
+internally at the Kempner Institute:
+
+```bash
+# Step 1 — tokenize (tatm is one of many tools that writes this format)
+tatm tokenize --tokenizer meta-llama/Llama-3.2-1B \
+              --output-dir /path/to/tokenized/dataset \
+              <dataset-spec>
+
+# Step 2 — validate
+uv run python scripts/prepare_data.py /path/to/tokenized/dataset
+```
+
+Rolling your own: write flat arrays of uint16 / uint32 into `.bin` or
+`.npy` files, optionally drop a `metadata.yaml` alongside them, and
+point training at the directory.
+
+### Validate with `prepare_data.py`
+
+```bash
+uv run python scripts/prepare_data.py /path/to/tokenized/dataset
+```
+
+[`scripts/prepare_data.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/prepare_data.py)
+walks the directory, reports the shard count, size in GB, total token
+count, dtype, and (if `metadata.yaml` is present) the tokenizer name
+and vocab size. If the dtype is uint16 / uint32 the script prints the
+exact train-time flags:
+
+```
+Compatible with KempnerForge MemoryMappedDataset.
+
+Train with:
+  --data.dataset_path=/path/to/tokenized/dataset
+  --data.file_pattern='*.bin'
+  --model.vocab_size=128256
+```
+
+Wire those into your TOML:
+
+```toml
+[data]
+dataset_path = "/path/to/tokenized/dataset"
+file_pattern = "*.bin"
+
+[model]
+vocab_size = 128256   # must match what you tokenized with
+```
+
+### Optional: `metadata.yaml` (tatm format)
+
+The validator reads `metadata.yaml` if present. Schema used by
+`tatm`:
+
+```yaml
+tokenized_info:
+  dtype: uint32                              # or uint16
+  tokenizer: meta-llama/Llama-3.2-1B
+  vocab_size: 128256
+```
+
+If you generate shards yourself, dropping this file in the directory
+lets the validator print the right `vocab_size` flag and lets
+`.bin`-format shards bypass the heuristic dtype inference. It's
+optional — without it the validator still runs.
+
+## Path B: HuggingFace streaming
+
+For experiments on standard benchmark datasets, skip the
+pre-tokenize step and stream directly:
+
+```toml
+[data]
+hf_dataset_name       = "wikitext"
+hf_dataset_config     = "wikitext-103-raw-v1"
+hf_dataset_split      = "train"
+hf_dataset_text_field = "text"
+hf_streaming          = true
+tokenizer_path        = "gpt2"
+```
+
+With `hf_streaming = true`,
+[`StreamingHuggingFaceDataset`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/data/dataset.py)
+downloads and tokenizes on the fly during iteration. Each rank
+processes every `world_size`-th document, so no coordination is
+needed for distributed runs.
+
+The tokenizer path is loaded through
+`transformers.AutoTokenizer.from_pretrained`, so it can be a
+HuggingFace hub ID (`"gpt2"`, `"meta-llama/Llama-3.2-1B"`) or a
+local directory.
+
+### Cache the tokenizer first
+
+HuggingFace won't reach out to the hub from a compute node that
+doesn't have internet. Cache on the login node once:
+
+```bash
+python -c "from transformers import AutoTokenizer; AutoTokenizer.from_pretrained('gpt2')"
+```
+
+The tokenizer lands in `~/.cache/huggingface/` and the compute-node
+run picks it up transparently. See
+[`configs/train/hf_wikitext.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/hf_wikitext.toml)
+for the full HF-streaming reference config.
+
+### Non-streaming (eager) HF loading
+
+`hf_streaming = false` switches to `HuggingFaceDataset`, which
+downloads the full dataset and tokenizes in one pass before training
+starts. Faster per-step once loaded, but costs memory and startup
+time for large datasets. Use only for small benchmarks where the
+whole dataset fits.
+
+## Which path to pick
+
+| Constraint | Path |
+|------------|------|
+| Deterministic, reproducible runs | Pre-tokenized (Path A) |
+| Multi-TB datasets | Pre-tokenized (Path A) |
+| Air-gapped compute nodes | Pre-tokenized (Path A) |
+| Quick experiment on a benchmark dataset | HF streaming (Path B) |
+| Dataset bigger than disk | HF streaming (Path B) |
+| Same data across reruns, offline | Either — but pre-tokenize once |
+
+Pre-tokenizing is strictly a one-time cost for strictly better
+runtime behavior (zero-copy mmap, exact resumption, deterministic
+sample order). HF streaming is optimized for exploration.
+
+## Mixed datasets
+
+Both paths support weighted mixing via `data.datasets`:
+
+```toml
+[[data.datasets]]
+name   = "code"
+path   = "/data/tokenized/code"
+weight = 0.3
+
+[[data.datasets]]
+name      = "web"
+hf_name   = "HuggingFaceFW/fineweb"
+hf_config = "sample-10BT"
+weight    = 0.7
+```
+
+See [Data § Mixing and annealing](../data/mixing-and-annealing.md)
+for the mechanics and phase-transition recipes.
+
+## Sequence packing
+
+`pack_sequences = true` packs multiple shorter documents into one
+`seq_len` window, with a `doc_ids` tensor that prevents cross-document
+attention. Useful when document lengths are much smaller than
+`seq_len`; otherwise the default (one document per sample, truncated
+or padded) is fine.
+
+## Resumption
+
+Both paths work with
+[checkpoint auto-resume](../checkpointing/auto-resume.md), but via
+different mechanisms:
+
+- **Pre-tokenized (Path A)**: wrapped in `StatefulDataLoader`, which
+  saves and restores the sampler's position via
+  `DistributedSampler.set_skip()`. A job that preempts at step 3,500
+  picks up at sample `3500 × batch_size × world_size` without replay.
+- **HF streaming (Path B)**: wrapped in a plain `DataLoader`;
+  `StreamingHuggingFaceDataset` tracks its own position and exposes
+  `load_state_dict` / `state_dict`, which `scripts/train.py` drives
+  directly. Same guarantee — no replay, no skip — via a different
+  code path.
+
+## See also
+
+- [Data § MemoryMappedDataset](../data/memory-mapped.md) — the full
+  `MemoryMappedDataset` API and the packing implementation.
+- [Data § StatefulDataLoader](../data/stateful-dataloader.md) —
+  `StatefulDataLoader` and resumption.
+- [Configuration § `[data]`](../configuration/config-sections.md) —
+  every `DataConfig` field with its default.
+- [End-to-end training run](end-to-end-training-run.md) — uses
+  Path B (HF wikitext) as the runnable example.
+- [`configs/train/hf_wikitext.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/hf_wikitext.toml)
+  — reference HF-streaming config.

--- a/docs/how-to/run-evaluation.md
+++ b/docs/how-to/run-evaluation.md
@@ -1,0 +1,225 @@
+# Run evaluation
+
+Three entry points, three use cases:
+
+| Entry point | When to use |
+|-------------|-------------|
+| `[eval]` section in training config | Periodic eval loss during a training run |
+| `scripts/eval.py` | Standalone eval on a saved checkpoint — quick loss/perplexity on new data |
+| `scripts/eval_harness.py` | Downstream benchmarks (HellaSwag, ARC, MMLU, …) via lm-eval-harness |
+
+All three compute through the same underlying
+[`run_eval`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/eval.py)
+function when they need loss; the harness path additionally converts
+the DCP checkpoint to HuggingFace format and hands off to `lm_eval`.
+
+## Path 1: eval inside the training loop
+
+Flip on `[eval]` in your TOML:
+
+```toml
+[eval]
+enabled              = true
+interval             = 500          # steps between evals
+steps                = 50           # batches per eval
+dataset_path         = "/data/eval_set"
+file_pattern         = "*.bin"
+# OR — HuggingFace eval data:
+# hf_dataset_name    = "wikitext"
+# hf_dataset_config  = "wikitext-103-raw-v1"
+# hf_dataset_split   = "validation"
+```
+
+Every `interval` steps, the training loop pauses the optimizer,
+switches the model to eval mode, iterates `steps` batches of held-out
+data, and logs `eval/loss` and `eval/perplexity` through
+[`MetricsTracker.log_eval`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/metrics/tracker.py).
+The stdout backend renders one compact line per call:
+
+```
+[step 500] eval/loss=3.8200 | eval/perplexity=45.6000
+```
+
+The eval dataloader is a plain `DataLoader` with a `DistributedSampler`
+(not `StatefulDataLoader`). It's deterministic because it doesn't
+shuffle, and it's allowed to reset on epoch boundary — eval iteration
+uses `StopIteration` → re-init to wrap around if `steps` exceeds the
+dataset.
+
+### Perplexity is capped
+
+```python
+{"eval/loss": avg_loss, "eval/perplexity": math.exp(min(avg_loss, 20.0))}
+```
+
+`exp(20) ≈ 4.85e8`. When the model hasn't converged yet and loss is
+huge, `exp` would overflow — so the clamp keeps the number finite.
+Treat `perplexity ≈ 5e8` as "loss is still blowing up," not a real
+perplexity.
+
+### PP integration
+
+`run_eval` auto-detects pipeline parallelism via its `pp_schedule`
+argument. On PP stages, eval runs through the same
+`schedule.step(input, target, losses)` machinery as training; the
+last stage broadcasts the loss back to rank 0 so logging stays
+consistent.
+
+## Path 2: standalone eval on a checkpoint
+
+```bash
+# Single GPU
+uv run python scripts/eval.py configs/train/7b.toml \
+    --checkpoint.load_path=checkpoints/7b/step_10000 \
+    --eval.dataset_path=/data/eval_set \
+    --eval.steps=100
+
+# Multi-GPU (FSDP for large models)
+uv run torchrun --nproc_per_node=4 scripts/eval.py configs/train/7b.toml \
+    --checkpoint.load_path=checkpoints/7b/step_10000 \
+    --eval.dataset_path=/data/eval_set
+```
+
+[`scripts/eval.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/eval.py)
+is the training script minus the optimizer:
+
+- Same `load_config` + `init_distributed` + `build_parallel_model`
+  path, so FSDP / TP configurations work unchanged
+- Loads the checkpoint via `CheckpointManager(...)` with
+  `exclude_keys=["optimizer"]` — model + RNG only
+- Runs `run_eval(model, dataloader, loss_fn, device, eval_steps)` and
+  prints results to stdout + JSON
+
+Output:
+
+```
+==================================================
+Evaluation Results (step 10000)
+==================================================
+  eval/loss: 2.4321
+  eval/perplexity: 11.3856
+==================================================
+
+{"step": 10000, "tokens_seen": 4194304000, "eval/loss": 2.4321, ...}
+```
+
+The JSON dump at the end is useful for scripting — redirect to a file
+and diff across checkpoints.
+
+### HuggingFace eval data path
+
+```bash
+uv run python scripts/eval.py configs/train/7b.toml \
+    --checkpoint.load_path=checkpoints/7b/step_10000 \
+    --eval.hf_dataset_name=wikitext \
+    --eval.hf_dataset_config=wikitext-103-raw-v1
+```
+
+Rank 0 tokenizes the full eval split (via
+[`HuggingFaceDataset`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/data/dataset.py))
+and broadcasts packed sequences to all other ranks — fine for
+benchmark-sized eval sets, avoid for anything multi-GB.
+
+### Pipeline parallelism is not supported here
+
+The standalone script's model build goes through `build_parallel_model`,
+not the PP stage builder. If you need PP eval, drive it from the
+training loop (Path 1).
+
+## Path 3: lm-eval-harness for downstream tasks
+
+The training-loss eval is useful for training signal; for downstream
+benchmarks you want lm-eval-harness.
+
+```bash
+# Install the extra (lm-eval is optional — not default dep)
+uv add lm-eval
+
+# Run default task suite: hellaswag, arc_easy, arc_challenge,
+# winogrande, piqa, boolq
+uv run python scripts/eval_harness.py \
+    --checkpoint checkpoints/7b/step_10000 \
+    --config    configs/train/7b.toml
+
+# Specific tasks
+uv run python scripts/eval_harness.py \
+    --checkpoint checkpoints/7b/step_10000 \
+    --config    configs/train/7b.toml \
+    --tasks     hellaswag,mmlu,arc_easy
+
+# Pre-converted HF model — skip DCP conversion
+uv run python scripts/eval_harness.py \
+    --hf-model ./exports/my_model \
+    --tasks    hellaswag
+```
+
+[`scripts/eval_harness.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/eval_harness.py)
+does three things:
+
+1. Converts the DCP checkpoint to HuggingFace format via
+   `dcp_to_hf()` from `scripts/convert_checkpoint.py`, into a tempdir
+2. Calls `lm_eval.simple_evaluate(model="hf", model_args=...)` with
+   the task list
+3. Prints results and optionally writes JSON via `--output`
+
+### Flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--checkpoint` | — | DCP checkpoint dir (will be converted) |
+| `--config` | — | TOML (required with `--checkpoint` to resolve model architecture) |
+| `--hf-model` | — | Pre-converted HF dir, skip conversion |
+| `--tasks` | `hellaswag,arc_easy,arc_challenge,winogrande,piqa,boolq` | comma-sep tasks |
+| `--batch-size` | `8` | eval batch size |
+| `--num-fewshot` | `None` (task default) | override few-shot count |
+| `--output` | `None` | save full JSON results |
+
+### Conversion caveat
+
+DCP → HF conversion is a one-time cost per checkpoint — the full
+model is materialized on one device, keys are remapped, and weights
+are written as safetensors. Time scales with model size and filesystem
+throughput, so larger checkpoints on networked storage take longer. If
+you're scanning many checkpoints with the harness, convert once
+manually and re-use the output with `--hf-model`:
+
+```bash
+uv run python scripts/convert_checkpoint.py dcp-to-hf \
+    --dcp-dir checkpoints/7b/step_10000 \
+    --hf-dir  exports/7b_step_10000 \
+    --config  configs/model/llama_7b.toml
+
+uv run python scripts/eval_harness.py \
+    --hf-model exports/7b_step_10000 \
+    --tasks hellaswag,mmlu
+```
+
+## Picking a path
+
+| Goal | Path |
+|------|------|
+| Track training signal as loss curve | Path 1 (in-training) |
+| Loss on a specific held-out set for a specific checkpoint | Path 2 (`scripts/eval.py`) |
+| Downstream accuracy — HellaSwag / MMLU / ARC | Path 3 (`scripts/eval_harness.py`) |
+| Quick sanity on small datasets | Path 2 |
+| Scanning 20 checkpoints for best MMLU | Path 3 with pre-conversion |
+
+The three paths don't overlap in outputs: Path 1/2 report `eval/loss`
++ perplexity; Path 3 reports task-specific metrics (accuracy, acc-norm,
+pass@k). You'll often run both — loss for the monitoring signal,
+harness for final reporting.
+
+## See also
+
+- [Training § Evaluation](../training/evaluation.md) — `run_eval`
+  implementation notes.
+- [Configuration § `[eval]`](../configuration/config-sections.md) —
+  every `EvalConfig` field with its default.
+- [Checkpointing § DCP model format](../checkpointing/dcp-model.md) —
+  what the DCP → HF converter reads.
+- [End-to-end training run](end-to-end-training-run.md) — the source
+  of the checkpoints the three paths consume.
+- [`scripts/eval.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/eval.py)
+  and
+  [`scripts/eval_harness.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/eval_harness.py)
+  — the scripts this page documents.

--- a/docs/how-to/scaling-guide.md
+++ b/docs/how-to/scaling-guide.md
@@ -1,0 +1,264 @@
+# Scaling guide
+
+A walkthrough from 1 to 32 GPUs with Kempner's H200 cluster as the
+reference hardware. Every number on this page is from the measured
+benchmarks — if you want the raw data, go to
+[MFU scaling (dense)](../reference/benchmarks.md#mfu-scaling-dense)
+and [MoE Expert Parallelism](../reference/benchmarks.md#moe-expert-parallelism).
+This page decides *when* to reach for each dimension and *what*
+throughput you should expect.
+
+## The order of parallelism
+
+Before any scaling decision, keep the
+[canonical order](../architecture/parallelism-order.md) in mind.
+`build_parallel_model` applies the intra-stage parallelisms in this
+exact sequence:
+
+```
+TP → EP → [FP8] → AC → FSDP (dp_shard)
+```
+
+Pipeline parallelism is applied separately in `scripts/train.py`
+(split into stages *before* `build_parallel_model` runs on each
+stage), and DP replicate / CP are mesh dimensions without a dedicated
+apply step — they fall out of how the `DeviceMesh` is constructed.
+Getting the order wrong is silent: gradients can be mathematically
+wrong but the loss curve looks plausible. Let the validator enforce
+the mesh shape, and pick your dimensions knowing what each costs.
+
+## What each dimension costs
+
+| Dimension | Memory win | Comm pattern | When it earns its keep |
+|-----------|-----------|--------------|------------------------|
+| **FSDP (`dp_shard`)** | params, grads, opt state sharded | once per step (all-gather + reduce-scatter) | Always, unless model doesn't fit even at `ep`+`tp`+`pp` |
+| **TP** | shards attention + MLP activations | every matmul (all-gather + reduce-scatter) | When a model is too big for FSDP alone, or `n_layers` is the bottleneck |
+| **PP** | shards layers across stages | once per micro-batch (P2P send/recv) | When TP+FSDP still can't fit (70B memory-tight) |
+| **EP** (MoE only) | shards expert weights | all-to-all on dispatch + combine | When expert weights dominate param budget; required at 32+ experts |
+| **CP** | shards along sequence | n/a (stub, not wired up) | Not yet |
+| **DP replicate** | none | all-reduce on grads across replicas | Rarely — shrinks all-reduce domain at memory cost |
+
+Matching principle: **cheap collectives first, expensive last**.
+FSDP fires one all-gather per step; TP fires one per matmul. At
+equal memory savings, FSDP wins until it can't fit.
+
+## 1 GPU — smoke test
+
+Your first job is to confirm the loop works end-to-end. Use either
+`hf_wikitext.toml` (~40M params, HF streaming) or `debug.toml`
+(pre-tokenized path). See
+[End-to-end training run](end-to-end-training-run.md).
+
+```bash
+uv run python scripts/train.py configs/train/hf_wikitext.toml
+```
+
+MFU at this scale is *uninformative* — the loop is framework-bound,
+not matmul-bound. Don't chase numbers here.
+
+## 4 GPUs (single node) — FSDP is the answer
+
+The benchmark record: **7B dense + FSDP=4 hits 53.8% MFU at 38,983
+tok/s**, the highest intra-node efficiency measured. This is the
+scale where FSDP shines:
+
+```toml
+[distributed]
+dp_shard = -1     # auto-resolves to 4
+tp       = 1
+pp       = 1
+```
+
+Why pure FSDP beats TP here: at 4 GPUs on 7B, pure FSDP measures
+53.8% MFU vs 34.7% for pure `tp=4` (same GPUs). TP fires
+all-gather/reduce-scatter on every matmul; FSDP fires once per step.
+See [the benchmark](../reference/benchmarks.md#mfu-scaling-dense).
+
+Reference config:
+[`configs/train/7b.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b.toml).
+
+## 8 GPUs — the scaling cliff
+
+Going from 4 to 8 GPUs crosses a node boundary for the first time:
+intra-node NVLink → inter-node InfiniBand. The 7B model drops from
+**93% linear efficiency at 4 GPUs to 53% at 8 GPUs**. Two strategies:
+
+1. **Stay with 7B + FSDP=8** and accept the hit. Simplest; still
+   useful for short experiments.
+2. **Move to 13B + FSDP=8** — 13B on 8 H200s measures 44.4% MFU.
+   Better absolute throughput (35,405 tok/s) because compute density
+   per GPU grows.
+
+Past this cliff, the slope is gentle (8 → 32 GPUs degrades only
+53% → 47% efficiency). The first inter-node hop is the expensive
+one — design around it.
+
+## 16 GPUs — TP enters the picture
+
+At 16 GPUs, pure FSDP works but isn't the efficient pick for larger
+models. Two measured options at 13B / 16 GPUs:
+
+- **`TP=4 × FSDP=4`**: 33.7% MFU, 53,814 tok/s. Use when you need
+  the memory headroom or plan to scale further to 32.
+- **FSDP=16**: usable for 7B, not tested for 13B at this step count.
+
+Why TP here and not at 8 GPUs: TP's per-matmul cost is only worth
+paying when the memory savings unlock a larger model or a larger
+batch. At 8 GPUs / 13B, FSDP alone fits.
+
+## 32 GPUs — mix TP + PP + FSDP
+
+The measured 32-GPU best for 13B is **`TP=4 × FSDP=8`** at 32.7% MFU
+/ 104,309 tok/s. Three patterns are in the recipes:
+
+| Model | Parallelism | MFU | tok/s |
+|-------|-------------|:---:|------:|
+| 13B | `tp=4 × dp_shard=8` | 32.7% | 104,309 |
+| 70B | `tp=4 × dp_shard=8` | 25.4% | (memory fits) |
+| 70B | `tp=4 × pp=4 × dp_shard=2` | not measured | alternative for memory-tight setups |
+
+`tp=4` maps to one node (intra-node NVLink → cheap collective). The
+remaining 8 ranks go into FSDP. PP only enters when memory forces it:
+70B with `TP=4 × FSDP=8` *fits*, so the PP version is only the right
+pick when activation memory pushes you over. The PP=4 variant adds a
+pipeline bubble in exchange for halved FSDP sharding work.
+
+Full recipe catalog: [Parallelism recipes](../reference/parallelism-recipes.md).
+
+## When each dimension becomes load-bearing
+
+```
+1 GPU     → no parallelism (smoke test only)
+4 GPUs    → FSDP-only (single node)
+8-16 GPUs → FSDP, usually. TP only if model too big or batch tiny.
+32 GPUs   → TP=4 (intra-node) + FSDP=N (across). 70B adds PP when memory-tight.
+64+ GPUs  → Same pattern, larger FSDP. PP mandatory for 100B+ dense.
+MoE       → Add EP when expert weights dominate memory, typically 32+ experts.
+```
+
+Quantitatively, from the benchmark:
+
+- At 32 GPUs, **7B uses 27.6 GB / 140 GB** — room to spare, but
+  compute-per-GPU is low (26.9% MFU).
+- **13B uses 36.3 GB** — the goldilocks zone on H200 (32.7% MFU).
+- **70B with TP=4 uses 93.2 GB** — near saturation, still holds 25.4%
+  MFU.
+
+Pick the model size to saturate ~60-70% of H200 memory at your target
+GPU count. Smaller wastes compute; larger runs the OOM gauntlet.
+
+## Batch-size scaling
+
+The training config's `batch_size × grad_accum_steps × world_size ×
+seq_len == global tokens per step`. Two knobs to raise global batch
+when scaling:
+
+1. **`batch_size`** (micro-batch per rank). Hard-capped by activation
+   memory — raising it eventually OOMs.
+2. **`grad_accum_steps`**. Cheap: each micro-batch is a standalone
+   forward/backward, gradients accumulate, optimizer steps once every
+   `grad_accum_steps`. `maybe_no_sync` skips the DP all-reduce on
+   all but the last micro-batch, so communication cost scales with
+   optimizer steps, not micro-batches.
+
+Concrete example: `moe_24gpu.toml` uses `grad_accum=32` to saturate
+throughput on a 24-GPU run where the per-rank batch size is bounded
+by activation memory. See
+[`configs/train/moe_24gpu.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/moe_24gpu.toml).
+
+For LR scaling with batch size: follow whatever recipe your reference
+paper used (GPT-3 / Llama linear scaling rule up to a batch of ~1M
+tokens, then sub-linear). KempnerForge doesn't auto-scale LR.
+
+## Activation checkpointing
+
+`activation_checkpointing = "full"` recomputes every block's forward
+during backward — trades compute for memory. Every measured MFU
+number on this page is with full AC because it was necessary to fit
+the batch size. The cost is roughly 30% more compute per step;
+usually you don't have a choice, because without AC you OOM.
+
+`"selective"` checkpoints a subset of blocks — sometimes usable for
+smaller models where full AC leaves GPUs underutilized. Measured
+marginal on most configs in the benchmark.
+
+## MoE scaling
+
+A separate track. Even at 32 GPUs, the measured MoE run (8 experts,
+4B total, 1.8B active, `TP=4 × EP=2 × FSDP=4`) hits only **1.5%
+MFU**. This is correct, not broken:
+
+- ~56M active params per GPU on H200 (designed for billions).
+- Communication dominates (EP all-to-all + FSDP + TP).
+- Reaching dense-MFU territory on MoE at this scale would require
+  **~50B total parameters / ~10B active** — a different model size
+  class.
+
+Don't compare dense MFU to MoE MFU. Compare tok/s and loss/token for
+the same target recipe. Full discussion:
+[Benchmarks § Why MFU is 1.5%](../reference/benchmarks.md#why-mfu-is-15).
+
+EP turn-on criteria live in [MoE experiments](moe-experiments.md#when-to-turn-on-ep):
+
+- Expert weights > 50% of total params.
+- FSDP alone OOMs.
+- InfiniBand available (all-to-all on Ethernet is punishing).
+
+## Common pitfalls
+
+### Going TP too early
+
+Using `tp=4 × dp_shard=1` on a 4-GPU single-node 7B job: **34.7%
+MFU** vs **53.8% MFU** for pure FSDP. If memory fits, FSDP wins.
+Don't reach for TP until you've proven FSDP can't.
+
+### Forgetting `dp_shard = -1`
+
+The `dp_shard = -1` sentinel auto-resolves to
+`world_size / (dp_replicate × tp × pp × cp × ep)`. Setting it to a
+fixed number forces a mismatch when you change GPU count. Use `-1`
+unless you have a specific reason to pin it.
+
+### Mis-sized activation memory
+
+Symptoms: OOM on step 2 (allocator fragments), or peak memory climbs
+slowly over hundreds of steps. Fix 1: enable
+`activation_checkpointing = "full"`. Fix 2: set
+`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` — load-bearing
+for the 32-GPU MoE config per the benchmark.
+
+### Running MoE + PP
+
+`JobConfig.__post_init__` raises this — MoE is data-dependent and
+doesn't compose with static pipeline stages. No workaround in
+KempnerForge today. See
+[MoE experiments § Composition caveats](moe-experiments.md#composition-caveats).
+
+### FP8 + TP
+
+Also rejected in validation —
+[`Float8Linear`'s DTensor path is incomplete](../distributed/fp8.md#tp-incompatibility).
+You can compose FP8 with FSDP (that's the point) and FP8 with EP
+(they're orthogonal), but FP8 + TP will raise at startup.
+
+### Chasing MFU instead of tok/s
+
+MFU is a fraction; tok/s is the rate you actually care about. A 7B
+model at 4 GPUs hits 53.8% MFU / 38,983 tok/s. A 13B model at 8 GPUs
+hits 44.4% MFU / 35,405 tok/s — *lower* MFU, but 13B is a better
+model for the same tok/s. Optimize the loss-per-wall-clock-hour goal,
+not the MFU scoreboard.
+
+## See also
+
+- [Benchmarks](../reference/benchmarks.md) — the raw measurements
+  this page cites.
+- [Parallelism recipes](../reference/parallelism-recipes.md) — every
+  shipped TOML with the parallelism combo it demonstrates.
+- [Parallelism order](../architecture/parallelism-order.md) — why
+  the mesh dimensions must be applied in a specific sequence.
+- [Validation rules](../configuration/validation-rules.md) — what
+  the cross-section validator rejects and why.
+- [End-to-end training run](end-to-end-training-run.md) — the
+  single-job walkthrough this guide scales from.
+- [MoE experiments](moe-experiments.md) — the MoE scaling workflow.

--- a/docs/how-to/slurm-distributed-setup.md
+++ b/docs/how-to/slurm-distributed-setup.md
@@ -1,0 +1,210 @@
+# SLURM distributed setup
+
+KempnerForge ships three SLURM launch scripts under
+[`scripts/slurm/`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/slurm):
+
+| Script | Launcher | Scope |
+|--------|----------|-------|
+| `singlenode.sh` | `torchrun --standalone` | 1 node, N GPUs |
+| `multinode.sh`  | `srun` direct | 2+ nodes, N×M GPUs |
+| `interactive.sh`| `srun` inside an existing allocation | attach to `salloc` session |
+
+This page explains when to use each, what environment the scripts
+assemble, and how preemption + auto-resume compose with them.
+
+## Single node: `singlenode.sh`
+
+```bash
+sbatch scripts/slurm/singlenode.sh configs/train/7b.toml
+sbatch scripts/slurm/singlenode.sh configs/train/7b.toml --train.max_steps=1000
+```
+
+The script:
+
+- Reads `SLURM_GPUS_PER_NODE` (default 4) to build `torchrun
+  --nproc_per_node=$NGPUS`
+- Detects the first UP InfiniBand interface (`ip -br addr`) and
+  exports `NCCL_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME` to it
+- Launches `torchrun --standalone` so there's no rendezvous
+  coordination needed (single-host)
+
+Edit the header for your cluster:
+
+```bash
+#SBATCH --partition=<partition-name>
+#SBATCH --account=<account-name>
+#SBATCH --gpus-per-node=4
+#SBATCH --time=24:00:00
+```
+
+## Multi-node: `multinode.sh`
+
+```bash
+sbatch --nodes=4 scripts/slurm/multinode.sh configs/train/7b.toml
+sbatch --nodes=8 scripts/slurm/multinode.sh \
+    configs/train/7b.toml --train.max_steps=50000
+```
+
+Two things make multi-node different from single-node on this
+codebase:
+
+1. **Launch method is `srun` direct, not `torchrun`.** Each srun task
+   is one process bound to one GPU. SLURM already sets
+   `SLURM_PROCID` / `SLURM_LOCALID` / `SLURM_NTASKS`, and
+   [`get_world_info`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/setup.py)
+   maps them to `RANK` / `LOCAL_RANK` / `WORLD_SIZE`. No torchrun in
+   the loop.
+2. **`--ntasks-per-node` must equal `--gpus-per-node`.** This is the
+   load-bearing invariant. Violate it and local rank maps incorrectly,
+   processes land on the wrong GPU, and NCCL fails silently or crashes
+   at first collective.
+
+```bash
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=4      # ← must match gpus-per-node
+#SBATCH --gpus-per-node=4
+#SBATCH --signal=B:SIGTERM@120   # SLURM sends SIGTERM 120s before time-limit
+#SBATCH --requeue                # auto-resubmit on preemption
+```
+
+The script then:
+
+- Extracts `MASTER_ADDR` via `scontrol show hostnames
+  $SLURM_JOB_NODELIST | head -n 1`
+- Picks a random free port in `[15000, 20000]` for `MASTER_PORT` (so
+  two jobs on the same node don't collide)
+- Detects the first UP IB interface and binds both NCCL and Gloo to
+  it
+- Launches `srun uv run python scripts/train.py $CONFIG`
+
+### Why Gloo needs the same IB interface
+
+Async DCP checkpointing uses a CPU-side Gloo process group for
+coordination. Without `GLOO_SOCKET_IFNAME` pointed at the IB
+interface, Gloo falls back to the management Ethernet (`em4` on
+Kempner nodes), which is on a different subnet — peer connections
+time out and the checkpoint never completes.
+
+### NCCL environment the script sets
+
+```bash
+NCCL_SOCKET_IFNAME=ib0      # OOB bootstrap + socket transport
+NCCL_IB_DISABLE=0           # enable IB verbs transport
+NCCL_NET_GDR_LEVEL=2        # GPU-direct RDMA
+NCCL_IB_GID_INDEX=3         # H100/H200 fabric config
+NCCL_TIMEOUT=1800           # 30 minutes — raise for slow collectives
+GLOO_SOCKET_IFNAME=ib0
+```
+
+`NCCL_IB_GID_INDEX=3` is specific to the RoCE/IB fabric on Kempner
+H100/H200 nodes. On other clusters this may need to be 0 or 1 — check
+with your admins or `ibv_devinfo`.
+
+## Interactive / existing allocation: `interactive.sh`
+
+When you already have an allocation (`salloc` or a queued job) and
+want to attach training to it without a new `sbatch`:
+
+```bash
+# Pass the JOBID of the existing allocation, then the config:
+bash scripts/slurm/interactive.sh 3565401 configs/train/debug.toml
+bash scripts/slurm/interactive.sh 3565401 configs/train/7b.toml --train.max_steps=50
+```
+
+The script resolves `NODELIST` / `MASTER_ADDR` via `squeue -j $JOBID`
+and `scontrol show hostnames`, auto-detects the IB interface, then
+dispatches `srun --jobid=$JOBID` with `--ntasks-per-node=$GPUS_PER_NODE`.
+Useful for debugging on a reserved node without going through the
+queue again.
+
+## Preemption, SIGTERM, auto-resume
+
+The full mechanics live in
+[Resilience § SLURM preemption](../resilience/slurm-preemption.md);
+the short version:
+
+- `#SBATCH --signal=B:SIGTERM@120` tells SLURM: "send SIGTERM 120
+  seconds before the wallclock time limit, to rank 0 (`B:` = batch
+  script process)."
+- The training loop's
+  [`ShutdownHandler`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/signal_handler.py)
+  catches SIGTERM, flips `should_shutdown()` to `True`, and the step
+  loop writes an emergency DCP checkpoint before exiting cleanly.
+- `#SBATCH --requeue` puts the job back in the queue. When it starts
+  again, `CheckpointManager` follows the `latest` symlink in
+  `checkpoint.dir` and resumes at the exact step / sample.
+
+The 120-second window is a design parameter: emergency checkpoints
+must finish within it or the job is SIGKILL'd. Async DCP save times
+depend on model size, FSDP degree, and filesystem — measure on your
+cluster with `checkpoint.async_save = true` and a test run before
+trusting the default for 70B+. If your save consistently overruns,
+raise `#SBATCH --signal=B:SIGTERM@<seconds>` accordingly.
+
+## Auto-resume in practice
+
+With `--requeue` set, you can monitor a preempted-and-restarted job:
+
+```bash
+squeue -j <jobid>                  # see current state
+sacct -j <jobid> --format=JobID,State,ExitCode,Start,End
+scontrol show job <jobid> | grep RestartCount
+```
+
+On first launch, `SLURM_RESTART_COUNT` is `0`; after a requeue it
+increments. The script echoes this so the log makes it obvious:
+
+```
+Restart cnt:  2
+```
+
+If you see rising restart counts but training never crosses step
+`eval_interval`, something is preempting the job faster than it can
+checkpoint — raise the `#SBATCH --signal` window or drop
+`checkpoint.interval`.
+
+## Checking the launch worked
+
+First time you run on a new cluster, verify:
+
+1. **All ranks start** — the script's banner line should print once
+   per rank, and rank 0 log should show `world_size = N × M`.
+2. **NCCL talks over IB** — set `NCCL_DEBUG=INFO` in the script once
+   to see the negotiated transport. Each rank should log `NET/IB`
+   (not `NET/Socket`).
+3. **First all-reduce succeeds** — rank 0 reports model build and
+   step 1 loss within a minute or two. A multi-minute hang at step 1
+   usually means Gloo is on the wrong interface (DCP init fails) or
+   IB GID is wrong.
+
+If step 1 hangs, kill the job and re-run with:
+
+```bash
+export NCCL_DEBUG=INFO
+export TORCH_DISTRIBUTED_DEBUG=DETAIL
+```
+
+## What the SLURM scripts don't do
+
+- **Tokenizer caching** — you still need to pre-cache HuggingFace
+  tokenizers on a login node (compute nodes are usually air-gapped).
+  See
+  [Prepare tokenized data § Cache the tokenizer first](prepare-tokenized-data.md#cache-the-tokenizer-first).
+- **Data staging** — `configs/train/*.toml` expects your dataset at
+  `data.dataset_path`. Pre-copy or symlink before `sbatch`.
+- **Env mounts** — the scripts assume `uv run python` resolves the
+  repo's `.venv`. If your cluster uses different mount points, edit
+  the `uv run` lines.
+
+## See also
+
+- [Resilience § SLURM preemption](../resilience/slurm-preemption.md)
+  — the full `ShutdownHandler` timeline and SLURM requeue dance.
+- [Distributed § DeviceMesh](../distributed/device-mesh.md) — how
+  `init_distributed` turns rank info into a mesh.
+- [End-to-end training run](end-to-end-training-run.md) — runs
+  through the single-node path before this page scales it.
+- [Scaling guide](scaling-guide.md) — which parallelism combo to pick
+  at each GPU count; this page tells you how to launch it.
+- [`scripts/slurm/multinode.sh`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/slurm/multinode.sh)
+  — the reference script this page documents.

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,8 @@ once you want a real run:
   auto-resume, resharding, HuggingFace conversion.
 - **{doc}`metrics-and-profiling/index`** — metrics tracker, MFU,
   memory monitor, profiler, WandB / TensorBoard backends.
+- **{doc}`resilience/index`** — SLURM preemption, NaN detection,
+  NCCL liveness, GPU health, elastic training.
 
 ## Indices
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,15 @@ once you want a real run:
   model inspection, attention visualization, activation extraction,
   checkpoint analysis, optimizer comparison, MoE routing.
 
+## Looking for something specific?
+
+- **{doc}`how-to/index`** — end-to-end researcher workflows: prepare
+  data, scale 1→32 GPUs, compare optimizers, set up MoE experiments,
+  extract activations, debug regressions.
+- **{doc}`architecture/index`** — model forward pass, parallelism
+  application order, data flow through the training loop.
+- **{doc}`configuration/index`** — the typed dataclass system, CLI
+  overrides, registry for swappable components.
 
 ## Indices
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,8 @@ once you want a real run:
   loss functions, gradient utilities, hooks, evaluation, generation.
 - **{doc}`distributed/index`** — DeviceMesh, FSDP2, tensor /
   expert / pipeline parallelism, FP8.
+- **{doc}`moe/index`** — routers, capacity and dispatch, auxiliary
+  losses and balancing, FP8 interaction.
 
 ## Indices
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,8 +53,72 @@ once you want a real run:
 - **{doc}`resilience/index`** — SLURM preemption, NaN detection,
   NCCL liveness, GPU health, elastic training.
 
-## Indices
+### Reference Tables and API Documentation
 
-- {ref}`genindex`
-- {ref}`modindex`
-- {ref}`search`
+- **{doc}`reference/index`** — available configs, parallelism
+  recipes, benchmarks, environment variables.
+- **{doc}`api/index`** — API reference, auto-generated from
+  docstrings.
+
+## Contributing
+
+Documentation PRs follow the same flow as code PRs. The editor loop, build
+commands, and style conventions live in
+[Contributing § Writing Docs](contributing.md#writing-docs).
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+:caption: Getting Started
+
+getting-started/index
+```
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+:caption: Architecture and How-to
+
+architecture/index
+how-to/index
+```
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+:caption: Subsystems
+
+training/index
+distributed/index
+moe/index
+data/index
+checkpointing/index
+metrics-and-profiling/index
+resilience/index
+```
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+:caption: Configuration and Reference
+
+configuration/index
+reference/index
+```
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+:caption: API
+
+api/index
+```
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+:caption: Project
+
+contributing
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,10 @@ once you want a real run:
   losses and balancing, FP8 interaction.
 - **{doc}`data/index`** — memory-mapped datasets, HuggingFace
   streaming, sampler, stateful dataloader, mixing and annealing.
+- **{doc}`checkpointing/index`** — DCP model and train-state,
+  auto-resume, resharding, HuggingFace conversion.
+- **{doc}`metrics-and-profiling/index`** — metrics tracker, MFU,
+  memory monitor, profiler, WandB / TensorBoard backends.
 
 ## Indices
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,8 @@ once you want a real run:
 
 - **{doc}`training/index`** — training loop, optimizers, schedulers,
   loss functions, gradient utilities, hooks, evaluation, generation.
+- **{doc}`distributed/index`** — DeviceMesh, FSDP2, tensor /
+  expert / pipeline parallelism, FP8.
 
 ## Indices
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,8 @@ once you want a real run:
   expert / pipeline parallelism, FP8.
 - **{doc}`moe/index`** — routers, capacity and dispatch, auxiliary
   losses and balancing, FP8 interaction.
+- **{doc}`data/index`** — memory-mapped datasets, HuggingFace
+  streaming, sampler, stateful dataloader, mixing and annealing.
 
 ## Indices
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,12 @@ once you want a real run:
 - **{doc}`configuration/index`** — the typed dataclass system, CLI
   overrides, registry for swappable components.
 
+
+### Subsystem reference
+
+- **{doc}`training/index`** — training loop, optimizers, schedulers,
+  loss functions, gradient utilities, hooks, evaluation, generation.
+
 ## Indices
 
 - {ref}`genindex`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,25 +1,30 @@
 # KempnerForge
 
-PyTorch-native framework for fault-tolerant distributed training of foundation models on AI clusters.
+PyTorch-native framework for fault-tolerant distributed training of
+foundation models on AI clusters.
 
-This site is the canonical documentation for KempnerForge. It builds automatically from the `docs/`
-folder and the package source, and is published on every push to `main`.
+This site is the canonical documentation for KempnerForge. It builds from
+the `docs/` folder and the package source, and deploys to GitHub Pages on
+every push to `main`.
 
-:::{note}
-Content is in progress. This page and the API reference are scaffolding — the second-phase docs PR
-will fill in architecture, training, distributed, MoE, and checkpoint guides. Until then, see the
-[README](https://github.com/KempnerInstitute/KempnerForge#readme),
-[`examples/quickstart.md`](https://github.com/KempnerInstitute/KempnerForge/blob/main/examples/quickstart.md),
-and [`examples/notebooks/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/examples/notebooks).
-:::
+## New here?
 
-## Contents
+Start with the getting-started pages, then move to the flagship how-to
+once you want a real run:
 
-```{toctree}
-:maxdepth: 2
+- **{doc}`getting-started/install`** — prerequisites, `uv sync`,
+  environment verification, SLURM-specific notes.
+- **{doc}`getting-started/quickstart`** — five-minute walkthrough: debug
+  run → multi-GPU → custom data → optimizer swap → MoE → hooks.
+- **{doc}`getting-started/first-training-run`** — what the debug run
+  actually did, log line by log line.
+- **{doc}`how-to/end-to-end-training-run`** — flagship walkthrough:
+  tokenize → write a config → launch 1 GPU → launch 4 GPUs → resume →
+  generate. The integration test of the docs.
+- **{doc}`getting-started/notebooks`** — six interactive notebooks for
+  model inspection, attention visualization, activation extraction,
+  checkpoint analysis, optimizer comparison, MoE routing.
 
-api/index
-```
 
 ## Indices
 

--- a/docs/metrics-and-profiling/index.md
+++ b/docs/metrics-and-profiling/index.md
@@ -1,0 +1,88 @@
+# Metrics and profiling
+
+Everything the training loop reports about itself — throughput, MFU,
+loss smoothing, GPU memory, kernel traces. Two modules:
+
+- **`kempnerforge/metrics/`** — always-on per-step metrics with WandB /
+  TensorBoard dispatch, MFU computation, memory stats.
+- **`kempnerforge/profiling/`** — opt-in `torch.profiler` wrapper for
+  kernel-level traces and ad-hoc CUDA event timing.
+
+## At a glance
+
+| Component | Type | Enabled by |
+|-----------|------|-----------|
+| `MetricsTracker` | always-on per-step metrics | created unconditionally in `scripts/train.py` |
+| `WandBBackend` | cloud logging | `metrics.enable_wandb = true` |
+| `TensorBoardBackend` | local event files | `metrics.enable_tensorboard = true` |
+| `compute_mfu` | per-step MFU | always-on (part of `MetricsTracker`) |
+| `get_memory_stats` | per-step GPU memory | always-on |
+| `DeviceMemoryMonitor` | interval-scoped peak tracking + snapshots | opt-in, instantiate manually |
+| `build_profiler` | `torch.profiler` trace | `profiling.enable = true` |
+| `CUDATimer` | region-scoped GPU timing | opt-in, instantiate manually |
+
+Everything on the left of that table is exported from
+`kempnerforge.metrics` and `kempnerforge.profiling` — you can import and
+use any of these outside the training script.
+
+## What gets logged by default
+
+Every `metrics.log_interval` steps (default 10), `MetricsTracker.end_step`
+emits one stdout line and one backend update containing:
+
+```
+train/loss             train/grad_norm       train/lr
+train/tokens_per_sec   train/mfu             train/step_time_sec
+gpu/allocated_gb       gpu/peak_gb           gpu/reserved_gb
+gpu/mem_utilization
+smoothed/loss          smoothed/tokens_per_sec
+smoothed/mfu           smoothed/step_time
+```
+
+Plus eval metrics (via `tracker.log_eval`): eval loss, MoE aux loss and
+router stats, per-dataset losses for mixtures.
+
+## Config
+
+```toml
+[metrics]
+log_interval       = 10          # log every N steps
+enable_wandb       = false
+enable_tensorboard = false
+wandb_project      = "kempnerforge"
+wandb_run_name     = ""          # auto-generated if empty
+wandb_run_id       = ""          # restored from checkpoint on resume
+tensorboard_dir    = "tb_logs"
+
+[profiling]
+enable     = false
+start_step = 5                   # begin recording here
+end_step   = 8                   # stop after this step (exclusive)
+trace_dir  = "profiler_traces"
+```
+
+See [Configuration § `[metrics]` and `[profiling]`](../configuration/config-sections.md)
+for field-level notes.
+
+## Pages
+
+```{toctree}
+:maxdepth: 1
+
+metrics-tracker
+wandb
+tensorboard
+mfu
+memory-monitor
+profiler
+```
+
+## See also
+
+- [Training § Training loop](../training/training-loop.md) — where
+  `tracker.start_step` / `end_step` bookend every step.
+- [Checkpointing § Train state](../checkpointing/train-state.md) —
+  `wandb_run_id` is saved in `ckpt_extra` so resume reattaches to the
+  same run.
+- [Configuration § `[metrics]` and `[profiling]`](../configuration/config-sections.md) —
+  every knob on this page.

--- a/docs/metrics-and-profiling/memory-monitor.md
+++ b/docs/metrics-and-profiling/memory-monitor.md
@@ -1,0 +1,154 @@
+# Memory monitoring
+
+Two layers in
+[`kempnerforge/metrics/memory.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/metrics/memory.py):
+
+- **Functional helpers** — `get_memory_stats`, `get_memory_utilization`,
+  `format_memory_stats`, `reset_peak_memory`. These are used by the
+  [metrics tracker](metrics-tracker.md) every step to populate
+  `StepMetrics.peak_gb` / `mem_utilization`.
+- **`DeviceMemoryMonitor`** — opt-in per-interval tracker that adds
+  peak-reset semantics and an optional snapshot export for OOM debugging.
+
+## Functional helpers
+
+```python
+from kempnerforge.metrics import (
+    get_memory_stats, get_memory_utilization,
+    format_memory_stats, reset_peak_memory,
+)
+
+stats = get_memory_stats(device=0)
+# {"allocated_gb": 12.3, "peak_gb": 14.8,
+#  "reserved_gb": 16.0, "total_gb": 80.0}
+
+utilization = get_memory_utilization(device=0)   # peak_gb / total_gb
+
+print(format_memory_stats(device=0))
+# "GPU mem: 12.3GB allocated, 14.8GB peak, 16.0GB reserved / 80.0GB total (19%)"
+
+reset_peak_memory(device=0)   # torch.cuda.reset_peak_memory_stats
+```
+
+Four quantities, all in GB:
+
+- `allocated_gb` — bytes allocated to live tensors right now.
+- `peak_gb` — maximum `allocated_gb` seen since the last reset.
+- `reserved_gb` — bytes the PyTorch caching allocator has claimed from
+  CUDA; always ≥ `allocated_gb`. Large gap means fragmentation.
+- `total_gb` — total VRAM on the device.
+
+All of these are cheap — `torch.cuda.memory_allocated` is a
+thread-local counter, not a driver call. Safe to read every step.
+
+## `DeviceMemoryMonitor`
+
+Opt-in wrapper with per-interval peak reset + snapshot support. Not used
+by `scripts/train.py` directly; instantiate it yourself when you want
+window-scoped peak tracking:
+
+```python
+from kempnerforge.metrics import DeviceMemoryMonitor
+
+mon = DeviceMemoryMonitor(
+    device=0,
+    snapshot_step=100,         # None to disable
+    snapshot_dir="memory_snapshots",
+)
+
+for step in range(max_steps):
+    train_step(...)
+    if step % log_interval == 0:
+        mon.report(step)       # logs + resets peak + optional snapshot
+```
+
+`report(step)` does four things:
+
+1. Reads `get_memory_stats()` and `get_memory_utilization()`.
+2. Logs a one-line summary: `[step N] GPU mem: ... (X%)`.
+3. If `step == snapshot_step`, calls `capture_snapshot(step)` once.
+4. Calls `reset_peak_memory()` so the next interval's `peak_gb` reflects
+   *that interval*, not all-time.
+
+The interval-reset is the reason to prefer this over
+`get_memory_stats`: with the bare helper, `peak_gb` grows monotonically
+and you can't see that step 200 spiked higher than step 100.
+
+## Why `MetricsTracker` doesn't reset peak
+
+`MetricsTracker.end_step` reads `get_memory_stats` every step but
+**does not reset peak memory**. The `peak_gb` field in `StepMetrics`
+therefore reports the all-time peak since the process started, not the
+per-step peak. This matches what most people want in a training log:
+"what's my worst-case memory footprint."
+
+If you want per-step peak instead, add a `DeviceMemoryMonitor.report()`
+call alongside the tracker — the `reset_peak_memory()` it issues is
+global, so subsequent tracker reads reflect only the new interval.
+
+## Memory snapshot export
+
+`capture_snapshot(step)` dumps a CUDA allocator snapshot to a pickle file
+for offline analysis:
+
+```python
+# kempnerforge/metrics/memory.py — capture_snapshot
+torch.cuda.memory._record_memory_history()
+torch.cuda.synchronize(self.device)
+snapshot = torch.cuda.memory._snapshot()
+torch.cuda.memory._record_memory_history(enabled=None)
+
+with open(f"memory_snapshots/snapshot_step_{step}_device_{device}.pickle", "wb") as f:
+    pickle.dump(snapshot, f)
+```
+
+Load the pickle at [pytorch.org/memory_viz](https://pytorch.org/memory_viz)
+for a flamegraph-style timeline showing which allocator blocks are live,
+how fragmentation accumulates, and which call sites are holding memory.
+
+**Important caveat:** `_record_memory_history` + `_snapshot` are
+underscore-prefixed PyTorch APIs — they're stable enough to rely on in
+the short term but have changed shape between versions. The snapshot is
+best-effort: any failure (CUDA error, disk full, pickle error) is caught
+and logged as a warning, training continues.
+
+The snapshot also only covers *this rank*. For distributed memory
+analysis you need one snapshot per rank, saved to per-rank filenames
+(the default path includes `device_{device}`, but if you're running
+multiple ranks on separate devices via CUDA_VISIBLE_DEVICES you need to
+differentiate them by rank instead).
+
+## Use cases
+
+- **OOM diagnosis.** Set `snapshot_step` to one step before the OOM, run
+  again, load the pickle and see which allocation pushed over the edge.
+- **Fragmentation.** Compare `peak_gb` to `reserved_gb` over time. A
+  growing gap is fragmentation; the allocator can't reuse its reserved
+  pool for new allocations of different size.
+- **Activation checkpointing tuning.** Set `snapshot_step` inside a
+  backward pass (e.g. step 5 after warmup) to see which activations are
+  consuming the most.
+
+## Integration with memory viz
+
+Workflow:
+
+```bash
+# 1. Run with snapshot enabled
+uv run python scripts/train.py configs/train/debug.toml
+# [step 100] Memory snapshot saved: memory_snapshots/snapshot_step_100_device_0.pickle
+
+# 2. Open https://pytorch.org/memory_viz
+# 3. Drag-drop the .pickle file into the page
+```
+
+The visualizer runs entirely client-side — the pickle isn't uploaded
+anywhere.
+
+## See also
+
+- [Metrics tracker](metrics-tracker.md) — consumer of `get_memory_stats`
+  for the per-step `gpu/*` metrics.
+- [Profiler](profiler.md) — the complementary `torch.profiler` path; it
+  records `profile_memory=True` events inside the trace for Perfetto
+  inspection.

--- a/docs/metrics-and-profiling/metrics-tracker.md
+++ b/docs/metrics-and-profiling/metrics-tracker.md
@@ -1,0 +1,205 @@
+# Metrics tracker
+
+[`MetricsTracker`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/metrics/tracker.py)
+is the central per-step metric collector. One instance is created once in
+`scripts/train.py`; the training loop bookends every step with
+`start_step()` / `end_step()` and the tracker handles timing, smoothing,
+stdout formatting, and backend dispatch.
+
+## Wiring
+
+```python
+# scripts/train.py
+tracker = MetricsTracker(config, num_gpus=world_size)
+tracker.init_backends(config)     # lazy rank-0 init
+...
+while step < tc.max_steps:
+    tracker.start_step()
+    # ... forward, backward, optimizer step ...
+    tracker.end_step(step, loss=loss, grad_norm=gn, lr=lr,
+                     tokens_in_step=tokens_per_step)
+    ...
+tracker.close()
+```
+
+`init_backends` is separate from `__init__` because distributed init and
+config rewrites (e.g. restored `wandb_run_id`) happen between tracker
+construction and the first step.
+
+## Per-step flow
+
+`end_step` runs five things in order:
+
+1. **Timing** — `step_time = perf_counter() - _step_start`; derives
+   `tokens_per_sec = tokens_in_step / step_time`.
+2. **MFU** — calls `compute_mfu(model_config, tokens_per_sec, num_gpus,
+   gpu_peak_tflops, seq_len)`. See [MFU](mfu.md).
+3. **Memory stats** — `get_memory_stats()` + `get_memory_utilization()`,
+   captured every step from device 0.
+4. **EMA smoothing** — updates four smoothed keys (`loss`,
+   `tokens_per_sec`, `mfu`, `step_time`) with `alpha=0.1`.
+5. **Log if due** — if `step % log_interval == 0` or `step == 1`, dispatch
+   to stdout + all backends and return a `StepMetrics`. Otherwise return
+   `None`.
+
+## `StepMetrics`
+
+```python
+@dataclass
+class StepMetrics:
+    loss: float           # raw, not smoothed
+    grad_norm: float
+    lr: float
+    tokens_per_sec: float # global (across all GPUs)
+    mfu: float
+    step_time_sec: float
+    allocated_gb: float
+    peak_gb: float
+    reserved_gb: float
+    total_gb: float
+    mem_utilization: float
+```
+
+Returned from `end_step()` only on logging steps. The raw values are
+written to backends; the EMA-smoothed copies go under a `smoothed/` prefix
+(see below).
+
+## EMA smoothing
+
+```python
+# kempnerforge/metrics/tracker.py — _update_smoothed
+if key not in self._smoothed:
+    self._smoothed[key] = value      # bootstrap with first sample
+else:
+    self._smoothed[key] = alpha * value + (1 - alpha) * self._smoothed[key]
+```
+
+`alpha = 0.1` is hardcoded. Four metrics get smoothed: `loss`,
+`tokens_per_sec`, `mfu`, `step_time`. Smoothed values are reported to
+backends as `smoothed/loss`, `smoothed/tokens_per_sec`, etc. Stdout
+reports the raw values.
+
+Smoothing runs every step regardless of `log_interval` — the EMA is built
+from every data point, even ones that aren't logged.
+
+## Log interval
+
+```python
+if step % self.metrics_config.log_interval == 0 or step == 1:
+    self._log_step(step, metrics)
+```
+
+Default `log_interval = 10`. Step 1 is always logged (useful sanity check
+that the pipeline is alive). Step 0 is never reached — the training loop
+starts at `step = 1`.
+
+## Stdout format
+
+```
+[step 1000] loss=2.3400 | lr=3.00e-04 | grad_norm=1.250 | tok/s=125,000 | mfu=52.3% | mem=71.2/80GB | step_time=1.25s
+```
+
+Produced by `format_metrics(step, {...})` from
+[`kempnerforge/metrics/logger.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/metrics/logger.py).
+Numbers use `_format_number`: int gets k/M/B suffix, float gets scientific
+notation below 0.01 or above 1e6, otherwise 4 decimals.
+
+The same logger writes every other `logger.info` in the framework — with
+a `[rank N] LEVEL   ` prefix and ANSI color if `stdout.isatty()` and
+`NO_COLOR` isn't set (see [`_RankFormatter`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/metrics/logger.py)).
+
+## Backend dispatch
+
+`end_step` emits a numeric dict to every configured backend:
+
+```python
+backend_dict = {
+    "train/loss": ..., "train/grad_norm": ..., "train/lr": ...,
+    "train/tokens_per_sec": ..., "train/mfu": ..., "train/step_time_sec": ...,
+    "gpu/allocated_gb": ..., "gpu/peak_gb": ..., "gpu/reserved_gb": ...,
+    "gpu/mem_utilization": ...,
+    # plus smoothed/*
+}
+for backend in self._backends:
+    backend.log(backend_dict, step=step)
+```
+
+Backends are initialized lazily and only on rank 0:
+
+```python
+# kempnerforge/metrics/tracker.py — _init_backends
+if dist.is_initialized() and dist.get_rank() != 0:
+    return
+if mc.enable_wandb:
+    self._backends.append(WandBBackend(mc))
+if mc.enable_tensorboard:
+    self._backends.append(TensorBoardBackend(mc))
+```
+
+Non-rank-0 workers keep `_backends` empty; their `_log_step` call iterates
+over an empty list and only the stdout line is emitted (and even that is
+filtered by the `_RankFilter` — see
+[Logger](#logger-get_logger-format_metrics)).
+
+## Eval path
+
+```python
+def log_eval(self, metrics: dict[str, float], step: int) -> None:
+    logger.info(format_metrics(step, metrics))
+    for backend in self._backends:
+        backend.log(metrics, step=step)
+```
+
+Eval metrics don't touch the smoothing table — they're reported raw. The
+training loop calls `log_eval` after `run_eval`, and separately for MoE
+and per-dataset breakdowns:
+
+```python
+# scripts/train.py
+tracker.log_eval(moe_metrics, step)     # moe/aux_loss, moe/expert_balance
+tracker.log_eval(ds_metrics, step)      # per-source loss
+tracker.log_eval(eval_metrics, step)    # eval loss
+```
+
+Each call logs with the same `step`, so a single training step can
+produce several side-by-side rows in WandB / TensorBoard.
+
+## Close
+
+```python
+def close(self) -> None:
+    for backend in self._backends:
+        backend.close()
+```
+
+Called at the end of `scripts/train.py`. WandB closes the run; TensorBoard
+flushes the event file.
+
+## Logger: `get_logger`, `format_metrics`
+
+Anywhere in the framework, call:
+
+```python
+from kempnerforge.metrics import get_logger
+logger = get_logger(__name__)
+logger.info("starting distributed init")
+```
+
+Returns a `logging.Logger` named `kempnerforge.<name>`. On first call,
+configures the root `kempnerforge` logger with a `_RankFormatter` (adds
+`[rank N]` + colored level) and a `_RankFilter` (drops records from
+non-zero ranks by default).
+
+Override rank filtering with `get_logger(__name__, rank_zero_only=False)`
+when you genuinely want every rank to log — e.g. for distributed-init
+debugging. Once the root logger is configured it's cached, so this flag
+only takes effect on the very first call.
+
+## See also
+
+- [WandB](wandb.md) — how `WandBBackend` initializes and what it logs.
+- [TensorBoard](tensorboard.md) — `TensorBoardBackend` specifics and
+  where event files land.
+- [MFU](mfu.md) — what the `mfu` field is computed from.
+- [Memory monitor](memory-monitor.md) — the module behind `allocated_gb`,
+  `peak_gb`, `reserved_gb`, `total_gb`.

--- a/docs/metrics-and-profiling/mfu.md
+++ b/docs/metrics-and-profiling/mfu.md
@@ -1,0 +1,155 @@
+# MFU
+
+Model FLOPs Utilization — achieved compute throughput divided by the
+hardware peak. All the math lives in
+[`kempnerforge/metrics/mfu.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/metrics/mfu.py).
+
+```
+MFU = (flops_per_token * tokens_per_sec) / (num_gpus * gpu_peak_tflops * 1e12)
+```
+
+## Formula
+
+KempnerForge uses the PaLM paper approximation:
+
+```
+flops_per_token = 6 * active_params  +  12 * n_layers * dim * seq_len
+```
+
+`6*P` covers forward + backward matmuls (2 FLOPs per MAC, 3 passes — one
+forward and two in backward for weight + activation gradients). `12*L*D*S`
+covers the attention-score computation, which scales with sequence length.
+
+## Dense active params
+
+```python
+# kempnerforge/metrics/mfu.py — _dense_flops_per_token
+attn_params = (
+    dim * (n_heads * head_dim)         # Q
+    + 2 * dim * (n_kv_heads * head_dim) # K + V
+    + (n_heads * head_dim) * dim       # O
+)
+mlp_params = 3 * dim * computed_ffn_hidden_dim   # SwiGLU (up, gate, down)
+per_layer = attn_params + mlp_params
+output_params = vocab_size * dim
+active_params = n_layers * per_layer + output_params
+```
+
+Three things this does and doesn't count:
+
+- **Counts output projection.** The LM head matmul is genuinely on the
+  critical path.
+- **Omits the input embedding table.** It's a gather, not a matmul —
+  doesn't consume FLOPs.
+- **Omits bias and norm params.** They're free compared to the matmuls.
+
+## GQA is not discounted
+
+```python
+# 12 * n_layers * dim * seq_len — no n_kv_heads factor
+```
+
+The intuition would be "GQA reads fewer KV heads so attention is cheaper"
+— but with FlashAttention (the default in this repo), GQA is expanded at
+the kernel boundary: the same hardware multiplies `seq_len × seq_len ×
+n_heads` scores. The wall-clock savings come from memory bandwidth, not
+FLOPs. So `12*L*D*S` stays correct.
+
+## MoE
+
+```python
+# kempnerforge/metrics/mfu.py — _moe_flops_per_token
+n_moe_layers = sum(1 for i in range(n_layers) if (i + 1) % moe_frequency == 0)
+n_dense_layers = n_layers - n_moe_layers
+
+dense_active = n_dense_layers * (attn_params + mlp_params)
+shared_mlp   = moe_shared_experts * mlp_params
+moe_active   = n_moe_layers * (attn_params + moe_top_k * mlp_params + shared_mlp)
+
+active_params = dense_active + moe_active + output_params
+```
+
+Key moves:
+
+- **Active, not total, params.** Only `top_k` experts run per token, so
+  the MoE MLP contribution is `top_k * mlp_params`, not
+  `num_experts * mlp_params`.
+- **Shared experts are always on.** `shared_mlp` is added unconditionally.
+- **MoE frequency.** `(i + 1) % moe_frequency == 0` matches whichever
+  layers the config promotes to MoE; the rest stay dense.
+- **Router FLOPs ignored.** `dim × num_experts` is tiny compared to
+  `mlp_params`.
+
+The attention term (`12 * n_layers * dim * seq_len`) uses the full
+`n_layers` regardless of MoE vs dense — attention runs in every layer.
+
+## FP8 caveat
+
+`gpu_peak_tflops` is auto-detected as **bf16** peak, not fp8. For H100:
+
+- bf16 dense peak: 989 TFLOPS (reported in the table)
+- fp8 dense peak: ~1979 TFLOPS (2× bf16)
+
+If you train with [FP8](../distributed/fp8.md), the reported MFU is
+understated by a factor of ~2. Override it explicitly if that matters:
+
+```python
+tracker = MetricsTracker(
+    config, num_gpus=world_size,
+    gpu_peak_tflops=1979.0,     # fp8 peak for H100
+)
+```
+
+The opposite problem — reporting fp8 peak while the kernel actually runs
+in bf16 — gives an overstated MFU. If you're mixing precision, match the
+peak to the dominant matmul format.
+
+## GPU detection
+
+```python
+# kempnerforge/metrics/mfu.py — get_gpu_peak_tflops
+for gpu_name, tflops in _GPU_PEAK_TFLOPS.items():
+    if gpu_name in torch.cuda.get_device_name(device):
+        return tflops
+# Fallback by compute capability
+major, minor = torch.cuda.get_device_capability(device)
+if major >= 9:  return 989.0    # Hopper (H100, H200)
+elif major >= 8: return 312.0   # Ampere (A100)
+else:           return 100.0
+```
+
+Known GPUs in the table:
+
+| GPU | bf16 TFLOPS |
+|-----|-------------|
+| H100 / H100 SXM / H200 / H800 | 989 |
+| H100 PCIe | 756 |
+| A100 (any variant) | 312 |
+| L40S | 362 |
+| RTX 4090 | 330 |
+| A10G | 125 |
+| RTX 3090 | 142 |
+
+Unknown GPUs get a compute-capability-based fallback with a warning log.
+Add your GPU to `_GPU_PEAK_TFLOPS` for accurate MFU if the fallback is off.
+
+## Checking whether MFU is reasonable
+
+Rough bands on an H100 cluster (your mileage varies with batch size, seq
+length, parallelism strategy):
+
+- **< 25%** — something is wrong. Inspect the profiler for communication
+  overhead or CPU stalls.
+- **25–40%** — typical range for large models at modest batch sizes.
+- **40–55%** — well-tuned. FlashAttention working, FSDP overlap, no
+  pipeline bubbles.
+- **> 55%** — check for double-counted FLOPs (e.g. top_k forgotten in the
+  MoE denominator).
+
+## See also
+
+- [Metrics tracker](metrics-tracker.md) — where `compute_mfu` is called.
+- [Configuration § `[model]`](../configuration/config-sections.md) —
+  `n_layers`, `dim`, `n_heads`, `n_kv_heads`, `computed_ffn_hidden_dim`,
+  `moe_frequency`, `moe_top_k`, `moe_shared_experts` all feed the formula.
+- [FP8](../distributed/fp8.md) — when to override `gpu_peak_tflops`.

--- a/docs/metrics-and-profiling/profiler.md
+++ b/docs/metrics-and-profiling/profiler.md
@@ -1,0 +1,219 @@
+# Profiler
+
+[`kempnerforge/profiling/profiler.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/profiling/profiler.py)
+wraps `torch.profiler` with a schedule, a trace handler, and a
+post-training analysis that classifies kernels into matmul / comm /
+memory / other and writes a `summary.md` alongside the trace.
+
+Opt-in via config:
+
+```toml
+[profiling]
+enable     = false      # must flip to true
+start_step = 5          # profile from step 5 inclusive
+end_step   = 8          # through step 8 exclusive (3 active steps)
+trace_dir  = "profiler_traces"
+```
+
+`ProfilingConfig.__post_init__` enforces `end_step > start_step`.
+
+## Schedule
+
+```python
+# kempnerforge/profiling/profiler.py — build_profiler
+wait_steps   = max(0, config.start_step - 1)
+active_steps = config.end_step - config.start_step
+schedule(
+    wait=wait_steps,        # skip N steps
+    warmup=1,               # one warmup step (stabilizes CUDA caches)
+    active=active_steps,    # record this many
+    repeat=1,               # one cycle, then idle
+)
+```
+
+With the defaults (`start_step=5`, `end_step=8`):
+
+- Steps 1–4: `wait` — profiler idle.
+- Step 5: `warmup` — profiler running but trace discarded.
+- Steps 6–8: `active` — trace recorded.
+- Step 9+: done.
+
+Why one warmup step: CUDA kernel launches, cudnn picks, and memory-pool
+growth all stabilize in the first few steps. Without a warmup the trace
+includes one-time costs that make it look like everything is slow.
+
+Why not `repeat=N`: KempnerForge profiles once per run. If you need
+periodic snapshots, either run multiple configs or instantiate
+`torch.profiler.profile` directly.
+
+## Activities
+
+```python
+profile(
+    activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+    schedule=...,
+    on_trace_ready=tensorboard_trace_handler(str(trace_dir)),
+    record_shapes=True,
+    profile_memory=True,
+    with_stack=False,
+    with_flops=True,
+)
+```
+
+- **CPU + CUDA** — captures both sides. CPU traces catch Python overhead
+  and CPU-bound preprocessing; CUDA traces catch kernel time.
+- **`record_shapes=True`** — per-op input shapes in the trace. Required
+  for the `with_flops=True` counter to work.
+- **`profile_memory=True`** — allocations / frees appear in Perfetto as
+  memory timeline events. Useful for spotting activation spikes.
+- **`with_stack=False`** — skip Python stack capture. `True` adds
+  significant overhead and makes the trace much larger; flip only if
+  you're specifically hunting a Python-side hotspot.
+- **`with_flops=True`** — populates `evt.flops` for matmul ops, which
+  `_analyze_profiler` uses to compute achieved TFLOPS.
+
+## Loop integration
+
+```python
+# scripts/train.py
+prof = build_profiler(config.profiling, rank=rank)
+...
+if prof is not None:
+    prof.start()
+
+while step < tc.max_steps:
+    ...
+    if prof is not None:
+        prof.step()        # advance schedule after each step
+
+if prof is not None:
+    prof.stop()
+    if rank == 0:
+        print_profiler_summary(prof, trace_dir=config.profiling.trace_dir)
+```
+
+Three conditionals because profiling is entirely optional — `build_profiler`
+returns `None` when `enable=False`, and the rest of the loop no-ops.
+
+**All ranks profile**, but only rank 0 prints the summary. Each rank
+writes its own trace file to `trace_dir`, which is fine — trace
+filenames include host + PID so they don't collide.
+
+## Trace output
+
+`tensorboard_trace_handler` writes one `.pt.trace.json` per rank per
+scheduled trace to `trace_dir/`:
+
+```
+profiler_traces/
+├── node01_12345.1714838500.pt.trace.json
+├── node01_12346.1714838501.pt.trace.json
+└── ...
+```
+
+View with:
+
+```bash
+# Perfetto UI (preferred for detailed exploration)
+#   → https://ui.perfetto.dev/ → "Open trace file" → pick the .json
+
+# TensorBoard (aggregated, per-op tables)
+uv run tensorboard --logdir profiler_traces
+```
+
+Perfetto is better for zoom / search / timeline scrubbing. TensorBoard's
+profiler plugin is better for aggregate tables and kernel-level stats
+(when the plugin is installed, via `pip install torch_tb_profiler` — not
+a hard dep of KempnerForge).
+
+## `print_profiler_summary`
+
+After `prof.stop()`, rank 0 runs `print_profiler_summary(prof, trace_dir)`
+which prints three sections and writes a markdown report.
+
+### Console output
+
+- **Top CUDA kernels by total time** — `prof.key_averages().table(sort_by="cuda_time_total", row_limit=30)`.
+- **Top CUDA kernels by FLOPS** — same but `sort_by="flops", row_limit=20`.
+- **Aggregate GPU time breakdown** — totals for matmul / comm / memory /
+  other, plus achieved vs peak TFLOPS.
+
+### `summary.md`
+
+Written to `trace_dir/summary.md`. Contains three tables:
+
+- **GPU Time Breakdown** — matmul, communication, memory, other (%).
+- **Efficiency** — total FLOPS, achieved TFLOPS, peak, kernel efficiency %.
+- **Top CUDA Kernels** — top 20 by CUDA time with call count and GFLOPS.
+
+Plus a note on how to view the traces. Designed to commit into an
+experiment log.
+
+## Kernel classification
+
+`_analyze_profiler` classifies each kernel by substring matching on the
+event key (lowercased):
+
+| Category | Substrings matched |
+|----------|--------------------|
+| `matmul` | `gemm`, `mm`, `matmul`, `dot`, `bmm`, `cublas`, `nvjet`, `cutlass` |
+| `comm`   | `nccl`, `allreduce`, `allgather`, `reduce_scatter` |
+| `memory` | `memcpy`, `memset` |
+| `other`  | everything else |
+
+These are conservative — anything outside the lists (flash attention
+kernels, softmax, element-wise ops) falls into `other`. That's intentional;
+misclassifying attention as "matmul" would inflate the apparent matmul %.
+
+The breakdown is a *rough* indicator:
+
+- **High `matmul %` (>50%)** — compute-bound, MFU should be good.
+- **High `comm %` (>20%)** — communication overhead; check
+  [FSDP2](../distributed/fsdp2.md) overlap settings, tensor parallelism
+  placement, or batch size.
+- **High `other %` (>40%)** — element-wise or memory-bound kernels
+  dominate; check for small tensor shapes, un-fused ops, or Python-side
+  stalls (run with `with_stack=True` to pinpoint).
+
+## `CUDATimer` — manual region timing
+
+[`kempnerforge/profiling/cuda_timer.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/profiling/cuda_timer.py)
+provides CUDA-event-based timers for region-scoped measurement without
+the overhead of a full `torch.profiler` trace. Not used by `scripts/train.py`;
+instantiate yourself for ad-hoc timing:
+
+```python
+from kempnerforge.profiling import CUDATimer, CUDATimerCollection
+
+# Single region
+t = CUDATimer()
+t.start()
+# ... GPU work ...
+t.stop()
+print(f"took {t.elapsed_ms():.2f} ms")
+
+# Multiple regions
+timers = CUDATimerCollection(regions=["forward", "backward", "comm"])
+timers.start("forward"); loss = model(x, y); timers.stop("forward")
+timers.start("backward"); loss.backward(); timers.stop("backward")
+print(timers.elapsed_all())   # {"forward": 12.3, "backward": 8.1, "comm": 0.0}
+```
+
+Uses `torch.cuda.Event(enable_timing=True)` under the hood, so timing
+is GPU-accurate — unlike `time.perf_counter()`, which only sees the CPU
+side. `elapsed_ms()` synchronizes the stream once at read time, not per
+start/stop call — ~nanosecond overhead in the hot path.
+
+`CUDATimerCollection(..., enabled=False)` makes every method a no-op —
+useful for dropping timers in permanently without a per-step `if`.
+
+## See also
+
+- [Metrics tracker](metrics-tracker.md) — per-step metrics are always on;
+  the profiler is a deeper, trace-based alternative for a few steps.
+- [MFU](mfu.md) — per-step estimate; the profiler computes `achieved_tflops`
+  directly from kernel `evt.flops` counts, which is a useful cross-check.
+- [Memory monitor](memory-monitor.md) — snapshot-based memory debugging
+  is a complement to the profiler's inline `profile_memory=True` events.
+- [Configuration § `[profiling]`](../configuration/config-sections.md) —
+  `enable`, `start_step`, `end_step`, `trace_dir`.

--- a/docs/metrics-and-profiling/tensorboard.md
+++ b/docs/metrics-and-profiling/tensorboard.md
@@ -1,0 +1,107 @@
+# TensorBoard backend
+
+[`TensorBoardBackend`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/metrics/tracker.py)
+is the sibling to `WandBBackend` — same metric dict, local event files
+instead of a cloud run.
+
+```toml
+[metrics]
+enable_tensorboard = true
+tensorboard_dir    = "tb_logs"    # default; relative to cwd
+```
+
+Both backends can be enabled simultaneously; they don't interact.
+
+## Init is lazy
+
+```python
+# kempnerforge/metrics/tracker.py — TensorBoardBackend
+def _ensure_init(self) -> None:
+    if self._writer is not None:
+        return
+    try:
+        from torch.utils.tensorboard import SummaryWriter
+        self._writer = SummaryWriter(log_dir=self._config.tensorboard_dir)
+    except ImportError:
+        logger.warning("tensorboard not installed — disabling TensorBoard backend")
+        self._writer = False
+```
+
+`SummaryWriter(log_dir=...)` creates the directory on first use and opens
+an event file. Import happens on first log call, not at tracker
+construction — same lazy pattern as WandB.
+
+## What gets logged
+
+Every key in the backend dict becomes a scalar:
+
+```python
+def log(self, metrics: dict[str, float], step: int) -> None:
+    for key, val in metrics.items():
+        self._writer.add_scalar(key, val, global_step=step)
+```
+
+The namespaces `train/...`, `gpu/...`, `smoothed/...` become tabs in the
+TensorBoard UI.
+
+## Rank 0 only
+
+`_init_backends` gates construction on `dist.get_rank() == 0`, so only
+rank 0's training loop writes events. This avoids event-file corruption
+when multiple ranks write to the same log directory.
+
+If you want per-rank event files (e.g. for NCCL diagnostics), instantiate
+a `SummaryWriter` directly and skip the tracker — the backend plumbing
+is single-writer on purpose.
+
+## Output layout
+
+```
+tb_logs/
+├── events.out.tfevents.1714838401.node01.12345.0
+└── ...
+```
+
+View with:
+
+```bash
+uv run tensorboard --logdir tb_logs
+```
+
+## Co-location with profiler traces
+
+`[profiling].trace_dir` defaults to `profiler_traces/`. If you set both
+`tensorboard_dir` and `trace_dir` to the same path, TensorBoard will show
+both the scalar metrics and the profiler's PyTorch Profiler tab:
+
+```toml
+[metrics]
+enable_tensorboard = true
+tensorboard_dir    = "runs/7b"
+
+[profiling]
+enable    = true
+trace_dir = "runs/7b"     # same directory
+```
+
+But keeping them separate is fine — `tensorboard --logdir runs/` picks
+up both.
+
+## `close()`
+
+```python
+def close(self) -> None:
+    if self._writer and self._writer is not False:
+        self._writer.close()
+```
+
+Flushes the event file. Called from `tracker.close()` at training exit.
+
+## See also
+
+- [Metrics tracker](metrics-tracker.md) — what metrics end up in the
+  event file.
+- [Profiler](profiler.md) — traces also land in a TensorBoard-readable
+  format via `tensorboard_trace_handler`.
+- [Configuration § `[metrics]`](../configuration/config-sections.md) —
+  `enable_tensorboard` and `tensorboard_dir`.

--- a/docs/metrics-and-profiling/wandb.md
+++ b/docs/metrics-and-profiling/wandb.md
@@ -1,0 +1,129 @@
+# WandB backend
+
+[`WandBBackend`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/metrics/tracker.py)
+is opt-in. Enable it by setting two fields:
+
+```toml
+[metrics]
+enable_wandb   = true
+wandb_project  = "my-project"     # default "kempnerforge"
+wandb_run_name = "7b-debug"       # optional — wandb auto-generates one
+```
+
+The backend is constructed by `MetricsTracker._init_backends` on rank 0
+only; other ranks never touch wandb.
+
+## Init is lazy
+
+`__init__` just stashes the config — no network I/O. The first call to
+`log()` runs `_ensure_init`, which calls `wandb.init(...)` with these
+kwargs:
+
+```python
+# kempnerforge/metrics/tracker.py
+init_kwargs = {
+    "project": self._config.wandb_project,
+    "name":    self._config.wandb_run_name,
+    "resume":  "allow",
+}
+if self._config.wandb_run_id:
+    init_kwargs["id"] = self._config.wandb_run_id
+self._run = wandb.init(**init_kwargs)
+self._config.wandb_run_id = self._run.id      # write back for checkpoint
+```
+
+Two reasons for lazy init:
+
+- **Distributed setup finishes first.** By the time the first step logs,
+  process groups are built, checkpoint resume has happened, and
+  `wandb_run_id` may have been restored from the checkpoint `extra` dict.
+- **No wandb call in CI / tests.** Constructing a tracker never touches
+  the network unless a step actually logs.
+
+## Run ID and resume
+
+This is the key integration point with [Checkpointing](../checkpointing/index.md).
+On a fresh run:
+
+1. `wandb.init(...)` with no `id` → wandb mints a new run ID.
+2. `self._config.wandb_run_id = self._run.id` stores it on the live
+   `MetricsConfig`.
+3. The training loop writes it into `ckpt_extra`:
+
+   ```python
+   # scripts/train.py
+   if config.metrics.wandb_run_id:
+       ckpt_extra["wandb_run_id"] = config.metrics.wandb_run_id
+   ```
+
+   This ends up in the `train_state.extra` dict inside the checkpoint.
+
+On resume:
+
+```python
+# scripts/train.py — right after ckpt_mgr.load(...)
+if ckpt_extra_loaded.get("wandb_run_id"):
+    config.metrics.wandb_run_id = ckpt_extra_loaded["wandb_run_id"]
+```
+
+Then when tracker backends initialize lazily, `init_kwargs["id"]` carries
+the restored ID and `resume="allow"` tells wandb to reattach to that run.
+Metrics continue on the same chart rather than splitting across runs.
+
+`resume="allow"` (not `"must"`) is intentional: if the old run was
+deleted wandb-side, the flag falls back to a fresh run rather than
+crashing the job.
+
+## What gets logged
+
+Exactly the backend dict from `MetricsTracker._log_step`:
+
+```
+train/loss, train/grad_norm, train/lr,
+train/tokens_per_sec, train/mfu, train/step_time_sec,
+gpu/allocated_gb, gpu/peak_gb, gpu/reserved_gb, gpu/mem_utilization,
+smoothed/loss, smoothed/tokens_per_sec, smoothed/mfu, smoothed/step_time
+```
+
+Plus whatever dict is passed into `tracker.log_eval(...)` — eval loss,
+MoE aux loss and router utilization, per-source losses for mixtures.
+
+All scalars. No histograms, no images, no tables.
+
+## Failure modes
+
+`_ensure_init` wraps the `wandb.init(...)` call in a try/except and sets
+`self._run = False` as a sentinel on any failure:
+
+```python
+except ImportError:
+    logger.warning("wandb not installed — disabling WandB backend")
+    self._run = False
+except Exception as e:     # network, auth, quota, etc.
+    logger.warning(f"WandB init failed: {e}")
+    self._run = False
+```
+
+Subsequent `log()` calls check `if self._run is False: return` and silent
+no-op. This is the intended behavior — a flaky network or expired login
+should never crash training, just lose the logs.
+
+If you see logs going to stdout but not wandb, grep the stderr for
+`WandB init failed:` or `wandb not installed`.
+
+## `close()`
+
+Called from `tracker.close()` at the very end of training. Runs
+`wandb.finish()` which flushes pending metrics, uploads any
+`wandb.save`-queued files, and closes the run. No-op if `_run is False`.
+
+## See also
+
+- [Metrics tracker](metrics-tracker.md) — where `WandBBackend` is
+  constructed and called.
+- [TensorBoard](tensorboard.md) — the alternative backend with the same
+  metric dict.
+- [Checkpointing § Train state](../checkpointing/train-state.md) — how
+  `wandb_run_id` travels with the checkpoint.
+- [Configuration § `[metrics]`](../configuration/config-sections.md) —
+  per-field reference for `MetricsConfig`.

--- a/docs/moe/aux-loss-and-balancing.md
+++ b/docs/moe/aux-loss-and-balancing.md
@@ -1,0 +1,219 @@
+# Aux loss and balancing
+
+MoE training collapses when a handful of experts eat all the tokens
+and the rest starve — those starved experts are dead parameters.
+KempnerForge has three mechanisms to prevent that, composable depending
+on the router:
+
+| Mechanism | Router it applies to | On by default? | Config |
+|-----------|-----------------------|:--------------:|--------|
+| Switch-style auxiliary loss | `softmax_topk` | always | `moe_aux_loss_weight` |
+| Bias-based EMA balancing | `sigmoid_topk` | always | `bias_update_rate` (hardcoded 0.001) + `moe_bias_schedule` |
+| Sequence-level aux loss | `sigmoid_topk` | opt-in | `moe_sequence_aux_loss_weight` |
+| Per-expert gradient scaling | both | opt-in | `moe_gradient_scale` |
+
+## Training-loop integration
+
+Regardless of which router is active, the aux loss flows the same way:
+
+```python
+# scripts/train.py
+main_loss = cross_entropy(logits, labels)
+aux_loss  = model.get_moe_aux_loss()
+total     = main_loss + mc.moe_aux_loss_weight * aux_loss
+```
+
+`Transformer.get_moe_aux_loss()` walks every `MoEMLP` layer and sums
+`layer.mlp.aux_loss`. The coefficient `moe_aux_loss_weight`
+(default 0.01) is the knob that scales the balance pressure.
+
+For `sigmoid_topk` with no sequence aux loss, each layer's
+`aux_loss` is the scalar 0.0 — so `total = main_loss` and the
+coefficient has no effect. For `softmax_topk`, every step contributes
+a non-zero Switch-style penalty.
+
+## Softmax router — Switch-Transformer aux loss
+
+```python
+# kempnerforge/model/router.py — SoftmaxTopKRouter.forward (trimmed)
+one_hot         = F.one_hot(indices, num_classes=self.num_experts).float()
+tokens_per_exp  = one_hot.sum(dim=(0, 1))                       # (E,)
+f               = tokens_per_exp / (num_tokens * self.top_k)    # hard counts
+p               = probs.mean(dim=0)                             # soft probs
+self.aux_loss   = self.num_experts * (f * p).sum()
+```
+
+The quantity `num_experts · Σ_i f_i · p_i` is minimized when every
+expert gets `1/num_experts` of the tokens. `f_i` is detached (hard
+assignment) so no gradient flows through it; gradient flows only
+through `p_i`, lowering the gate logits for over-utilized experts.
+
+**Typical coefficient**: `moe_aux_loss_weight = 0.01`. Higher values
+(0.1) over-regularize — router gets uniform but can't specialize.
+Lower (0.001) under-regularizes — collapse risk on long runs.
+
+## Sigmoid router — bias-based balancing
+
+The `sigmoid_topk` router holds a learnable `expert_bias` parameter
+that's *added* to logits before sigmoid, and a buffer `expert_ema`
+holding running utilization:
+
+```python
+# kempnerforge/model/router.py — SigmoidTopKRouter.__init__
+self.expert_bias = nn.Parameter(torch.zeros(num_experts))
+self.register_buffer("expert_ema", torch.ones(num_experts) / num_experts)
+```
+
+Inside forward (training only):
+
+```python
+# kempnerforge/model/router.py — SigmoidTopKRouter.forward (trimmed)
+utilization = tokens_per_expert / (num_tokens * self.top_k + 1e-8)
+self.expert_ema.lerp_(utilization, 1.0 - self.ema_decay)   # ema_decay = 0.99
+
+with torch.no_grad():
+    target = 1.0 / self.num_experts
+    self.expert_bias.add_(effective_rate * (target - self.expert_ema))
+```
+
+Two moving parts:
+
+- **`expert_ema`** — exponential moving average of per-expert fraction
+  of tokens. `ema_decay = 0.99` means each step contributes 1% of the
+  current batch to the smoothed estimate.
+- **`expert_bias`** — incremented by `effective_rate · (target − ema)`.
+  Under-utilized experts (`ema < target`) get a positive nudge →
+  higher logits → more tokens next step. Over-utilized experts get a
+  negative nudge.
+
+The bias update is inside `torch.no_grad()` — the optimizer **does not
+touch it**, even though it's an `nn.Parameter`. It's a parameter only
+for DCP checkpointing and to keep it on the right device.
+
+### Bias adjustment
+
+Default `bias_update_rate = 0.001`. Not exposed in config — hardcoded
+in `SigmoidTopKRouter.__init__`. The effective rate used per step is
+modulated by the schedule:
+
+```python
+# kempnerforge/model/router.py — _effective_bias_rate
+if self.bias_schedule == "constant":
+    return rate
+progress = self._step / self._max_steps
+if self.bias_schedule == "cosine_decay":
+    return rate * 0.5 * (1 + cos(pi * progress))
+if self.bias_schedule == "linear_warmup":
+    return rate * min(1.0, progress * 10.0)   # ramp over first 10% of training
+```
+
+| `moe_bias_schedule` | Effective-rate curve | Typical use |
+|---------------------|----------------------|-------------|
+| `"constant"` (default) | flat at `rate` | standard DeepSeek-V3 |
+| `"cosine_decay"` | decays `rate → 0` over the run | late-training stability after balance is achieved |
+| `"linear_warmup"` | `0 → rate` over first 10% | cold-start stabilization when bias would otherwise overshoot |
+
+The schedule needs the current training step, which is pushed in each
+step via `model.set_moe_step(step, max_steps)` in
+`scripts/train.py`. `Transformer.set_moe_step` walks only sigmoid
+routers:
+
+```python
+# kempnerforge/model/transformer.py — set_moe_step
+for layer in self.layers.values():
+    if isinstance(layer.mlp, MoEMLP) and isinstance(layer.mlp.router, SigmoidTopKRouter):
+        layer.mlp.router.set_step(step, max_steps)
+```
+
+## Sequence-level aux loss (sigmoid only)
+
+Opt-in. When `moe_sequence_aux_loss_weight > 0`, the sigmoid router
+adds a Switch-style penalty on top of the bias mechanism:
+
+```python
+# kempnerforge/model/router.py — SigmoidTopKRouter.forward (trimmed)
+if self.sequence_aux_loss_weight > 0:
+    f = tokens_per_expert.detach() / (num_tokens * self.top_k + 1e-8)
+    p = scores.mean(dim=0)                    # differentiable through sigmoid
+    balance_loss = self.num_experts * (f * p).sum()
+    self.aux_loss = self.sequence_aux_loss_weight * balance_loss
+```
+
+Same formula as the softmax router's Switch-style loss, but with `p`
+as mean sigmoid *scores* rather than softmax probabilities. Gradient
+flows through `p` only.
+
+**When to use**: long runs (100k+ steps) where bias balancing alone
+sometimes drifts into degenerate modes. Recommended weight is much
+smaller than the softmax router's `moe_aux_loss_weight` — typical
+`0.001` (one tenth of 0.01) or lower, because the bias mechanism is
+already doing most of the balancing work.
+
+Leave `moe_aux_loss_weight` at its default 0.01 — it's the
+multiplier on `aux_loss` downstream, so the effective weight on the
+balance loss is `moe_aux_loss_weight × sequence_aux_loss_weight`.
+
+## Per-expert gradient scaling
+
+Opt-in via `moe_gradient_scale = true`. Normalizes each expert's
+output by its utilization so high-traffic experts don't dominate
+training:
+
+```python
+# kempnerforge/model/moe.py — MoEMLP._local_forward (grouped path, trimmed)
+if self.gradient_scale and self.training:
+    avg_tokens = total_assignments / max(self.num_experts, 1)
+    offset = 0
+    for count in tokens_per_expert:
+        if count > 0:
+            scale = avg_tokens / count
+            expert_out[offset:offset + count] *= scale
+        offset += count
+```
+
+An expert that receives `count` tokens has its output multiplied by
+`avg_tokens / count`. Hot experts get `scale < 1` (gradients shrunk);
+cold experts get `scale > 1` (gradients amplified). The scale passes
+through the `expert_out * sorted_weights` scatter-add, so the
+routing weights still apply on top of it.
+
+The same logic runs on the EP path (`ep_dispatch_and_compute`) using
+per-local-expert receive counts — see
+[EP § Gradient scaling](../distributed/expert-parallelism.md#gradient-scaling-optional).
+
+**Reference**: DeepSeek-V3 §3.2. Empirically small effect on short
+runs, visible on long runs where the router has converged to a
+specific usage distribution.
+
+**When to use**: long MoE training where expert utilization is
+known-imbalanced and you want gradient-magnitude parity across
+experts. Disabled by default because it changes gradient magnitudes
+and should be validated against a baseline.
+
+## Diagnosis
+
+`Transformer.get_expert_counts()` returns
+`dict[layer_idx → tensor(num_experts,)]` with the per-expert token
+count from the most recent forward. Interpretation rule-of-thumb:
+
+- **Balanced**: counts within ~20% of `num_tokens · top_k / num_experts`.
+- **Hot/cold**: one expert ≥ 2× the mean → router is specializing.
+  Fine if intentional, bad if unintentional.
+- **Dead expert**: count = 0 for many consecutive steps → that
+  expert isn't learning. Root cause is usually a too-small aux-loss
+  coefficient or a cold-start bias issue.
+
+See [MoE experiments § Hot/cold expert diagnosis](../how-to/moe-experiments.md).
+
+## See also
+
+- [Routers](routers.md) — where `aux_loss` is computed per router.
+- [Capacity and dispatch](capacity-and-dispatch.md) — what happens
+  when `capacity_factor` drops a token (the router still sees it,
+  but its weight becomes 0).
+- [Expert parallelism § Gradient scaling](../distributed/expert-parallelism.md#gradient-scaling-optional)
+  — per-expert gradient scaling on the EP path.
+- [MoE experiments](../how-to/moe-experiments.md) — recommended aux
+  loss weights per training scale.
+- [Validation rules § MoE + PP](../configuration/validation-rules.md)
+  — cross-section config checks (MoE + PP is unsupported).

--- a/docs/moe/capacity-and-dispatch.md
+++ b/docs/moe/capacity-and-dispatch.md
@@ -1,0 +1,243 @@
+# Capacity and dispatch
+
+After routing, each token has a `top_k` list of expert indices and
+weights. The dispatch layer has to:
+
+1. Optionally cap how many tokens each expert can receive
+   (`capacity_factor`).
+2. Actually run each expert on its assigned tokens — either in a
+   Python loop (sequential) or via one batched `torch._grouped_mm`
+   call (grouped GEMM).
+3. Weight-combine the expert outputs back into one tensor per token.
+
+Capacity and dispatch both live in
+[`kempnerforge/model/moe.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/moe.py).
+
+## Capacity factor
+
+```toml
+[model]
+moe_capacity_factor = 0.0   # 0 = no cap, >0 = cap per expert
+```
+
+With `capacity_factor > 0`, each expert can only accept a bounded
+number of tokens per forward:
+
+```python
+# kempnerforge/model/moe.py — _apply_capacity
+capacity = max(1, ceil(num_tokens * top_k / num_experts * capacity_factor))
+```
+
+At `capacity_factor = 1.0`, each expert gets exactly the average load.
+At `1.25`, each expert gets 25% headroom above the average — the
+canonical Switch Transformer setting. At `0.0` (default), there is
+no cap: every token goes to its top-`k` choices regardless of load.
+
+### Drop policy
+
+Tokens routed to an expert past capacity are **dropped from that
+expert** — their routing weight is set to 0:
+
+```python
+# kempnerforge/model/moe.py — _apply_capacity (trimmed)
+for k in range(top_k):
+    for e in range(num_experts):
+        assigned = (indices[:, k] == e).nonzero(as_tuple=True)[0]
+        if assigned.numel() <= capacity:
+            continue
+        drop = assigned[capacity:]
+        weights[drop, k] = 0.0
+```
+
+"First `capacity` tokens wins" — tokens are kept in sequence order,
+later tokens get dropped. If a token's *only* chosen expert is
+overloaded, the token contributes nothing to the MoE output — but
+the residual connection still carries it through unchanged:
+
+```python
+# kempnerforge/model/transformer.py — TransformerBlock.forward
+x = x + self.mlp(self.mlp_norm(x))   # MoE output + residual
+```
+
+So a dropped token is not an error — it passes through the layer
+as if it skipped the MLP entirely.
+
+### When to use capacity
+
+**With EP**: sometimes necessary. All-to-all buffers are sized for
+the *worst-case* token distribution. Without a cap, one rank can
+overflow its dispatch buffer when many tokens happen to prefer
+experts on that rank. A capacity factor of 1.25 bounds the buffer
+size predictably.
+
+**Without EP**: usually leave at 0. All experts live on the same
+rank and the sequential/grouped path handles any distribution.
+Setting a cap just costs throughput.
+
+**Caveats**: the inner loop is O(num_experts × top_k) Python and
+non-vectorized. At `num_experts = 64 × top_k = 8 = 512` Python
+iterations per forward, it starts to show on profile. Okay for the
+scale MoE runs we've tested; watch for it at 128+ experts.
+
+## Dispatch: two compute paths
+
+The dispatch happens in `MoEMLP._local_forward`. There are two paths
+guarded by a feature check:
+
+```python
+# kempnerforge/model/moe.py — module-level
+_HAS_GROUPED_MM = hasattr(torch, "_grouped_mm")
+_GROUPED_MM_DTYPES = {torch.bfloat16, torch.float16}
+```
+
+`torch._grouped_mm` exists in recent PyTorch (2.5+) but requires
+bf16/fp16 inputs — the meta registration rejects fp32.
+
+### Path A: grouped GEMM (bf16/fp16)
+
+The fast path when available:
+
+```python
+# kempnerforge/model/moe.py — grouped_expert_forward (trimmed)
+x_padded = x_sorted.new_zeros(num_experts, max_tokens, dim)
+# ... pack per-expert token groups into (E, max_tokens, dim) with padding ...
+if is_swiglu:
+    gate    = torch._grouped_mm(x_padded, gate_w)     # (E, M, H)
+    up      = torch._grouped_mm(x_padded, up_w)       # (E, M, H)
+    hidden  = F.silu(gate) * up
+else:
+    hidden  = torch._grouped_mm(x_padded, up_w)
+    hidden  = activation(hidden)
+out_padded  = torch._grouped_mm(hidden, down_w)       # (E, M, dim)
+```
+
+Three batched matmuls for SwiGLU (gate + up + down) or two for
+standard MLP (up + down). The `(E, max_tokens, dim)` padding is
+wasted compute — if one expert gets 100 tokens and another gets 2,
+both tensors sit at `max_tokens=100` padded. Imbalanced routing
+amplifies this.
+
+Implementation detail: the padding is also why capacity factor
+helps throughput under EP. Bounded max per expert ⇒ bounded
+padding ⇒ predictable compute.
+
+### Path B: sequential loop (fp32)
+
+Fallback when grouped GEMM can't run:
+
+```python
+# kempnerforge/model/moe.py — MoEMLP._local_forward (trimmed)
+for i in range(self.num_experts):
+    mask = (indices == i).any(dim=-1)
+    if not mask.any():
+        continue
+    expert_input   = x_flat[mask]
+    expert_output  = self.experts[i](expert_input)
+    weight_for_i   = (weights * (indices == i).float()).sum(dim=-1)
+    output[mask]  += weight_for_i[mask].unsqueeze(-1) * expert_output
+```
+
+One kernel launch per expert (or more, per matmul). Fine for
+`num_experts ≤ 8`, painful at 32+.
+
+**Rule of thumb**: if you're in fp32, you're not doing real MoE
+training. The fallback exists for unit-testing and debugging the
+grouped path without a CUDA device. Production runs use bf16
+(default) or fp16, both of which hit the grouped path.
+
+## Packed experts
+
+Opt-in via `moe_packed_experts = true`. Replaces the `nn.ModuleList`
+of experts with three packed `nn.Parameter` tensors of shape
+`(num_experts, dim, hidden)`:
+
+```python
+# kempnerforge/model/moe.py — MoEMLP.__init__ (trimmed)
+self.up_w   = nn.Parameter(stack(e.up_proj.weight.t()   for e in experts))
+self.down_w = nn.Parameter(stack(e.down_proj.weight.t() for e in experts))
+self.gate_w = nn.Parameter(stack(e.gate_proj.weight.t() for e in experts))  # SwiGLU
+```
+
+Grouped GEMM consumes these directly via
+`grouped_expert_forward_packed` — no per-step `torch.stack` over the
+`ModuleList`, and FSDP2 wraps three tensors instead of `3 × E`.
+
+Measured impact (see
+[Benchmark § MoE Expert Packing](https://github.com/KempnerInstitute/KempnerForge/blob/main/benchmarks/moe_packed/moe_packed_benchmark.md)):
+
+| Experts | Unpacked tok/s | Packed tok/s | Delta |
+|:-------:|---------------:|-------------:|:-----:|
+| 8  | 48,521 | 50,972 | +5.1% |
+| 16 | 26,994 | 36,860 | +36.5% |
+| 64 | 1,796  | 2,204  | +22.7% |
+
+The speedup grows with `num_experts` — the per-step `torch.stack`
+cost (in unpacked mode) scales with E, so eliminating it matters more
+as E grows. Peak memory is approximately the same.
+
+**Default is off** because EP integration (slicing packed weights
+along the expert axis) is newer than the unpacked path. Flip it on for
+MoE runs with ≥ 16 experts.
+
+## Output combine
+
+Both paths end in a weighted scatter-add back to the token axis:
+
+```python
+# kempnerforge/model/moe.py — _local_forward (grouped path, trimmed)
+expert_out = expert_out * sorted_weights.unsqueeze(-1)
+output = torch.zeros(num_tokens, dim, dtype=x_flat.dtype, device=x_flat.device)
+output.scatter_add_(0, sorted_token_ids.unsqueeze(-1).expand_as(expert_out), expert_out)
+```
+
+Dropped tokens (weight=0) contribute 0 here. Tokens with multiple
+experts (top-k > 1) get a sum of weighted outputs — the same token
+appears in `top_k` sorted-positions, and each contribution is added.
+
+After `_local_forward` returns, the shared expert (if any) is added:
+
+```python
+# kempnerforge/model/moe.py — MoEMLP.forward
+if self.shared_expert is not None:
+    output = output + self.shared_expert(x_flat)
+```
+
+Shared expert runs on *every* token, dense-style. It's additive, not
+part of the top-k selection.
+
+## EP branching
+
+When `ep_world_size > 1`, `MoEMLP.forward` bypasses `_local_forward`
+and calls `ep_dispatch_and_compute` from
+`kempnerforge/distributed/expert_parallel.py`:
+
+```python
+# kempnerforge/model/moe.py — MoEMLP.forward (trimmed)
+if self.ep_world_size > 1:
+    output = ep_dispatch_and_compute(
+        x_flat, weights, indices, self,
+        self.ep_group, self.local_expert_start,
+        self.num_local_experts, self.ep_world_size,
+        gradient_scale=self.gradient_scale,
+    )
+else:
+    output = self._local_forward(x_flat, weights, indices)
+```
+
+The capacity factor still applies before this branch — the `weights`
+tensor handed to `ep_dispatch_and_compute` has dropped-token weights
+already zeroed. See
+[Expert parallelism § Dispatch / combine flow](../distributed/expert-parallelism.md#dispatch--combine-flow)
+for the all-to-all mechanics.
+
+## See also
+
+- [Routers](routers.md) — where `(weights, indices)` come from.
+- [Aux loss and balancing](aux-loss-and-balancing.md) — `moe_gradient_scale`
+  lives on the dispatch path.
+- [Expert parallelism](../distributed/expert-parallelism.md) — the EP
+  branch of `MoEMLP.forward`.
+- [Benchmarks § MoE Expert Parallelism](../reference/benchmarks.md#moe-expert-parallelism)
+  — measured EP throughput with these dispatch paths.
+- [MoE experiments § Capacity factor](../how-to/moe-experiments.md)
+  — when to set `moe_capacity_factor > 0`.

--- a/docs/moe/index.md
+++ b/docs/moe/index.md
@@ -1,0 +1,85 @@
+# Mixture of Experts
+
+KempnerForge's MoE implementation covers Mixtral-style (softmax top-k,
+Switch aux loss) and DeepSeek-V3-style (sigmoid top-k with bias-based
+balancing) routing. Everything MoE-specific lives under
+[`kempnerforge/model/moe.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/moe.py)
+and
+[`kempnerforge/model/router.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/router.py);
+the distributed mechanics (all-to-all, expert parallelism) live under
+{doc}`../distributed/index`.
+
+## What's on this section
+
+- [**Routers**](routers.md) — `softmax_topk` vs `sigmoid_topk`, registry
+  selection, shared-expert composition.
+- [**Aux loss and balancing**](aux-loss-and-balancing.md) — Switch-style
+  aux loss, bias-based EMA balancing, sequence-level aux loss,
+  per-expert gradient scaling.
+- [**Capacity and dispatch**](capacity-and-dispatch.md) — capacity
+  factor, token drop policy, grouped GEMM vs sequential path, packed
+  experts.
+- [**MoE + FP8**](moe-fp8.md) — which Linears get excluded from Float8
+  conversion and why.
+
+## Config at a glance
+
+| Field | Default | What it controls |
+|-------|---------|------------------|
+| `num_experts` | `0` | `>0` enables MoE layers |
+| `moe_top_k` | `2` | Number of experts each token routes to |
+| `moe_router` | `"softmax_topk"` | Router type (see [Routers](routers.md)) |
+| `moe_frequency` | `1` | Every Nth layer is MoE; others are dense |
+| `moe_shared_experts` | `0` | Dense expert applied to every token on top of routed |
+| `moe_capacity_factor` | `0.0` | `>0` caps tokens per expert (see [Capacity and dispatch](capacity-and-dispatch.md)) |
+| `moe_aux_loss_weight` | `0.01` | Coefficient on `aux_loss` added to main loss |
+| `moe_packed_experts` | `false` | Packed weight tensors instead of `ModuleList` |
+| `moe_gradient_scale` | `false` | Per-expert output scaling by utilization |
+| `moe_sequence_aux_loss_weight` | `0.0` | Sigmoid-only: sequence-level balance penalty |
+| `moe_bias_schedule` | `"constant"` | Sigmoid-only: bias update rate schedule |
+
+All fields live in
+[`kempnerforge/config/model.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/model.py)
+(`ModelConfig`).
+
+## MoE layer placement
+
+`moe_frequency = 1` makes every transformer block an MoE block.
+`moe_frequency = 2` alternates dense / MoE layers, matching the
+DeepSeek-V2/V3 recipe. The dense layers use a plain `SwiGLUMLP`; only
+the MoE blocks hit the routing, dispatch, and aux-loss machinery on
+this section.
+
+## Cross-section constraints
+
+- **MoE + TP on experts**: not supported. Expert weights stay replicated
+  across the TP group.
+- **MoE + PP**: not supported — the config validator raises in
+  `JobConfig.__post_init__`.
+- **MoE + EP**: supported. `num_experts` must be divisible by
+  `ep_world_size`. See
+  [Expert parallelism](../distributed/expert-parallelism.md).
+- **MoE + FP8**: supported with exclusions. Experts, shared expert, and
+  router gate stay bf16 — [MoE + FP8](moe-fp8.md).
+
+## Pages
+
+```{toctree}
+:maxdepth: 1
+
+routers
+aux-loss-and-balancing
+capacity-and-dispatch
+moe-fp8
+```
+
+## See also
+
+- [Expert parallelism](../distributed/expert-parallelism.md) — the
+  all-to-all dispatch/combine used when `ep_world_size > 1`.
+- [MoE experiments](../how-to/moe-experiments.md) — end-to-end workflow
+  and diagnosis recipes.
+- [Validation rules](../configuration/validation-rules.md) — cross-section
+  config checks (MoE + PP unsupported, `num_experts % ep == 0`).
+- [Benchmarks § MoE Expert Parallelism](../reference/benchmarks.md#moe-expert-parallelism)
+  — measured throughput across EP sizes.

--- a/docs/moe/moe-fp8.md
+++ b/docs/moe/moe-fp8.md
@@ -1,0 +1,149 @@
+# MoE + FP8
+
+FP8 training (via `torchao.float8`) converts dense `nn.Linear` modules
+to `Float8Linear`. Three classes of Linear in an MoE model get
+**excluded** from that conversion:
+
+1. Routed experts (`experts.*`)
+2. Shared expert (`shared_expert.*`)
+3. Router gate (`router.gate`)
+
+Everything else — attention projections, output head, dense-layer
+MLPs — converts normally.
+
+## Filter rule
+
+From
+[`apply_float8`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/parallel.py):
+
+```python
+# kempnerforge/distributed/parallel.py — apply_float8._filter_fn
+def _filter_fn(module, fqn):
+    if "experts" in fqn or "shared_expert" in fqn:
+        return False
+    return "router" not in fqn
+```
+
+`convert_to_float8_training` walks the model, asks the filter for
+each `Linear`, and only replaces the module when the filter returns
+True.
+
+## Why experts are excluded
+
+The grouped GEMM path uses `torch._grouped_mm`, which is a distinct
+kernel from `torch._scaled_mm` (what `Float8Linear.forward` calls
+into). Even if an expert's `nn.Linear` *were* wrapped in `Float8Linear`,
+the wrap would be bypassed:
+
+- The forward path stacks per-expert weights into a single
+  `(E, dim, hidden)` tensor (or reads them from pre-packed
+  parameters) and calls `torch._grouped_mm` directly.
+- `Float8Linear.forward` is never called on the expert weights.
+
+The result would be FP8 *parameter storage* but bf16 *compute* — the
+worst of both worlds (lost precision at storage, no matmul speedup).
+
+See [Capacity and dispatch § Path A](capacity-and-dispatch.md#path-a-grouped-gemm-bf16fp16)
+for the grouped GEMM call site.
+
+## Why the router is excluded
+
+Two reasons:
+
+1. **Tiny output dim.** Router gate is `Linear(dim, num_experts)`.
+   `num_experts` is typically 8-64 — not divisible by 16, which
+   `torch._scaled_mm` requires for its fast path. Fallback paths
+   give no speedup.
+2. **Not compute-bound.** Routing is essentially a decision — the
+   gate matmul is a tiny fraction of total FLOPs. FP8 quantization
+   error on the routing decision could measurably perturb which
+   experts get picked, which is a stability risk.
+
+## Why the shared expert is excluded
+
+Same reason as routed experts. The shared expert is a `SwiGLUMLP` (or
+`StandardMLP`) with identical weight shapes to a routed expert — it
+runs through the same grouped-GEMM path when that path is active (on
+the dense forward side it's a plain `Linear` call, but convention
+keeps it FP8-excluded for consistency).
+
+In practice the shared expert runs on every token (not dispatched),
+so it *could* use `Float8Linear`. The decision to exclude it is
+conservative: keep the expert codepaths uniform, avoid a surprise if
+the shared expert is later routed through the grouped path.
+
+## What stays FP8
+
+Everything not caught by the three filter rules:
+
+| Module | Converted | FQN pattern |
+|--------|:---------:|-------------|
+| Attention Q/K/V/O | yes | `*.attention.{q_proj,k_proj,v_proj,o_proj}` |
+| Dense MLP gate/up/down | yes | `*.mlp.{gate_proj,up_proj,down_proj}` (dense layers only) |
+| Output head | yes | `output_head.proj` |
+| Router gate | no | `*.router.gate` |
+| Routed experts | no | `*.experts.*.{gate,up,down}_proj` |
+| Shared expert | no | `*.shared_expert.*` |
+| Embeddings | no | not `Linear` |
+| RMSNorm | no | not `Linear` |
+
+With `moe_frequency = 2` (alternating dense / MoE layers), the dense
+layers' MLPs get FP8 and the MoE layers' MLPs don't — which is fine,
+because the MoE layers' compute is dominated by grouped GEMM on the
+expert weights anyway.
+
+## Memory and throughput
+
+Excluding expert Linears means FP8 gives smaller gains for MoE than
+for dense training. A 4B-active MoE where half the FLOPs are in
+grouped-GEMM experts sees FP8 speedup only on the remaining half
+(attention + shared expert + output head + dense-layer MLPs).
+
+For the 7B dense Llama reference (see
+[Benchmarks § MFU scaling](../reference/benchmarks.md#mfu-scaling-dense)),
+FP8 provides a measurable throughput lift at 16 GPUs. For MoE runs,
+the same config would see a smaller lift because the expert portion
+of compute runs at bf16 regardless.
+
+## Config
+
+One switch:
+
+```toml
+[train]
+mixed_precision = "fp8"   # flips the conversion on
+```
+
+No separate MoE knob. The expert/router exclusions are hardcoded in
+`_filter_fn`. If you want to experiment with FP8 on a specific
+expert path — for example, trying FP8 on the shared expert — you'd
+edit `apply_float8` directly.
+
+## FP8 + EP + TP: what actually composes
+
+Three separate constraints:
+
+- **FP8 + TP**: Not supported.
+  [`JobConfig.__post_init__`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/job.py)
+  raises when `train.mixed_precision = "fp8"` and `distributed.tp > 1`.
+  Reason: `Float8Linear`'s weight wrapper calls `aten.is_pinned` on
+  DTensor, which has no sharding strategy yet. See
+  [FP8 § TP incompatibility](../distributed/fp8.md#tp-incompatibility).
+- **FP8 + EP**: Fine. Experts are excluded from FP8, so EP — which
+  operates on experts — is orthogonal to the conversion.
+- **FP8 + MoE without EP**: Fine. Non-expert Linears convert, expert
+  Linears stay bf16, grouped GEMM continues to work.
+
+## See also
+
+- [FP8](../distributed/fp8.md) — the canonical FP8 reference (full
+  conversion details, `enable_fsdp_float8_all_gather`, master weights,
+  hardware requirements).
+- [Expert parallelism § EP + FP8](../distributed/expert-parallelism.md#composition-with-other-parallelisms)
+  — EP compatibility notes with FP8.
+- [Capacity and dispatch § Path A](capacity-and-dispatch.md#path-a-grouped-gemm-bf16fp16)
+  — the grouped-GEMM path that bypasses `Float8Linear`.
+- [Parallelism order § Float8 before AC and FSDP](../architecture/parallelism-order.md)
+  — where FP8 conversion sits in the apply sequence.
+- [Validation rules](../configuration/validation-rules.md) — the
+  FP8 + TP config check.

--- a/docs/moe/routers.md
+++ b/docs/moe/routers.md
@@ -1,0 +1,160 @@
+# Routers
+
+KempnerForge ships two routers, registered under the `"router"` category
+of the component registry:
+
+| Registry key | Class | Style |
+|--------------|-------|-------|
+| `softmax_topk` | [`SoftmaxTopKRouter`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/router.py) | Mixtral — softmax probabilities + Switch-Transformer aux loss |
+| `sigmoid_topk` | [`SigmoidTopKRouter`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/router.py) | DeepSeek-V3 — per-expert sigmoid scores + learnable bias balancing |
+
+Both produce the same output shape — `(weights, indices)` of shape
+`(num_tokens, top_k)` — so `MoEMLP` works with either. They differ in
+*how* load balancing is maintained and *what* loss signal (if any) gets
+added to the training loss.
+
+## `SoftmaxTopKRouter` — Mixtral-style
+
+```python
+# kempnerforge/model/router.py — forward
+logits = self.gate(x)                                # (T, E)
+probs  = F.softmax(logits, dim=-1)                   # (T, E)
+weights, indices = torch.topk(probs, k=self.top_k)   # (T, K)
+weights = weights / weights.sum(dim=-1, keepdim=True)
+```
+
+Each token gets softmax probabilities over all experts; the top `K`
+are kept and renormalized. The auxiliary load-balancing loss is
+Switch-Transformer's:
+
+```
+L_aux = num_experts · Σ_i (f_i · P_i)
+```
+
+where `f_i` is the fraction of tokens assigned to expert *i* (hard
+counts, detached) and `P_i` is the mean softmax probability for
+expert *i* (differentiable through the gate). Gradient flows through
+`P_i` and pushes the gate to lower scores for over-utilized experts.
+
+`self.aux_loss` is updated on every forward; the training loop picks
+it up via `Transformer.get_moe_aux_loss()` and adds
+`moe_aux_loss_weight · aux_loss` to the main loss (see
+[Aux loss and balancing](aux-loss-and-balancing.md)).
+
+**Use when**: default, Mixtral-style runs, or when you want the
+balancing signal explicit in the loss. The aux loss coefficient is
+well-studied territory (Switch set 0.01, Mixtral uses similar).
+
+## `SigmoidTopKRouter` — DeepSeek-V3 style
+
+```python
+# kempnerforge/model/router.py — forward
+logits = self.gate(x)                                # (T, E)
+scores = torch.sigmoid(logits + self.expert_bias)    # (T, E) — bias added
+weights, indices = torch.topk(scores, k=self.top_k)
+weights = weights / weights.sum(dim=-1, keepdim=True)
+```
+
+Three things differ from the softmax router:
+
+1. **Sigmoid, not softmax.** Expert scores are independent per expert —
+   no competition for normalization. Raising expert *i*'s score doesn't
+   lower expert *j*'s.
+2. **`expert_bias` is a learnable `nn.Parameter`** added to the logits
+   before sigmoid. It's *not* updated by the optimizer — the training
+   loop adjusts it manually via an EMA of per-expert utilization (see
+   [Aux loss and balancing § Bias adjustment](aux-loss-and-balancing.md#bias-adjustment)).
+3. **No auxiliary loss by default.** `self.aux_loss = 0.0` unless
+   `sequence_aux_loss_weight > 0` (opt-in lightweight balance penalty,
+   covered on the aux-loss page).
+
+The claim from DeepSeek-V3 is that bias-based balancing reaches
+uniform expert utilization without injecting a balance-loss gradient
+into the main loss — so the routed experts learn a slightly cleaner
+signal. Empirically both approaches train; the sigmoid router is the
+one you pick when chasing DeepSeek-V3's recipe specifically.
+
+**Use when**: DeepSeek-V3 reproduction, or long MoE runs where
+auxiliary-loss coefficient tuning is annoying and you want the
+balancer off the main loss path.
+
+## Side effects
+
+Both routers store two tensors as forward-time side effects:
+
+```python
+self.aux_loss:       torch.Tensor  # scalar, picked up by Transformer.get_moe_aux_loss()
+self.expert_counts:  torch.Tensor  # (num_experts,), picked up by get_expert_counts()
+```
+
+`expert_counts` holds per-expert token counts (hard, detached) for the
+most recent forward. It's how hot/cold expert diagnosis works — see
+[MoE experiments § Hot/cold expert diagnosis](../how-to/moe-experiments.md).
+
+## Builders
+
+Builders live in the same file and are registered at import time:
+
+```python
+# kempnerforge/model/router.py
+def _build_softmax_topk(dim, num_experts, top_k): ...
+def _build_sigmoid_topk(dim, num_experts, top_k, **kwargs): ...
+
+registry.register("router", "softmax_topk", _build_softmax_topk)
+registry.register("router", "sigmoid_topk", _build_sigmoid_topk)
+```
+
+Selection is config-driven:
+
+```toml
+[model]
+num_experts = 8
+moe_top_k   = 2
+moe_router  = "sigmoid_topk"   # or "softmax_topk" (default)
+```
+
+[`build_moe()`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/moe.py)
+forwards the right kwargs to whichever router is selected (only
+`sigmoid_topk` consumes `sequence_aux_loss_weight` and
+`bias_schedule`).
+
+## Shared experts
+
+Independent of the router. When `moe_shared_experts > 0`, a
+`SwiGLUMLP`-style expert runs on **every token** and its output is
+*added* to the routed experts' weighted sum:
+
+```python
+# kempnerforge/model/moe.py — MoEMLP.forward
+output = routed_experts_forward(...)        # (B, L, D) from top-k routing
+if self.shared_expert is not None:
+    output = output + self.shared_expert(x_flat)
+```
+
+DeepSeek's original motivation: the shared expert absorbs the
+"universal" capacity so routed experts can specialize. In practice,
+`moe_shared_experts=1` with `sigmoid_topk` reproduces the DeepSeek-V3
+pattern; `0` (the default) is Mixtral-style "all experts are routed."
+
+## Picking a router
+
+|  | `softmax_topk` | `sigmoid_topk` |
+|---|---|---|
+| Balance mechanism | Auxiliary loss adds a term to main loss | EMA-driven bias adjustment; no loss term (by default) |
+| Coefficient to tune | `moe_aux_loss_weight` (typical 0.01) | `bias_update_rate` (0.001 default) + optional `sequence_aux_loss_weight` |
+| Best for | Mixtral baseline, pre-tuned aux-loss recipes | DeepSeek-V3 reproduction, minimal main-loss interference |
+| Aux-loss-free | No — aux loss always non-zero | Yes by default |
+| Shared experts | Works, but less common in published recipes | Standard DeepSeek pattern (`moe_shared_experts = 1`) |
+
+## See also
+
+- [Aux loss and balancing](aux-loss-and-balancing.md) — how the two
+  routers' balance signals flow into training.
+- [Capacity and dispatch](capacity-and-dispatch.md) — what happens to
+  the `(weights, indices)` tuple after routing.
+- [MoE + FP8](moe-fp8.md) — why `router.gate` is excluded from
+  Float8 conversion.
+- [Registry](../configuration/registry.md) — how the `"router"`
+  category fits with the other 6 registry categories.
+- [MoE experiments](../how-to/moe-experiments.md) — end-to-end
+  workflow using one or both routers.

--- a/docs/reference/available-configs.md
+++ b/docs/reference/available-configs.md
@@ -1,0 +1,83 @@
+# Available configs
+
+The
+[`configs/train/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/configs/train)
+directory ships 17 training presets. Most are named
+`<model>_<gpu-count>_<parallelism>.toml` so the filename doubles as a
+recipe. The
+[`configs/model/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/configs/model)
+directory ships 4 model-only presets used by
+[`scripts/convert_checkpoint.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/convert_checkpoint.py)
+for DCP ↔ HuggingFace conversion.
+
+## Dense training configs
+
+| File | Purpose | Model | GPUs | Parallelism | Notes |
+|------|---------|-------|-----:|-------------|-------|
+| [`debug.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/debug.toml) | Tiny model, fast smoke test | 256-dim, 4-layer | 1+ | FSDP (`dp_shard=-1`) | 100 steps, `compile_model=false`, `act_ckpt="none"` |
+| [`hf_wikitext.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/hf_wikitext.toml) | End-to-end HuggingFace streaming | 512-dim, 8-layer | 1+ | FSDP (`dp_shard=-1`) | GPT-2 tokenizer, `wikitext-103-raw-v1`, 500 steps |
+| [`7b.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b.toml) | General-purpose Llama-3 7B | 7B | any | FSDP (`dp_shard=-1`) | 100K steps, `compile_model=true`, full AC |
+| [`7b_32gpu_fsdp.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_32gpu_fsdp.toml) | Baseline multi-node 7B | 7B | 32 | pure FSDP | 2M tokens/step, simplest multi-node recipe |
+| [`7b_12gpu_tp4.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_12gpu_tp4.toml) | 7B with intra-node TP | 7B | 12 | TP=4 × FSDP=3 | TP within node (NVLink), FSDP across (IB) |
+| [`7b_16gpu_adamw.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_adamw.toml) | Long preemptible 7B run | 7B | 16 | FSDP (`dp_shard=-1`) | 100K steps, 210B tokens, ckpt every 500 steps |
+| [`7b_16gpu_fp8.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_fp8.toml) | FP8 compute + FSDP2 float8 AG | 7B | 16 | FSDP (`dp_shard=-1`) | `mixed_precision="fp8"`, E4M3 fwd / E5M2 bwd |
+| [`7b_16gpu_muon.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_muon.toml) | Muon optimizer + z-loss + chunked CE | 7B | 16 | FSDP (`dp_shard=-1`) | Tests Muon, chunked cross-entropy, z-loss together |
+| [`13b_24gpu_validation.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/13b_24gpu_validation.toml) | Full-stack validation run | 13B | 24 | TP=4 × FSDP=6 | WandB, profiling, eval, HF tokenizer, 1000 steps |
+| [`13b_32gpu_tp4_pp2.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/13b_32gpu_tp4_pp2.toml) | 13B with pipeline parallel | 13B | 32 | TP=4 × PP=2 × FSDP=4 | 40 layers → 20 per PP stage, `1f1b` schedule |
+| [`29b_32gpu_tp4_pp2.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/29b_32gpu_tp4_pp2.toml) | Custom 29B sized for H200 140GB | 29B | 32 | TP=4 × PP=2 × FSDP=4 | `dim=6144`, 56 layers, saturates 120 GB/GPU |
+| [`70b_32gpu_tp4.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/70b_32gpu_tp4.toml) | 70B without PP bubble | 70B | 32 | TP=4 × FSDP=8 | No PP — fits via FSDP sharding alone |
+| [`70b_32gpu_tp4_pp4.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/70b_32gpu_tp4_pp4.toml) | 70B when memory is tight | 70B | 32 | TP=4 × PP=4 × FSDP=2 | 80 layers → 20 per PP stage, less FSDP sharding |
+
+## MoE training configs
+
+| File | Purpose | Model | GPUs | Parallelism | MoE |
+|------|---------|-------|-----:|-------------|-----|
+| [`debug_moe.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/debug_moe.toml) | Tiny MoE smoke test | 256-dim, 4-layer | 1+ | FSDP (`dp_shard=-1`) | 4 experts, top-2, `moe_frequency=2` |
+| [`moe_8gpu_stress.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/moe_8gpu_stress.toml) | Saturate 2 nodes with MoE | ~4B total / 1.8B active | 8 | TP=4 × FSDP=2 | 8 experts, top-2, `moe_frequency=1` |
+| [`moe_24gpu.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/moe_24gpu.toml) | 24-GPU MoE stress test | ~7B total / 1.8B active | 24 | TP=4 × FSDP=6 | 8 experts, top-2, `grad_accum=32` for full saturation |
+| [`moe_ep_32gpu.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/moe_ep_32gpu.toml) | MoE + Expert Parallel | ~4B total / 1.8B active | 32 | TP=4 × EP=2 × FSDP=4 | 8 experts, top-2, all-to-all across IB |
+
+See the [MoE Expert Parallel benchmark](benchmarks.md#moe-expert-parallelism)
+for the numbers the last config produced.
+
+## Model-only configs
+
+These don't include training fields — they're loaded by
+[`scripts/convert_checkpoint.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/convert_checkpoint.py)
+to describe the architecture when round-tripping checkpoints to
+HuggingFace.
+
+| File | Architecture |
+|------|-------------|
+| [`llama_7b.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/model/llama_7b.toml) | `dim=4096`, 32 layers, 32 heads, 8 kv-heads, `ffn_dim_multiplier=1.3` |
+| [`llama_13b.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/model/llama_13b.toml) | `dim=5120`, 40 layers, 40 heads, 8 kv-heads, `ffn_dim_multiplier=1.3` |
+| [`llama_70b.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/model/llama_70b.toml) | `dim=8192`, 80 layers, 64 heads, 8 kv-heads, `ffn_hidden_dim=28672` |
+| [`moe_small.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/model/moe_small.toml) | `dim=2048`, 24 layers, 16 heads, 4 kv-heads, 8 experts top-2 |
+
+## Conventions
+
+- **`dp_shard = -1`** in a config means "fill the remaining mesh
+  dimension with FSDP" — the loader resolves this to
+  `world_size / (dp_replicate·tp·pp·cp·ep)`. Most single-dimension
+  configs (7B, FP8, Muon, debug) use `-1` so the same config works on
+  any GPU count.
+- **`compile_model = false`** is set on every MoE config. Routing
+  produces data-dependent shapes that break `torch.compile`'s graph —
+  [`JobConfig.validate(world_size)`](../configuration/validation-rules.md)
+  logs a warning (not an error) if you combine them.
+- **Paths in these configs** (`dataset_path = "/path/to/..."`) are
+  placeholders — replace them with a real tokenized shard directory
+  before running. The `hf_wikitext.toml` config is the only one that
+  runs end-to-end without path edits (it streams from the HF Hub).
+- **Short `max_steps`** (20–100) in the multi-node configs is a
+  benchmark-sizing default, not a training budget. Override with
+  `--train.max_steps=…` for real runs.
+
+## See also
+
+- [Parallelism recipes](parallelism-recipes.md) — same data, indexed
+  by (model, GPU count) rather than by filename.
+- [Benchmarks](benchmarks.md) — measured throughput for the configs
+  that were benchmarked end-to-end.
+- [Config sections](../configuration/config-sections.md) — the fields
+  every TOML key maps to.

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -1,0 +1,132 @@
+# Benchmarks
+
+Two benchmark reports live under
+[`benchmarks/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/benchmarks)
+in the repo. Each is a standalone markdown report with numbers,
+reproduction commands, and the shell script that produced them.
+
+## MFU scaling (dense)
+
+Report:
+[`benchmarks/mfu_scaling/mfu_scaling.md`](https://github.com/KempnerInstitute/KempnerForge/blob/main/benchmarks/mfu_scaling/mfu_scaling.md).
+Driver:
+[`benchmarks/mfu_scaling/mfu_bench.sh`](https://github.com/KempnerInstitute/KempnerForge/blob/main/benchmarks/mfu_scaling/mfu_bench.sh).
+
+14 experiments across 7B / 13B / 70B Llama-3 on 1–32 H200s (8 nodes ×
+4 H200 141 GB). bf16, full activation checkpointing, fused AdamW,
+cosine LR, `seq_len=4096`. Steady-state MFU averaged over the last 5
+of 20 steps.
+
+### Best MFU by GPU count
+
+| GPUs | Best config | MFU | tok/s |
+|-----:|-------------|----:|------:|
+| 1 | 7B, single GPU | 57.8% | 10,471 |
+| 2 | 7B, FSDP=2 | 51.7% | 18,728 |
+| 4 | 7B, FSDP=4 | 53.8% | 38,983 |
+| 8 | 13B, FSDP=8 | 44.4% | 35,405 |
+| 16 | 13B, TP=4+FSDP=4 | 33.7% | 53,814 |
+| 32 | 13B, TP=4+FSDP=8 | 32.7% | 104,309 |
+
+### Headline observations
+
+- **FSDP dominates when memory allows.** At 4 GPUs on 7B, pure FSDP
+  hits 53.8% MFU, vs 34.7% for pure TP=4 and 35.9% for TP=2+FSDP=2.
+  TP fires all-gather/reduce-scatter on every matmul; FSDP fires once
+  per step.
+- **Biggest scaling cliff is the first inter-node hop.** 7B drops from
+  93% linear efficiency at 4 GPUs (intra-node NVLink) to 53% at 8 GPUs
+  (inter-node IB). Subsequent scaling (8→32) degrades gradually,
+  53%→47%.
+- **Larger models scale better past 8 GPUs.** At 32 GPUs the 7B model
+  uses only 27.6 GB of 140 GB and hits 26.9% MFU; 13B uses 36.3 GB and
+  hits 32.7% MFU; 70B (with TP=4+FSDP=8) fits at 93.2 GB and holds
+  25.4% MFU. Compute-to-communication ratio is the lever.
+- **70B needs TP.** Pure FSDP can't shard 70B enough to fit on H200s
+  without activation-checkpoint-aware sharding of attention; TP=4
+  across a node cuts the per-GPU attention and MLP state by 4×.
+
+### Reproduction
+
+```bash
+salloc -p <partition> --account=<account> \
+    --nodes=8 --ntasks-per-node=4 --gpus-per-node=4 \
+    --cpus-per-task=16 --mem=1490G -t 00-10:00:00
+bash benchmarks/mfu_scaling/mfu_bench.sh
+```
+
+The driver runs all 14 experiments sequentially inside a single
+interactive allocation. Results go to `mfu_results/*.log` (one per
+experiment). The full report prints the per-experiment log layout at
+its tail.
+
+## MoE Expert Parallelism
+
+Report:
+[`benchmarks/moe_expert_parallel/moe_ep_benchmark.md`](https://github.com/KempnerInstitute/KempnerForge/blob/main/benchmarks/moe_expert_parallel/moe_ep_benchmark.md).
+Driver:
+[`benchmarks/moe_expert_parallel/moe_ep_bench.sh`](https://github.com/KempnerInstitute/KempnerForge/blob/main/benchmarks/moe_expert_parallel/moe_ep_bench.sh).
+
+32-GPU MoE: 8 nodes × 4 H200. Mesh `(dp_shard=4, ep=2, tp=4)`.
+Architecture: `dim=2048`, 24 layers, 8 experts top-2, `moe_frequency=1`.
+~4B total params, ~1.8B active per token.
+
+### Per-sub-module FSDP wrapping fix
+
+The report documents a measured improvement from wrapping
+`layer.attention` and `layer.mlp` as separate FSDP2 units (instead of
+the entire block or deferring MoE params to the top-level wrap). At
+batch_size=12 with full activation checkpointing:
+
+| Metric | Before fix | After fix | Change |
+|--------|-----------:|----------:|-------:|
+| Memory | 119.9 GB | 106.7 GB | −13.2 GB (−11%) |
+| Throughput | 16,200 tok/s | 27,000 tok/s | +67% |
+| Step time | 12.0 s | 7.4 s | −38% |
+
+The 67% throughput improvement at batch_size=12 comes from relieving
+allocator pressure — at 119.9 GB (86% utilization) before the fix, the
+allocator spent substantial time on fragmentation; post-fix at 106.7
+GB (76%) it doesn't. Batch_size=12 overtook batch_size=8 as the
+optimum after the fix.
+
+### Why MFU is 1.5%
+
+MFU of 1.5% is correct for this model at this scale, not a bug. ~1.8B
+active parameters on 32 × H200 means ~56M active params per GPU —
+each H200 is designed for billions. Communication overhead (EP
+all-to-all, FSDP all-gather/reduce-scatter, TP collectives) dwarfs
+compute. For comparison, a dense 13B model hits 32.7% MFU on the same
+hardware; an MoE model targeting similar MFU would need ~50B total
+parameters (~10B active).
+
+### Reproduction
+
+```bash
+salloc -p <partition> --account=<account> \
+    --nodes=8 --ntasks-per-node=4 --gpus-per-node=4 \
+    --cpus-per-task=16 --mem=1490G -t 00-04:00:00
+bash benchmarks/moe_expert_parallel/moe_ep_bench.sh
+```
+
+Or run the best config directly:
+
+```bash
+srun --nodes=8 --ntasks-per-node=4 --gpus-per-node=4 \
+    --kill-on-bad-exit=1 \
+    --export=ALL,PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+    uv run python scripts/train.py configs/train/moe_ep_32gpu.toml
+```
+
+`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` is load-bearing for
+this config — fragmentation under bf16 EP without it pushes peak
+memory above the limit.
+
+## See also
+
+- [Parallelism recipes](parallelism-recipes.md) — the configs behind
+  the 7B/13B/70B and MoE EP numbers.
+- [Architecture § Parallelism order](../architecture/parallelism-order.md)
+  — why the mesh dimensions compose in a specific order.
+- [README § Benchmarks](https://github.com/KempnerInstitute/KempnerForge#benchmarks)
+  — summary of both reports at the repo root.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,116 @@
+# Environment variables
+
+Every environment variable KempnerForge reads, grouped by source.
+Authoritative locations in the tree:
+[`kempnerforge/distributed/setup.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/setup.py),
+[`kempnerforge/resilience/elastic.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/elastic.py),
+[`kempnerforge/metrics/logger.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/metrics/logger.py),
+and the helper launch scripts under
+[`scripts/slurm/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/scripts/slurm).
+
+## Rank / world-size (torchrun or SLURM)
+
+Read by `get_world_info()` in
+[`kempnerforge/distributed/setup.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/setup.py).
+Each torchrun-style var falls back to the SLURM equivalent, so the
+same entry point works under both launchers.
+
+| Variable | Fallback | Purpose |
+|----------|----------|---------|
+| `RANK` | `SLURM_PROCID` | Global rank (0..world_size-1) |
+| `LOCAL_RANK` | `SLURM_LOCALID` | Rank within a node (0..gpus_per_node-1) |
+| `WORLD_SIZE` | `SLURM_NTASKS` | Total number of ranks |
+
+`get_world_info()` reads whichever is set and then calls
+`os.environ.setdefault(...)` on all three, so downstream code
+(PyTorch, WandB, logging) sees a torchrun-shaped environment even on
+srun-direct launches.
+
+## Rendezvous (MASTER_ADDR / MASTER_PORT)
+
+| Variable | Set by | Notes |
+|----------|--------|-------|
+| `MASTER_ADDR` | user / launch script / `init_distributed()` | If unset, `init_distributed()` runs `scontrol show hostnames $SLURM_JOB_NODELIST | head -n1` |
+| `MASTER_PORT` | user / launch script / `init_distributed()` | If unset, derived from `SLURM_JOB_ID` via a seeded RNG; otherwise picked by binding an ephemeral socket |
+
+The SLURM launch helpers
+([`scripts/slurm/multinode.sh`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/slurm/multinode.sh),
+[`_run_training.sh`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/slurm/_run_training.sh))
+export both before `srun` so every rank agrees. `init_distributed()`
+only fills in missing values — it never overwrites.
+
+## NCCL / Gloo (auto-set by `_set_nccl_env()`)
+
+`init_distributed()` calls `_set_nccl_env()`, which detects the IB
+interface (`ls /sys/class/net | grep '^ib'`) and populates defaults:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NCCL_SOCKET_IFNAME` | detected IB interface (e.g. `ib0`) | NCCL bootstrap transport |
+| `GLOO_SOCKET_IFNAME` | same as above | Gloo (used by DCP async checkpoint coordination) |
+| `NCCL_IB_DISABLE` | `0` | Keep InfiniBand RDMA enabled |
+| `NCCL_NET_GDR_LEVEL` | `2` | GPUDirect RDMA level — enables GPU→NIC DMA |
+
+All four use `setdefault`, so anything you export before launch wins.
+The launch scripts also set `NCCL_IB_GID_INDEX=3` and
+`NCCL_TIMEOUT=1800`; those are shell-level conventions, not read
+anywhere in the Python code.
+
+## SLURM metadata (resilience)
+
+Read by `get_slurm_context()` and `running_under_slurm()` in
+[`kempnerforge/resilience/elastic.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/elastic.py).
+Purely informational — used to populate logs and decide whether a job
+is a restart.
+
+| Variable | Purpose |
+|----------|---------|
+| `SLURM_JOB_ID` | Job identifier; also used to derive `MASTER_PORT` |
+| `SLURM_JOB_NAME` | Job name (logged) |
+| `SLURM_JOB_NODELIST` | Nodelist; parsed by `scontrol show hostnames` to find `MASTER_ADDR` |
+| `SLURM_NNODES` | Node count (logged) |
+| `SLURM_NTASKS_PER_NODE` | Tasks per node (logged) |
+| `SLURM_RESTART_COUNT` | Non-zero means this is a requeue (used to detect restarts) |
+| `SLURM_JOB_PARTITION` | Partition name (logged) |
+| `SLURM_ARRAY_TASK_ID` | Array index when applicable (logged) |
+
+## Logging
+
+| Variable | Read in | Purpose |
+|----------|---------|---------|
+| `NO_COLOR` | [`kempnerforge/metrics/logger.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/metrics/logger.py) | Disables ANSI color codes in logs when set to any truthy value |
+| `RANK` | same | Used to prefix log lines with the current rank |
+
+## User-facing launch-script variables
+
+Read only by the SLURM helpers under
+[`scripts/slurm/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/scripts/slurm),
+not by any Python module:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `KEMPNERFORGE_LOG_DIR` | `${SLURM_SUBMIT_DIR:-$PWD}/logs/distributed` | Per-rank log destination for `_run_training.sh`, `_run_distributed_tests.sh`, `_dcgm_monitor.sh` |
+| `IB_IFNAME` | `ib0` (fallback in `interactive.sh`) | IB interface for the NCCL/Gloo exports in the launch scripts |
+| `PYTORCH_CUDA_ALLOC_CONF` | (unset) | Passed through in `scripts/slurm/interactive.sh` and the MoE-EP benchmark scripts as `expandable_segments:True` |
+
+## Who sets what
+
+| Source | Variables it populates |
+|--------|------------------------|
+| User / job script | `KEMPNERFORGE_LOG_DIR`, `IB_IFNAME`, `PYTORCH_CUDA_ALLOC_CONF`, optionally `NCCL_*` overrides |
+| `torchrun` | `RANK`, `LOCAL_RANK`, `WORLD_SIZE`, `MASTER_ADDR`, `MASTER_PORT` |
+| `srun` (SLURM) | `SLURM_*` (incl. `SLURM_PROCID`, `SLURM_LOCALID`, `SLURM_NTASKS`, `SLURM_JOB_*`) |
+| `scripts/slurm/_run_training.sh` | Exports `RANK`, `LOCAL_RANK`, `WORLD_SIZE`, `MASTER_ADDR`, `MASTER_PORT`, `NCCL_*`, `GLOO_*` before calling the trainer |
+| `init_distributed()` | Fills missing `RANK`/`LOCAL_RANK`/`WORLD_SIZE` from `SLURM_*`, missing `MASTER_ADDR`/`MASTER_PORT`, and all four `NCCL_*`/`GLOO_*` defaults |
+
+## See also
+
+- [SLURM launch scripts](https://github.com/KempnerInstitute/KempnerForge/tree/main/scripts/slurm)
+  — how `multinode.sh`, `_run_training.sh`, and friends assemble these
+  variables end-to-end.
+- [Architecture § One-slide overview](../architecture/index.md) —
+  where `RANK`/`LOCAL_RANK`/`WORLD_SIZE` feed into the mesh
+  construction.
+- [Benchmarks § MoE Expert Parallelism](benchmarks.md#moe-expert-parallelism)
+  — where `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` is
+  load-bearing.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,39 @@
+# Reference
+
+Curated tables and exhaustive lists that don't fit a narrative but are
+useful: every config preset, every proven parallelism combination at
+each GPU count, every env var the framework reads.
+
+```{toctree}
+:maxdepth: 1
+
+available-configs
+parallelism-recipes
+benchmarks
+environment-variables
+```
+
+- **[Available configs](available-configs.md)** — the full
+  [`configs/train/*.toml`](https://github.com/KempnerInstitute/KempnerForge/tree/main/configs/train)
+  and
+  [`configs/model/*.toml`](https://github.com/KempnerInstitute/KempnerForge/tree/main/configs/model)
+  tables, with "what this config exists to prove" per row.
+- **[Parallelism recipes](parallelism-recipes.md)** — (model, GPU count,
+  parallelism) combinations that we've actually run end-to-end, indexed
+  by model rather than by filename.
+- **[Benchmarks](benchmarks.md)** — summaries and reproduction commands
+  for
+  [`benchmarks/mfu_scaling/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/benchmarks/mfu_scaling)
+  (dense 7B/13B/70B MFU scaling) and
+  [`benchmarks/moe_expert_parallel/`](https://github.com/KempnerInstitute/KempnerForge/tree/main/benchmarks/moe_expert_parallel)
+  (MoE Expert Parallelism with per-sub-module FSDP wrapping).
+- **[Environment variables](environment-variables.md)** — every env var
+  the framework reads, grouped by source (torchrun / SLURM / NCCL /
+  logging) with who-sets-what.
+
+## See also
+
+- [README § Training Configurations](https://github.com/KempnerInstitute/KempnerForge#training-configurations)
+  — the current configs table at the repo root.
+- [README § Benchmarks](https://github.com/KempnerInstitute/KempnerForge#benchmarks)
+  — the MFU table at the repo root.

--- a/docs/reference/parallelism-recipes.md
+++ b/docs/reference/parallelism-recipes.md
@@ -1,0 +1,114 @@
+# Parallelism recipes
+
+Every recipe here corresponds to a TOML preset we've actually run, not
+a theoretical configuration. Factors multiply to the given GPU count:
+`dp_replicate × dp_shard × tp × pp × cp × ep == world_size` (see
+[Validation rules § Parallelism arithmetic](../configuration/validation-rules.md#parallelism-arithmetic)).
+
+Single-node = 4 H200 141GB per node. Intra-node uses NVLink; inter-node
+uses InfiniBand.
+
+## 7B (Llama-3)
+
+| GPUs | Nodes | Parallelism | Config | When to pick this |
+|-----:|------:|-------------|--------|-------------------|
+| 1 | 1 | single GPU | [`debug.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/debug.toml) / [`7b.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b.toml) | Smoke test; `7b.toml` fits in 80 GB with full AC |
+| 4 | 1 | FSDP=4 | [`7b.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b.toml) (`dp_shard=-1`) | Single-node baseline; highest MFU |
+| 12 | 3 | TP=4 × FSDP=3 | [`7b_12gpu_tp4.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_12gpu_tp4.toml) | TP within node, FSDP across — uncommon GPU count |
+| 16 | 4 | FSDP=16 | [`7b_16gpu_adamw.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_adamw.toml) | Long preemptible runs (`7b_requeue.sh`) |
+| 16 | 4 | FSDP=16, FP8 | [`7b_16gpu_fp8.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_fp8.toml) | FP8 compute with bf16 masters; `tp=1` required |
+| 16 | 4 | FSDP=16, Muon | [`7b_16gpu_muon.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_muon.toml) | Muon + z-loss + chunked CE integration test |
+| 32 | 8 | FSDP=32 | [`7b_32gpu_fsdp.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_32gpu_fsdp.toml) | Simple multi-node baseline |
+
+The 7B model underutilizes 32 H200s (27.6 GB / 140 GB in the benchmark)
+— at that scale [13B delivers higher MFU](benchmarks.md#mfu-scaling-dense).
+
+## 13B (Llama-3)
+
+| GPUs | Nodes | Parallelism | Config | When to pick this |
+|-----:|------:|-------------|--------|-------------------|
+| 8 | 2 | FSDP=8 | (inline override) | Pure FSDP when 13B params fit ≤90 GB/GPU |
+| 24 | 6 | TP=4 × FSDP=6 | [`13b_24gpu_validation.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/13b_24gpu_validation.toml) | Full validation: WandB + profiling + eval |
+| 32 | 8 | TP=4 × PP=2 × FSDP=4 | [`13b_32gpu_tp4_pp2.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/13b_32gpu_tp4_pp2.toml) | Pipeline parallel recipe — 20 layers per stage |
+
+## 29B (custom)
+
+| GPUs | Nodes | Parallelism | Config | When to pick this |
+|-----:|------:|-------------|--------|-------------------|
+| 32 | 8 | TP=4 × PP=2 × FSDP=4 | [`29b_32gpu_tp4_pp2.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/29b_32gpu_tp4_pp2.toml) | `dim=6144`, 56 layers — sized to saturate 120 GB/GPU |
+
+## 70B (Llama-3)
+
+| GPUs | Nodes | Parallelism | Config | When to pick this |
+|-----:|------:|-------------|--------|-------------------|
+| 32 | 8 | TP=4 × FSDP=8 | [`70b_32gpu_tp4.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/70b_32gpu_tp4.toml) | No PP — avoids bubble when FSDP alone fits |
+| 32 | 8 | TP=4 × PP=4 × FSDP=2 | [`70b_32gpu_tp4_pp4.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/70b_32gpu_tp4_pp4.toml) | Memory-tight alternative — 20 layers per PP stage |
+
+`70b_32gpu_tp4.toml` is the preferred of the two when memory allows:
+the PP version adds a pipeline bubble in exchange for less FSDP
+sharding work. See
+[Validation rules § Sequence length](../configuration/validation-rules.md#sequence-length)
+and
+[§ Tensor-parallel head divisibility](../configuration/validation-rules.md#tensor-parallel-head-divisibility)
+— both 70B recipes rely on `n_heads=64 % tp=4 == 0` and
+`n_kv_heads=8 % tp=4 == 0`.
+
+## MoE (Mixtral-style, 8 experts top-2)
+
+| GPUs | Nodes | Parallelism | Config | When to pick this |
+|-----:|------:|-------------|--------|-------------------|
+| 1+ | 1+ | FSDP | [`debug_moe.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/debug_moe.toml) | Smoke test; tiny MoE, `moe_frequency=2` |
+| 8 | 2 | TP=4 × FSDP=2 | [`moe_8gpu_stress.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/moe_8gpu_stress.toml) | Real dataset, full AC, saturates 2 nodes |
+| 24 | 6 | TP=4 × FSDP=6 | [`moe_24gpu.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/moe_24gpu.toml) | `grad_accum=32` for throughput saturation |
+| 32 | 8 | TP=4 × EP=2 × FSDP=4 | [`moe_ep_32gpu.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/moe_ep_32gpu.toml) | Expert Parallel — all-to-all across IB |
+
+`PP=1` is mandatory for MoE (routing is data-dependent and resists
+pipeline-stage splitting — see the cross-section rules in
+[Validation rules](../configuration/validation-rules.md)).
+`ep > 1` requires `num_experts > 0` and
+`num_experts % ep == 0` — see
+[§ Expert parallel](../configuration/validation-rules.md#expert-parallel).
+
+## Choosing a parallelism combination
+
+The order the cross-section validator enforces (see
+[Parallelism order](../architecture/parallelism-order.md)) is:
+
+1. **PP** — split layers across stages; set first because it rewrites
+   the model into stage submodules.
+2. **TP** — shard attention heads and MLP within each PP stage; needs
+   `n_heads % tp == 0`, `n_kv_heads % tp == 0`.
+3. **CP** — split along the sequence dimension (not wired up yet).
+4. **EP** — shard experts across ranks (MoE only).
+5. **FSDP (`dp_shard`)** — shard remaining params; the "fill the rest"
+   dimension, usually `dp_shard=-1`.
+6. **DP replicate (`dp_replicate`)** — multiple full copies, typically
+   `1` until a recipe deliberately trades memory for smaller all-reduce
+   domains.
+
+Rules of thumb from [the benchmarks](benchmarks.md):
+
+- **FSDP-only wins when it fits.** At 4 GPUs / 7B, pure FSDP beats
+  `tp=4` by ~18 MFU points; TP all-gather/reduce-scatter on every
+  matmul dwarfs FSDP's once-per-step gradient communication.
+- **TP when memory forces it or `n_layers` blocks FSDP.** 70B at 32
+  GPUs needs TP — pure FSDP=32 OOMs on activation memory. TP within a
+  node (NVLink) is cheap; across nodes (IB) is slow.
+- **PP when even TP+FSDP can't fit.** 70B with PP=4 fits with half the
+  FSDP shards (`dp_shard=2` vs `dp_shard=8`) at the cost of the PP
+  bubble; only pick it when memory requires.
+- **EP when expert count outgrows a single rank.** At 8 experts and 32
+  GPUs, EP=2 halves per-rank expert storage. At higher expert counts
+  (64+, DeepSeekMoE-scale) EP becomes load-bearing.
+
+## See also
+
+- [Available configs](available-configs.md) — the same recipes, indexed
+  by filename.
+- [Benchmarks](benchmarks.md) — measured throughput and MFU for the
+  dense 7B/13B/70B and MoE EP recipes above.
+- [Architecture § Parallelism order](../architecture/parallelism-order.md)
+  — the invariants the cross-section validator enforces.
+- [Validation rules](../configuration/validation-rules.md) — the
+  precise checks `JobConfig.validate(world_size)` runs against these
+  combinations.

--- a/docs/resilience/elastic.md
+++ b/docs/resilience/elastic.md
@@ -1,0 +1,133 @@
+# SLURM elastic helpers
+
+[`kempnerforge/resilience/elastic.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/elastic.py)
+is a small pile of SLURM-environment helpers. Most of these are
+read-only introspection — they pull variables out of the environment
+and return typed data. The one with teeth is `resolve_resume_path`,
+documented on its own page; this page covers the rest.
+
+## `SLURMInfo` and `get_slurm_info`
+
+```python
+@dataclass
+class SLURMInfo:
+    job_id: str
+    job_name: str
+    node_list: str
+    num_nodes: int
+    ntasks_per_node: int
+    restart_count: int
+    partition: str
+    array_task_id: str | None
+
+    @property
+    def is_requeued(self) -> bool:
+        return self.restart_count > 0
+```
+
+`get_slurm_info()` reads these from env vars and returns `None` if not
+running under SLURM (i.e. `SLURM_JOB_ID` is unset):
+
+```python
+# kempnerforge/resilience/elastic.py — get_slurm_info
+SLURMInfo(
+    job_id          = os.environ["SLURM_JOB_ID"],
+    job_name        = os.environ.get("SLURM_JOB_NAME", ""),
+    node_list       = os.environ.get("SLURM_JOB_NODELIST", ""),
+    num_nodes       = int(os.environ.get("SLURM_NNODES", "1")),
+    ntasks_per_node = int(os.environ.get("SLURM_NTASKS_PER_NODE", "1")),
+    restart_count   = int(os.environ.get("SLURM_RESTART_COUNT", "0")),
+    partition       = os.environ.get("SLURM_JOB_PARTITION", ""),
+    array_task_id   = os.environ.get("SLURM_ARRAY_TASK_ID"),
+)
+```
+
+Use it when you want to branch on SLURM-only behavior:
+
+```python
+from kempnerforge.resilience import get_slurm_info
+
+info = get_slurm_info()
+if info is not None and info.is_requeued:
+    logger.info(f"Detected requeue #{info.restart_count}")
+```
+
+## `is_slurm_job` / `is_slurm_requeue`
+
+Convenience booleans for the same data:
+
+```python
+is_slurm_job()     # "SLURM_JOB_ID" in os.environ
+is_slurm_requeue() # int(os.environ.get("SLURM_RESTART_COUNT", "0")) > 0
+```
+
+Neither calls `get_slurm_info` — they just check the relevant env
+var directly, so they're cheap to call frequently.
+
+## `log_job_info`
+
+Called once during training startup:
+
+```python
+# scripts/train.py
+log_job_info()
+```
+
+Emits one info-level log line with the SLURM job details, plus a
+second line if this is a requeue:
+
+```
+SLURM job: id=123456, name=kf-7b-adamw, nodes=4, tasks/node=4,
+           partition=h200_preempt, restart_count=2
+Job was requeued (restart #2) — will auto-resume
+```
+
+If not running under SLURM it logs `"Not running under SLURM"` and
+returns.
+
+## `resolve_resume_path`
+
+Covered on its own page — see
+[Checkpointing § Auto-resume](../checkpointing/auto-resume.md). This is
+the function that decides whether the training run loads an existing
+checkpoint at startup.
+
+## Patterns these enable
+
+### "First run vs requeue" branching
+
+```python
+info = get_slurm_info()
+if info and info.is_requeued:
+    # Skip LR warmup on requeue (schedule state restored from checkpoint)
+    scheduler_state = "restored"
+else:
+    # Fresh run
+    scheduler_state = "fresh"
+```
+
+In practice you don't need this — `scripts/train.py` handles warmup
+restoration via the scheduler's own `state_dict`. The branch is useful
+for one-off behaviors (e.g. "only print config diff on first run").
+
+### Array job sharding
+
+```python
+info = get_slurm_info()
+if info and info.array_task_id is not None:
+    shard = int(info.array_task_id)
+    # Use shard to pick a config variant, data shard, etc.
+```
+
+`scripts/train.py` doesn't read `array_task_id` — wire it through CLI
+overrides if you want per-array-task config variants.
+
+## See also
+
+- [SLURM preemption](slurm-preemption.md) — where the requeue loop
+  actually happens.
+- [Checkpointing § Auto-resume](../checkpointing/auto-resume.md) —
+  `resolve_resume_path` behavior and the `latest` symlink protocol.
+- [`scripts/slurm/7b_requeue.sh`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/slurm/7b_requeue.sh)
+  — the reference launch script that sets the SLURM env these helpers
+  read.

--- a/docs/resilience/gpu-health.md
+++ b/docs/resilience/gpu-health.md
@@ -1,0 +1,105 @@
+# GPU health
+
+[`check_gpu_health`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/health.py)
+runs a short smoke test against a CUDA device. The training loop
+**does not** call it automatically — it's an opt-in diagnostic, most
+useful at job startup or after a suspected hardware fault.
+
+## What it checks
+
+```python
+# kempnerforge/resilience/health.py — check_gpu_health
+result = {
+    "cuda_available": torch.cuda.is_available(),
+    "device_accessible": False,
+    "compute_ok": False,
+    "memory_ok": False,
+    "error": "",
+}
+```
+
+Four booleans + an error string. Each test must pass before the next
+runs:
+
+1. **`cuda_available`** — `torch.cuda.is_available()`. If this is
+   False the rest short-circuits.
+2. **`device_accessible`** — `torch.cuda.set_device(device)`. Catches
+   stale CUDA contexts or permission errors that let `cuda_available`
+   pass but block actual device use.
+3. **`compute_ok`** — `x = torch.ones(16); y = x + x; assert y.sum() == 32`.
+   A tiny elementwise + reduction. Catches fused-kernel or launcher
+   failures that look fine to `set_device` but crash on first op.
+4. **`memory_ok`** — allocate a 1 MB buffer
+   (`torch.empty(256*1024, dtype=float32)`) and free it. Catches the
+   case where the GPU is reachable and can launch kernels but OOMs on
+   any new allocation (usually a stale allocator state).
+
+## Usage
+
+```python
+from kempnerforge.resilience import check_gpu_health
+
+health = check_gpu_health(device=0)
+if not (health["cuda_available"] and health["compute_ok"] and health["memory_ok"]):
+    raise RuntimeError(f"GPU unhealthy: {health['error']}")
+```
+
+Or as a pre-flight check before long runs:
+
+```python
+# At job start, before init_distributed
+for device in range(torch.cuda.device_count()):
+    h = check_gpu_health(device)
+    if h["error"]:
+        logger.error(f"Device {device}: {h['error']}")
+```
+
+## When to use it
+
+- **After a hardware-suspected crash.** If a run died with a CUDA
+  error, re-check the device before resuming.
+- **On cluster nodes you don't own.** Mixed-tenant clusters sometimes
+  leave GPUs in a partially-wedged state; this surfaces that before
+  your training burns a training-step of compute.
+- **Before expensive data loading.** Cheaper to fail at step 0 than
+  30 minutes into HF dataset streaming.
+
+## When it won't help
+
+- **Transient NCCL failures.** `check_gpu_health` runs local ops only
+  — no collective. For distributed liveness see
+  [NCCL liveness](nccl-liveness.md).
+- **Slow / degraded GPUs.** The test passes if the GPU *works*, not if
+  it's running at spec. For throughput regressions use the
+  [profiler](../metrics-and-profiling/profiler.md) or watch
+  `step_time_sec` in the metrics.
+- **Memory fragmentation under real load.** A 1 MB allocation doesn't
+  trigger fragmentation; full training allocations might. Use
+  [memory snapshots](../metrics-and-profiling/memory-monitor.md#memory-snapshot-export)
+  for that.
+
+## Return shape
+
+```python
+{
+  "cuda_available": True,
+  "device_accessible": True,
+  "compute_ok": True,
+  "memory_ok": True,
+  "error": "",
+}
+```
+
+`error` is the string of the last-raised `RuntimeError` / `AssertionError`
+if any test failed. `cuda_available` gets a special case — if False,
+`error` is set to `"CUDA not available"` before returning. Otherwise
+errors only appear if a test actually raised.
+
+## See also
+
+- [NCCL liveness](nccl-liveness.md) — the distributed-side counterpart;
+  covers "GPUs are alive but not talking to each other".
+- [NaN detection](nan-detection.md) — model-level failures rather than
+  device-level.
+- [Memory monitor](../metrics-and-profiling/memory-monitor.md) — runtime
+  memory tracking; complementary to the 1 MB allocation test here.

--- a/docs/resilience/index.md
+++ b/docs/resilience/index.md
@@ -1,0 +1,81 @@
+# Resilience
+
+Long training runs die — preempted, NaN'd, a GPU falls off the bus.
+KempnerForge's resilience module handles the recoverable failures so
+the run picks up from the last checkpoint instead of burning a
+re-submit.
+
+Three failure modes the module addresses:
+
+- **Preemption / manual stop** — SLURM sends a termination signal,
+  KempnerForge catches it, writes an emergency checkpoint, and exits.
+- **Numerical blow-up** — NaN / Inf loss detected, optimizer step
+  skipped, gradient zeroed. If it persists, stop so a human can roll
+  back.
+- **Silent distributed hangs** — periodic NCCL liveness ping detects
+  a dead peer before the training loop deadlocks.
+
+## At a glance
+
+| Component | Source | Wired into `train.py`? |
+|-----------|--------|-------------------------|
+| `ShutdownHandler` | `resilience/signal_handler.py` | always-on |
+| `NaNDetector` | `resilience/health.py` | hardcoded `action="warn"` |
+| `check_nccl_health` | `resilience/health.py` | opt-in via `train.nccl_health_check_interval` |
+| `check_gpu_health` | `resilience/health.py` | no — manual utility |
+| `SLURMInfo` / `get_slurm_info` / `log_job_info` | `resilience/elastic.py` | `log_job_info()` at startup |
+| `resolve_resume_path` | `resilience/elastic.py` | at checkpoint load time |
+
+Everything in the first column is importable from
+`kempnerforge.resilience`.
+
+## Config
+
+```toml
+[train]
+shutdown_timeout_sec       = 600.0   # ShutdownHandler hard deadline (0 = disabled)
+nccl_health_check_interval = 0       # NCCL ping every N steps (0 = disabled)
+```
+
+Two knobs. There is deliberately no `nan_detection` section — the
+action and max-consecutive count are hardcoded in `scripts/train.py`
+(`action="warn"`, `max_consecutive=10`). Edit the script if you need
+different behavior; see [NaN detection](nan-detection.md).
+
+## SLURM launch
+
+The reference preemption-resilient launch script is
+[`scripts/slurm/7b_requeue.sh`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/slurm/7b_requeue.sh):
+
+```bash
+#SBATCH --signal=B:SIGTERM@120   # SIGTERM 120s before hard kill
+#SBATCH --requeue                # auto-resubmit on preempt
+
+srun --kill-on-bad-exit=1 uv run python scripts/train.py "${CONFIG}"
+```
+
+Pair with a checkpoint interval of a few hundred steps (~1.5 hours for
+a 7B run on 16 H100s), so the emergency checkpoint never loses more
+than that.
+
+## Pages
+
+```{toctree}
+:maxdepth: 1
+
+slurm-preemption
+nan-detection
+gpu-health
+nccl-liveness
+elastic
+```
+
+## See also
+
+- [Checkpointing § Auto-resume](../checkpointing/auto-resume.md) —
+  what a requeued job does on startup.
+- [Training § Training loop](../training/training-loop.md) — where
+  `shutdown_handler.should_shutdown()` and `nan_detector.check_loss()`
+  are polled each step.
+- [Configuration § `[train]`](../configuration/config-sections.md) —
+  the two resilience-related config fields.

--- a/docs/resilience/nan-detection.md
+++ b/docs/resilience/nan-detection.md
@@ -1,0 +1,172 @@
+# NaN detection
+
+[`NaNDetector`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/health.py)
+watches for NaN / Inf in the loss every step. When it fires, the
+training loop zeros gradients, skips the optimizer step, and increments
+a consecutive-NaN counter. If too many consecutive NaNs pile up, the
+loop stops so a human can roll back to an earlier checkpoint.
+
+## Wiring
+
+```python
+# scripts/train.py
+nan_detector = NaNDetector(action="warn", max_consecutive=10)
+...
+# Inside the training loop, after backward:
+if not nan_detector.check_loss(avg_loss, step):
+    optimizer.zero_grad()
+    if nan_detector.should_rollback:
+        logger.error("Too many consecutive NaNs — stopping")
+        break
+    step += 1
+    continue
+```
+
+Two things to note:
+
+- **`action="warn"` and `max_consecutive=10` are hardcoded in
+  `scripts/train.py`** — not exposed as TOML config. If you want
+  `"skip"` or `"raise"` behavior, edit the script or construct the
+  detector yourself.
+- **`check_gradients` is *not* called by the training loop.** Gradient
+  NaNs typically manifest as loss NaNs on the next step anyway; skip it
+  unless you're specifically debugging a gradient-explosion case.
+
+## Three actions
+
+```python
+# kempnerforge/resilience/health.py — NaNDetector.__init__
+if action not in ("warn", "skip", "raise"):
+    raise ValueError(f"Invalid NaN action: {action!r} (expected warn/skip/raise)")
+```
+
+| Action | Behavior | When to pick it |
+|--------|----------|-----------------|
+| `"warn"` | Log a warning, return `False`. Loop zeros grads and continues. | Default. NaN-tolerant training where a single bad step shouldn't kill the run. |
+| `"skip"` | Same as `"warn"` but logs `"— skipping optimizer step"` explicitly. | Same as warn; the two are nearly equivalent since the caller already skips the optimizer step on `False`. |
+| `"raise"` | Raise `RuntimeError` immediately. | Early development when you want the run to die loudly on first NaN. |
+
+In the shipped training loop, `"warn"` and `"skip"` produce the same
+outcome (the caller already zeros grads and advances the step). The
+distinction exists for callers that only call `check_loss` and let the
+return value drive their own logic.
+
+## Cross-rank sync
+
+The critical detail. On a distributed run, a NaN on one rank must stop
+*every* rank — otherwise one rank zeros grads while the others keep
+optimizing and FSDP gets an inconsistent view of the parameter sharding
+on the next step.
+
+```python
+# kempnerforge/resilience/health.py — check_loss
+local_nan = not _is_finite(loss)
+if dist.is_initialized():
+    nan_flag = torch.tensor([1.0 if local_nan else 0.0], device="cuda")
+    dist.all_reduce(nan_flag)
+    any_nan = nan_flag.item() > 0
+else:
+    any_nan = local_nan
+```
+
+Four bytes per step — dwarfed by the gradient all-reduce. The
+`all_reduce` is a `SUM` (the default) — any rank with NaN lifts the
+flag above zero on every rank.
+
+If `any_nan` is true but `local_nan` is false, the log line mentions
+"detected on another rank" so you can correlate which rank blew up from
+per-rank logs.
+
+## State tracking
+
+```python
+@dataclass
+class NaNState:
+    consecutive_nans: int = 0       # reset on a good step
+    total_nans: int = 0             # monotonic across the run
+    last_good_loss: float = inf     # last finite loss value
+    last_good_step: int = 0
+    nan_steps: list[int] = []       # capped at max_history (default 100)
+```
+
+`consecutive_nans` resets on any finite step. It's the one that drives
+rollback: when it reaches `max_consecutive` (default 5 in the class, 10
+in the shipped config), `should_rollback` flips to `True`.
+
+`nan_steps` is a diagnostic — a post-hoc "which steps actually failed"
+list. Capped at 100 entries to bound memory on pathological runs.
+
+## Rollback recommendation
+
+```python
+@property
+def should_rollback(self) -> bool:
+    return self.state.consecutive_nans >= self.max_consecutive
+```
+
+When this trips, the training loop *stops* — it doesn't roll back
+automatically:
+
+```python
+# scripts/train.py
+if nan_detector.should_rollback:
+    logger.error("Too many consecutive NaNs — stopping")
+    break
+```
+
+Rolling back is manual: resubmit with `checkpoint.load_path` pointing at
+an earlier `step_N` directory. The reason it's not automatic is that
+the *source* of the NaN determines what's safe:
+
+- **LR spike** — reduce `optimizer.lr` or `scheduler.warmup_steps`,
+  restart from an earlier checkpoint.
+- **Bad data** — skip the offending shard, restart from the same
+  checkpoint.
+- **FP8 overflow** — reduce `distributed.fp8_interval` or disable FP8
+  for sensitive layers, restart.
+
+A rule-of-thumb: if you hit `should_rollback`, don't resume from the
+most recent checkpoint. It was written just before the NaN storm, so
+whatever state caused the explosion is baked in.
+
+## Manual use
+
+Call the detector outside the training loop for ad-hoc checks:
+
+```python
+from kempnerforge.resilience import NaNDetector
+
+det = NaNDetector(action="raise", max_consecutive=1)  # fail fast
+for step, batch in enumerate(loader):
+    loss = model(batch).item()
+    det.check_loss(loss, step)    # raises on first NaN
+```
+
+`check_gradients(model, step)` does the same but walks
+`model.named_parameters()` and returns `False` on the first NaN grad.
+The `action="raise"` mode raises `RuntimeError` instead of returning
+`False` (the warning case still returns `False`).
+
+## Limitations
+
+- **NaN action isn't in config.** Fixed at `"warn"` / `max_consecutive=10`
+  in `scripts/train.py:85`. Change the source if you need something
+  different.
+- **No gradient scan in the hot path.** `check_gradients` exists but
+  isn't wired in. Add it if you're hunting a specific gradient
+  pathology; expect a small per-step cost (one `isfinite` + `.all()`
+  per parameter).
+- **Loss is already a CPU scalar.** `check_loss` gets a Python float, so
+  the distributed sync creates a new tensor on CUDA and all-reduces it
+  — a negligible one-off each step but not free. If you optimize this
+  path, aggregate the NaN flag into the existing grad-norm all-reduce.
+
+## See also
+
+- [SLURM preemption](slurm-preemption.md) — the other "stop cleanly"
+  mechanism; both rely on the training loop polling a flag between
+  steps.
+- [GPU health](gpu-health.md) — coarser health check; run it at
+  startup and after any NCCL failure.
+- [Checkpointing § Auto-resume](../checkpointing/auto-resume.md) —
+  where to point `checkpoint.load_path` when rolling back.

--- a/docs/resilience/nccl-liveness.md
+++ b/docs/resilience/nccl-liveness.md
@@ -1,0 +1,122 @@
+# NCCL liveness
+
+[`check_nccl_health`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/health.py)
+is a one-line all-reduce that verifies every rank is still talking to
+every other rank. Cheap enough to run periodically from the training
+loop.
+
+## The check
+
+```python
+# kempnerforge/resilience/health.py — check_nccl_health
+if not dist.is_initialized():
+    return True
+
+try:
+    tensor = torch.ones(1, device="cuda")
+    dist.all_reduce(tensor)
+    torch.cuda.synchronize()
+    expected = dist.get_world_size()
+    return abs(tensor.item() - expected) < 1e-5
+except RuntimeError as e:
+    logger.error(f"NCCL health check failed: {e}")
+    return False
+```
+
+A 4-byte all-reduce of ones. If every rank contributed, the result
+equals `world_size`. If not — RuntimeError (mismatched group, network
+drop) or a wrong sum (one rank contributed zeros).
+
+`torch.cuda.synchronize()` forces the collective to complete before
+reading `.item()`. Without it the check would short-circuit if the
+collective hadn't actually started yet.
+
+## Periodic check in the loop
+
+```python
+# scripts/train.py
+if (
+    tc.nccl_health_check_interval > 0
+    and step % tc.nccl_health_check_interval == 0
+    and not check_nccl_health()
+):
+    logger.error(f"NCCL health check failed at step {step} — stopping")
+    break
+```
+
+`train.nccl_health_check_interval` defaults to **0** (disabled). Set it
+to a positive integer to enable:
+
+```toml
+[train]
+nccl_health_check_interval = 500   # every 500 steps
+```
+
+500 is a reasonable starting point: once every few minutes of
+wall-clock, adds one extra all-reduce to that step. Setting it to 1
+would sync every step — not useful because the gradient all-reduce in
+the same step would already have failed.
+
+## The timeout gotcha
+
+The function signature advertises a timeout:
+
+```python
+def check_nccl_health(timeout_sec: float = 10.0) -> bool:
+```
+
+But `timeout_sec` is **not used** in the current implementation — the
+function calls `dist.all_reduce` without a timeout and just catches
+`RuntimeError`. If the collective hangs, the `try/except` won't trip;
+the process blocks inside the C++ call.
+
+In practice hangs are covered by two other layers:
+
+- `NCCL_TIMEOUT` (set in `scripts/slurm/7b_requeue.sh` to 1800 = 30min)
+  aborts the collective at the NCCL level and raises a `RuntimeError`,
+  which `check_nccl_health` does catch.
+- `ShutdownHandler`'s forced-exit timer kills the process if graceful
+  shutdown stalls — see [SLURM preemption](slurm-preemption.md).
+
+But a stuck all-reduce can still eat 30 min of wall-clock before the
+NCCL-level timeout fires. If you need faster failure detection, lower
+`NCCL_TIMEOUT` at the env level.
+
+## When it fires
+
+Most common causes of `check_nccl_health() == False`:
+
+- **Rank crashed silently.** `world_size - 1` ranks participate, the
+  all-reduce sum is off by one. Almost always the crashed rank's stdout
+  has the real error — check per-rank logs.
+- **Network partition.** Happens on Ethernet fabrics under heavy load;
+  rare but not zero on InfiniBand. NCCL retries internally; repeated
+  failures mean the fabric degraded.
+- **Out-of-band process kill.** User ran `scancel` on one rank only.
+  Don't do this — use `scancel --signal=USR1` instead so
+  `ShutdownHandler` cleans up.
+
+## Manual use
+
+```python
+from kempnerforge.resilience import check_nccl_health
+
+# After a suspected partial failure
+if not check_nccl_health():
+    logger.error("NCCL unhealthy — aborting")
+    sys.exit(1)
+```
+
+No-op if `dist.is_initialized()` is False — returns True so calling
+code doesn't need to special-case single-process runs.
+
+## See also
+
+- [GPU health](gpu-health.md) — per-device checks; NCCL liveness tests
+  the *group* instead.
+- [SLURM preemption](slurm-preemption.md) — the forced-exit timer
+  provides the ultimate bound on how long a hang can live.
+- [Distributed § DeviceMesh](../distributed/device-mesh.md) — where
+  the NCCL process groups come from.
+- [Configuration § `[train]`](../configuration/config-sections.md) —
+  `nccl_health_check_interval` and `shutdown_timeout_sec`.

--- a/docs/resilience/slurm-preemption.md
+++ b/docs/resilience/slurm-preemption.md
@@ -1,0 +1,172 @@
+# SLURM preemption
+
+Long training runs on shared clusters get preempted. When SLURM sends a
+termination signal, KempnerForge catches it, saves a checkpoint, and
+exits cleanly so the next job can auto-resume from that checkpoint.
+
+Two pieces:
+
+- **`ShutdownHandler`** in
+  [`kempnerforge/resilience/signal_handler.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/resilience/signal_handler.py)
+  — registers signal handlers, flips a flag, and enforces a timeout.
+- **`scripts/slurm/7b_requeue.sh`** — the SLURM batch script that asks
+  for the early signal and requests auto-requeue.
+
+## `ShutdownHandler`
+
+Wired into the training loop at two points:
+
+```python
+# scripts/train.py
+shutdown_handler = ShutdownHandler(timeout_sec=config.train.shutdown_timeout_sec)
+shutdown_handler.register()
+...
+while step < tc.max_steps:
+    # ... train step, log, checkpoint ...
+    if shutdown_handler.should_shutdown():
+        logger.warning(f"Shutdown requested at step {step} — saving emergency checkpoint")
+        ckpt_mgr.save(step=step, tokens_seen=tokens_seen,
+                      scheduler=scheduler, extra=ckpt_extra)
+        shutdown_handler.finish()
+        break
+```
+
+`register()` installs handlers for `SIGTERM` and `SIGUSR1`. `finish()`
+cancels the forced-exit timer and restores the previous signal handlers.
+
+### Why cooperative, not `sys.exit`
+
+When the signal arrives, the handler does **not** call `sys.exit` or
+`os._exit`. It just sets a flag:
+
+```python
+# kempnerforge/resilience/signal_handler.py — _handle_signal
+self._shutdown_requested = True
+self._signal_received = sig
+```
+
+Reason: exiting mid-collective leaves NCCL buffers and open file
+descriptors in an inconsistent state. On the next requeue, the new
+process can inherit stale state (shared memory, port bindings) or hit a
+torch.distributed deadlock because peers think the group is still
+active.
+
+The training loop polls `should_shutdown()` after every step, at which
+point no collective is in flight. A checkpoint can be written safely,
+`ckpt_mgr.wait()` can flush the async writer, and the process group can
+be destroyed cleanly.
+
+### Forced-exit timer
+
+Cooperative shutdown assumes the loop reaches the polling point. If a
+collective hangs (network drops, peer dies), it won't. A daemon thread
+enforces a hard limit:
+
+```python
+# kempnerforge/resilience/signal_handler.py — _handle_signal
+if self._timeout_sec > 0 and self._timer is None:
+    self._timer = threading.Timer(self._timeout_sec, self._force_exit)
+    self._timer.daemon = True
+    self._timer.start()
+
+# _force_exit
+os._exit(1)
+```
+
+`os._exit(1)` is the blunt-force option — skips Python atexit handlers,
+skips C++ destructors, kills the process immediately. That's intentional:
+at this point graceful didn't work, and leaving a zombie holding GPU
+memory would block the requeue.
+
+`timeout_sec` comes from `train.shutdown_timeout_sec` (default 600s = 10
+min). Set to 0 to disable the timer entirely — not recommended under
+SLURM because you then rely on SLURM's own kill-timeout, which may
+leave GPU state half-freed.
+
+## SLURM side
+
+```bash
+# scripts/slurm/7b_requeue.sh
+#SBATCH --signal=B:SIGTERM@120
+#SBATCH --requeue
+```
+
+Two directives:
+
+- **`--signal=B:SIGTERM@120`** — SLURM sends `SIGTERM` to the batch
+  script's bash shell 120 seconds before the hard kill. The `B:` prefix
+  means "signal the batch process"; without it the signal goes only to
+  the allocation's `srun` child and bash (and therefore our Python)
+  might miss it.
+
+  `srun` then forwards the signal to each task's Python process. The
+  120-second lead time must exceed `shutdown_timeout_sec` plus the time
+  for the in-flight step + checkpoint to finish — 600s default is safe
+  for most configs; reduce to ~90s if your checkpoints save quickly and
+  you want to maximize step time.
+
+- **`--requeue`** — if the job is preempted, SLURM re-submits it. The
+  new run reads
+  [`resolve_resume_path`](../checkpointing/auto-resume.md) and picks up
+  from the emergency checkpoint written in the previous run. SLURM
+  increments `SLURM_RESTART_COUNT` — visible in `log_job_info()` output.
+
+## The full preemption timeline
+
+```
+  T-120s: SLURM sends SIGTERM to batch shell → srun → all Python ranks
+  T-120s: ShutdownHandler sets _shutdown_requested = True
+          ShutdownHandler starts 600s forced-exit timer (T+480s)
+  T-120s: Training loop in mid-step — completes the step
+   T-??s: Loop polls should_shutdown() → saves emergency checkpoint
+          ckpt_mgr.wait() flushes async writer to disk
+   T-??s: shutdown_handler.finish() cancels the forced-exit timer
+   T-??s: Process exits cleanly, SLURM epilogue runs
+     T-0: SLURM's SIGTERM deadline — if still alive, hard SIGKILL
+          (in practice we exit well before this because async save is fast)
+   T+??: SLURM sees job failed; `--requeue` re-submits
+          new job starts, resolve_resume_path finds the checkpoint
+          training resumes from step N+1
+```
+
+## `SIGUSR1`
+
+Intercepted identically to `SIGTERM`. Useful for a "nicely save and
+exit" command:
+
+```bash
+scancel --signal=USR1 <JOBID>
+```
+
+Forces a clean shutdown + checkpoint without relying on preemption
+timing. This is the recommended way to stop a run manually — don't
+`scancel` without a signal, because default `scancel` sends `SIGTERM`
+with a short grace period and may skip the emergency checkpoint if the
+step is long.
+
+## Troubleshooting
+
+**"Received SIGTERM" logged but no emergency checkpoint saved.** Usually
+means `shutdown_timeout_sec` was too short: the forced-exit timer fired
+while the async checkpoint was still writing. Increase the timeout.
+
+**Process hangs after "Shutdown requested".** Check for an in-flight
+NCCL collective that can't complete (peer already killed).
+`check_nccl_health()` from [NCCL liveness](nccl-liveness.md) is useful
+for detecting this proactively.
+
+**Checkpoint exists but resume starts from step 0.** Inspect
+`checkpoint/latest` — the symlink may be stale if a previous save
+crashed mid-write. See [Auto-resume](../checkpointing/auto-resume.md)
+for the resolution order.
+
+## See also
+
+- [NaN detection](nan-detection.md) — in-training failure mode; also
+  uses a "stop cleanly" pattern.
+- [NCCL liveness](nccl-liveness.md) — detect hung collectives before
+  they make preemption-handling fail.
+- [Auto-resume](../checkpointing/auto-resume.md) — what the *next* run
+  does after requeue.
+- [`scripts/slurm/7b_requeue.sh`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/slurm/7b_requeue.sh)
+  — preemption-resilient launch script.

--- a/docs/training/evaluation.md
+++ b/docs/training/evaluation.md
@@ -1,0 +1,151 @@
+# Evaluation
+
+KempnerForge runs evaluation two ways: **in-loop** (every
+`eval_config.interval` training steps) and **standalone** (via
+[`scripts/eval.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/eval.py)).
+Both call the same `run_eval` from
+[`kempnerforge/training/eval.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/eval.py).
+
+## `EvalConfig`
+
+```toml
+[eval]
+enabled = true
+interval = 1000                         # run eval every N training steps
+steps = 50                              # batches per evaluation
+
+# Pre-tokenized data:
+dataset_path = "/path/to/tokenized/eval"
+file_pattern = "*.npy"
+
+# Or HuggingFace streaming:
+hf_dataset_name = "wikitext"
+hf_dataset_config = "wikitext-103-raw-v1"
+hf_dataset_split = "validation"
+```
+
+Validation runs in `__post_init__`: `interval` and `steps` must be
+positive. The `dataset_path` / `hf_dataset_name` choice is made by the
+loader — if both are set, pre-tokenized takes precedence.
+
+## `run_eval`
+
+```python
+@torch.no_grad()
+def run_eval(
+    model, eval_dataloader, loss_fn, device, eval_steps,
+    *, pp_schedule=None, pp_rank=None, pp_size=None, pp_group=None,
+) -> dict[str, float]:
+```
+
+Returns
+
+```python
+{"eval/loss": avg_loss, "eval/perplexity": math.exp(min(avg_loss, 20.0))}
+```
+
+The `min(avg_loss, 20.0)` caps perplexity at `e^20 ≈ 5e8` so an early
+NaN-adjacent loss doesn't overflow the WandB / TensorBoard logger.
+
+`run_eval` toggles `model.eval()` on entry and `model.train()` on
+exit, so the training loop can call it mid-training without leaving the
+model in eval mode.
+
+### Standard path (no PP)
+
+Loops over `eval_steps` batches:
+
+```python
+for _ in range(eval_steps):
+    batch = next(eval_iter)
+    logits = model(input_ids)
+    loss   = loss_fn(logits, labels)
+    total_loss += loss.item()
+avg_loss = total_loss / eval_steps
+```
+
+If the eval dataloader runs out before `eval_steps`, it cycles — the
+`try/except StopIteration` refreshes `eval_iter`. So `eval_steps` can
+exceed the eval set's length without error, but the extra steps will
+repeat already-seen batches.
+
+### PP path (`pp_schedule` provided)
+
+Mirrors the [PP training step](training-loop.md#pp-step-pp_enabled-is-true):
+collects `eval_steps` batches into full tensors, feeds through
+`pp_schedule.step(..., losses=pp_losses)`, averages the per-microbatch
+losses on the last stage, then broadcasts a single scalar across the
+PP group:
+
+```python
+loss_tensor = torch.tensor([avg_loss], device=device)
+dist.broadcast(loss_tensor, group_src=pp_size - 1, group=pp_group)
+```
+
+All PP stages see the same `avg_loss` after the broadcast, which is
+what the metrics tracker expects.
+
+## In-loop evaluation
+
+The training loop fires eval at the top of the periodic-work section:
+
+```python
+if eval_config.enabled and eval_dataloader is not None \
+        and step % eval_config.interval == 0:
+    eval_metrics = run_eval(
+        model, eval_dataloader, loss_fn, device, eval_config.steps,
+        pp_schedule=pp_schedule, pp_rank=pp_rank, pp_size=pp_size,
+        pp_group=pp_group,
+    )
+    tracker.log_eval(eval_metrics, step)
+    hook_runner.on_eval_end(eval_metrics, step)
+```
+
+Cadence tuning:
+
+- `interval = 1000` with `steps = 50` means eval runs ~50 batches
+  every 1000 training steps. Keep `steps × batch_size` below 1% of your
+  training step cost or you'll pay it in visible wall time.
+- `steps` is independent of the eval set size — the loader cycles, so
+  small eval sets with large `steps` will repeat batches (biases the
+  estimate toward the loop position).
+
+## Standalone evaluation
+
+`scripts/eval.py` runs `run_eval` without training. It:
+
+1. Loads the same `JobConfig` you trained with (so model
+   architecture, tokenizer, parallelism mesh match).
+2. Forces `config.eval.enabled = True`.
+3. Builds the model **without pipeline parallel** (PP-eval in
+   `eval.py` is not implemented — standalone eval assumes single
+   forward).
+4. Creates a dummy `torch.optim.SGD(lr=0.0)` — unused, but required by
+   `CheckpointManager.load()`'s signature.
+5. Loads the checkpoint with `exclude_keys=["optimizer"]` so the
+   dummy SGD state isn't overwritten.
+6. Builds the eval dataloader (pre-tokenized or HF-streaming).
+7. Calls `run_eval` and prints the results + a JSON line for
+   programmatic consumption.
+
+Usage:
+
+```bash
+uv run torchrun --nproc_per_node=4 scripts/eval.py configs/train/7b.toml \
+    --checkpoint.load_path /path/to/checkpoint \
+    --eval.dataset_path /path/to/eval_tokens \
+    --eval.steps 200
+```
+
+The stdout-final JSON line (`{"step": ..., "tokens_seen": ...,
+"eval/loss": ..., "eval/perplexity": ...}`) is designed to be parsed —
+pipe it through `jq` for batch-evaluation sweeps.
+
+## See also
+
+- [Training loop § Periodic work](training-loop.md#periodic-work) —
+  where in-loop eval fires and in what order.
+- [Hooks § `on_eval_end`](hooks.md#lifecycle-events) — how to append
+  custom logic to every eval round.
+- [Configuration § EvalConfig](../configuration/config-sections.md) —
+  every field with its default.

--- a/docs/training/generation.md
+++ b/docs/training/generation.md
@@ -1,0 +1,150 @@
+# Generation
+
+Autoregressive decoding for research and debug, implemented in
+[`kempnerforge/model/generate.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/generate.py).
+Single-GPU only — not a production serving path.
+
+## `sample`
+
+```python
+from kempnerforge.model.generate import sample
+
+next_token = sample(logits, temperature=1.0, top_k=0, top_p=1.0)
+# (batch, vocab_size) -> (batch,)
+```
+
+Applies, in order:
+
+1. **`temperature == 0`** → `logits.argmax(dim=-1)` (greedy; short-circuit,
+   none of the filters below run).
+2. **Temperature scaling** → `logits / temperature`.
+3. **Top-k filtering** → keep the `top_k` largest values per batch row,
+   mask the rest with `-inf`. `top_k=0` disables.
+4. **Top-p (nucleus) filtering** → sort descending, keep the smallest
+   prefix whose probabilities sum to < `top_p`. `top_p=1.0` disables.
+5. **Sample** → `torch.multinomial(probs, num_samples=1).squeeze(-1)`.
+
+The order matters: top-k and top-p both operate on temperature-scaled
+logits, not raw ones.
+
+You can call `sample()` standalone for custom decode loops — it's the
+one-shot primitive behind `generate()`.
+
+## `generate`
+
+```python
+from kempnerforge.model.generate import generate
+
+@torch.no_grad()
+def generate(
+    model: Transformer,
+    prompt_tokens: torch.Tensor,        # (batch, prompt_len)
+    max_new_tokens: int,
+    *,
+    temperature: float = 1.0,
+    top_k: int = 0,
+    top_p: float = 1.0,
+    eos_token_id: int | None = None,
+) -> torch.Tensor:                      # (batch, total_len)
+```
+
+What it does:
+
+1. Saves `was_training`, switches `model.eval()`.
+2. Validates `prompt_len + max_new_tokens ≤ model.config.max_seq_len`
+   — raises `ValueError` otherwise.
+3. Allocates one `KVCache` per transformer layer, sized for the full
+   sequence (`batch_size, total_len, n_kv_heads, head_dim`), matching
+   the model's parameter dtype.
+4. **Prefill**: forwards the whole prompt through the model with the
+   KV caches; grabs the last-position logits.
+5. **Decode loop**: for `max_new_tokens` iterations:
+   - `sample()` to pick the next token.
+   - If `eos_token_id` is set, OR it into a per-row `done` mask; break
+     early if `done.all()`.
+   - Forward the single sampled token (`next_token.unsqueeze(1)`) with
+     the same KV caches to get the next logits.
+6. Restores `model.train()` if `was_training`.
+7. Returns `torch.cat([prompt_tokens, generated], dim=1)`.
+
+## KV cache
+
+Imported from
+[`kempnerforge.model.attention`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/attention.py).
+`generate()` allocates one cache per layer and passes them through the
+model via `model(..., kv_caches=kv_caches)`.
+
+Size: `batch_size × total_len × n_kv_heads × head_dim × 2 (K+V) × dtype_bytes`
+per layer, times `n_layers`. For a 7B Llama-3 at `batch=1, total_len=8192,
+bf16` that's ~2 GB of KV cache — easily fits on a single H200 but
+watch the budget for larger batches or longer contexts.
+
+## Stop criteria
+
+Two:
+
+- **`max_new_tokens`** — hard limit, always enforced.
+- **`eos_token_id`** — optional. When provided, generation stops early
+  only when **every** row in the batch has emitted EOS. A partial-batch
+  early-stop would require padding, which `generate()` doesn't
+  implement. If that matters, decode batches of size 1 or post-process
+  the output yourself.
+
+## Standalone CLI: `scripts/generate.py`
+
+```bash
+uv run python scripts/generate.py configs/train/7b.toml \
+    --checkpoint.load_path /path/to/checkpoint \
+    --prompt "The capital of France is" \
+    --max_tokens 64 \
+    --temperature 0.7 \
+    --top_p 0.9
+```
+
+Interactive REPL:
+
+```bash
+uv run python scripts/generate.py configs/train/7b.toml \
+    --checkpoint.load_path /path/to/checkpoint \
+    --interactive
+```
+
+The CLI loads the model via DCP (not through the full distributed
+stack — no FSDP2, no `init_distributed`), tokenizes the prompt with
+the HF tokenizer specified in `data.tokenizer_path`, calls
+`generate()`, decodes with `skip_special_tokens=True`, and prints the
+generated suffix.
+
+Args (beyond config / overrides):
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--prompt` | (required unless `--interactive`) | Prompt string |
+| `--max_tokens` | `128` | Max new tokens |
+| `--temperature` | `1.0` | Sampling temperature; `0` = greedy |
+| `--top_k` | `0` | Top-k cutoff; `0` = disabled |
+| `--top_p` | `1.0` | Nucleus threshold; `1.0` = disabled |
+| `--interactive` | `False` | REPL mode |
+| `--device` | auto | `cuda` / `cpu` |
+| `--dtype` | `bfloat16` | `float32` / `bfloat16` / `float16` |
+
+## Limitations
+
+- **Single-GPU only** — no FSDP / TP / PP model support in
+  `generate()`. For distributed inference, export to HF and use
+  vLLM or similar.
+- **No KV-cache reuse across calls** — each `generate()` call
+  allocates fresh caches. Good for research, wasteful for serving.
+- **No speculative decoding, no beam search, no repetition penalty** —
+  this is a minimal sampler for evaluating training progress, not a
+  generation stack. If you need any of those, fork `generate.py`.
+
+## See also
+
+- [Training loop § Periodic work](training-loop.md#periodic-work) —
+  training-time eval doesn't use `generate()`, only loss. Use
+  `generate()` for qualitative spot-checks between runs.
+- [Checkpointing](../checkpointing/index.md) — how `scripts/generate.py`
+  loads the DCP checkpoint it decodes from.
+- [Model § Attention paths](../architecture/model.md) — the KV-cache
+  path vs the training path through attention.

--- a/docs/training/gradient-utilities.md
+++ b/docs/training/gradient-utilities.md
@@ -1,0 +1,141 @@
+# Gradient utilities
+
+Two primitives govern how gradients move through the training loop:
+`maybe_no_sync` controls when they get reduced, `clip_grad_norm_`
+controls their magnitude.
+
+## `maybe_no_sync`
+
+```python
+from kempnerforge.training.grad import maybe_no_sync
+
+for micro_step in range(grad_accum_steps):
+    with maybe_no_sync(model, micro_step, grad_accum_steps):
+        logits = model(input_ids, doc_ids=doc_ids)
+        loss = loss_fn(logits, labels)
+        (loss / grad_accum_steps).backward()
+```
+
+Context manager from
+[`kempnerforge/training/grad.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/grad.py).
+On all microbatches except the last:
+
+```python
+model.set_requires_gradient_sync(False)
+try: yield
+finally: model.set_requires_gradient_sync(True)
+```
+
+Why:
+
+- FSDP2 fires a reduce-scatter collective at the end of every backward
+  pass. Without `maybe_no_sync`, a step with `grad_accum_steps = 8`
+  fires **8 collectives per optimizer step**. With it, the first 7
+  accumulate locally and the 8th fires one collective that covers all
+  accumulated gradients.
+- The method is FSDP2-specific (`set_requires_gradient_sync`). On
+  non-FSDP models (DDP, single GPU), `hasattr(model,
+  "set_requires_gradient_sync")` is `False` and the context is a
+  no-op — safe to use unconditionally.
+- On the last microbatch (`micro_step + 1 == grad_accum_steps`), the
+  context skips straight to `yield` so the final backward triggers a
+  normal reduce-scatter.
+
+Not used under pipeline parallel — the PP schedule manages its own
+sync internally. See
+[Training loop § PP step](training-loop.md#pp-step-pp_enabled-is-true).
+
+## `clip_grad_norm_`
+
+```python
+from kempnerforge.distributed import clip_grad_norm_
+
+grad_norm = clip_grad_norm_(model, tc.grad_clip_norm)
+```
+
+Lives in
+[`kempnerforge/distributed/utils.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/utils.py)
+(re-exported from `kempnerforge.distributed`). Wraps
+`torch.nn.utils.clip_grad_norm_` with an extra path for **mixed DTensor
+meshes**.
+
+The problem it solves: when a model combines TP and FSDP, some
+parameters are DTensors on the `(dp_shard, tp)` mesh (TP-sharded
+linears) and others are on `(dp_shard,)` alone (norm scales, biases).
+PyTorch's `clip_grad_norm_` doesn't know how to combine gradients
+living on different meshes — it would produce an incorrect norm.
+
+Algorithm:
+
+1. Collect all non-`None` `.grad` tensors from the model.
+2. Build a `mesh_key` per gradient (DTensor's `_spec.mesh` id, or `0`
+   for plain tensors).
+3. **If only one mesh** (pure FSDP, single GPU, plain tensors): call
+   `torch.nn.utils.clip_grad_norm_` directly — the fast path.
+4. **If multiple meshes**: group gradients by mesh, compute per-group
+   `sum-of-squares`, call `.full_tensor()` on each DTensor partial sum
+   so the underlying all-reduce happens, then combine across groups
+   with a plain `sqrt`.
+5. Scale every gradient by `clip_coef = max_norm / (total_norm +
+   1e-6)`, clamped to ≤ 1.
+
+Returns the **pre-clip** total norm as a scalar tensor — the value you
+log as `grad_norm` in metrics.
+
+### `foreach` parameter
+
+`clip_grad_norm_(..., foreach=True)` is the default — faster on CUDA
+via the fused foreach implementation. Only touched if your model
+contains some exotic parameter type that the foreach path can't
+handle.
+
+## Gradient accumulation in practice
+
+The full microbatching pattern in `scripts/train.py` is:
+
+```python
+for micro_step in range(tc.grad_accum_steps):
+    with maybe_no_sync(model, micro_step, tc.grad_accum_steps):
+        logits = model(input_ids, doc_ids=doc_ids)
+        loss   = loss_fn(logits, labels)
+        scaled_loss = loss / tc.grad_accum_steps
+        scaled_loss.backward()
+        total_loss += loss.item()
+
+grad_norm = clip_grad_norm_(model, tc.grad_clip_norm)
+optimizer.step()
+optimizer.zero_grad()
+```
+
+Two invariants:
+
+- **Loss scaling**: `scaled_loss = loss / grad_accum_steps` keeps the
+  effective LR independent of the accumulation factor. If you change
+  `grad_accum_steps=4 → 8`, the optimizer step size stays the same
+  per-token.
+- **Clip after accumulate**: `clip_grad_norm_` runs **after** the
+  microbatch loop, not inside it — the clip sees the final accumulated
+  gradient.
+
+## Config fields
+
+```toml
+[train]
+grad_accum_steps = 8                    # microbatches per optimizer step
+grad_clip_norm = 1.0                    # max grad L2 norm
+```
+
+Both live in
+[`TrainConfig`](../configuration/config-sections.md).
+`TrainConfig.__post_init__` requires `grad_clip_norm > 0` — there is no
+"disable clipping" escape hatch; `1.0` is a near-free safety margin
+and what every shipped config uses.
+
+## See also
+
+- [Training loop](training-loop.md) — where these utilities are called
+  from.
+- [Resilience § NaN detection](../resilience/index.md) — what happens
+  when `clip_grad_norm_` returns a NaN or Inf.
+- [Distributed § DeviceMesh](../distributed/index.md) — why gradients
+  on different meshes happen and what the mesh structure looks like.

--- a/docs/training/hooks.md
+++ b/docs/training/hooks.md
@@ -1,0 +1,159 @@
+# Hooks
+
+The `TrainingHook` interface in
+[`kempnerforge/training/hooks.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/hooks.py)
+is the supported way to run custom logic during training without
+forking [`scripts/train.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/train.py).
+
+## Interface
+
+```python
+from kempnerforge.training.hooks import TrainingHook, StepContext, HookRunner
+
+class MyHook(TrainingHook):
+    def on_train_begin(self, config): ...
+    def on_step_end(self, ctx: StepContext): ...
+    def on_eval_end(self, metrics: dict[str, float], step: int): ...
+    def on_checkpoint_save(self, step: int, path: str): ...
+    def on_train_end(self, step: int, tokens_seen: int): ...
+```
+
+`TrainingHook` is a concrete base class with empty method bodies —
+subclass and override only what you need. The `HookRunner` dispatches
+calls to a list of hooks; when the list is empty, each entry point
+short-circuits on an `if not self.hooks: return` check, so an unused
+runner costs one branch per call site.
+
+## `StepContext`
+
+Passed to `on_step_end`, every step:
+
+```python
+@dataclass
+class StepContext:
+    step: int
+    loss: float
+    grad_norm: float
+    lr: float
+    tokens_seen: int
+    model: torch.nn.Module
+    optimizer: torch.optim.Optimizer
+```
+
+`model` and `optimizer` are the live references — you can read
+parameter values and optimizer state. **Gradients have already been
+zeroed by the time `on_step_end` fires.** The loop order is:
+
+```python
+optimizer.step()
+scheduler.step()
+optimizer.zero_grad()                   # grads cleared here
+...
+tracker.end_step(...)
+hook_runner.on_step_end(StepContext(...))
+```
+
+If your hook needs to inspect gradients, it can't — you need to
+modify `train.py` and capture them before `optimizer.zero_grad()`. The
+`wandb.log` of `p.grad.norm()` in the module's docstring example
+requires capturing the norms during the backward pass (via a
+pre-`zero_grad` hook), not reading `p.grad` in `on_step_end`.
+
+## Lifecycle events
+
+| Event | Fires at | What you get |
+|-------|----------|--------------|
+| `on_train_begin(config)` | Once, after setup, before the loop | Full `JobConfig` |
+| `on_step_end(ctx)` | Every training step, after metrics | `StepContext` |
+| `on_eval_end(metrics, step)` | After every eval round | `{"eval/loss": ..., "eval/perplexity": ...}` |
+| `on_checkpoint_save(step, path)` | After a DCP checkpoint is written | `path` is `config.checkpoint.dir` |
+| `on_train_end(step, tokens_seen)` | Once, after the loop exits (normal or shutdown) | Final counters |
+
+Ordering at step boundaries:
+
+```
+… step body …
+tracker.end_step(...)                   # metrics dispatched to WandB/TB
+hook_runner.on_step_end(StepContext(...))
+# MoE-specific metrics logged
+# NCCL health / eval / profiler / checkpoint / shutdown
+```
+
+`on_step_end` fires **after** the metrics tracker — logging from a
+hook into WandB happens on the same step number, not a step off. At
+the end of a checkpoint-save step, the order is `on_step_end` first,
+then `on_checkpoint_save`.
+
+## Registering hooks
+
+Hooks are created in-process, not from TOML:
+
+```python
+# In a custom launcher that imports scripts/train.py as a library,
+# or in a fork that monkey-patches the hook_runner after construction:
+
+from kempnerforge.training.hooks import HookRunner
+hook_runner = HookRunner([MyHook1(), MyHook2()])
+```
+
+`scripts/train.py` instantiates `HookRunner()` with no hooks at line
+502. To register hooks today, you either fork `train.py` to pass a
+populated list, or import-and-patch from a custom entry point.
+A config-driven hook registry is not yet wired up.
+
+## When to write a hook vs fork `train.py`
+
+| Task | Hook or fork |
+|------|--------------|
+| Custom WandB logging (histograms, attention maps from eval) | **Hook** (`on_step_end`, `on_eval_end`) |
+| External heartbeat / health ping | **Hook** (`on_step_end`) |
+| Upload checkpoint to S3 after save | **Hook** (`on_checkpoint_save`) |
+| Inspect gradients | **Fork** (grads are zeroed before `on_step_end`) |
+| Inject a custom optimizer step | **Fork** (no `on_pre_optimizer_step` event) |
+| Change the loss function mid-run | **Fork** (`loss_fn` is closed over once at setup) |
+| Custom learning-rate schedule not in the registry | Register a new scheduler, not a hook |
+
+The guiding principle: hooks observe, they don't intervene. Anything
+that needs to modify the step (not just log about it) belongs in a
+fork or a new registry entry.
+
+## Example: per-step gradient-norm histogram
+
+```python
+class GradHistogramHook(TrainingHook):
+    """Stash pre-clip grad norms during backward, log them in on_step_end.
+
+    This requires adding a forward hook during on_train_begin because
+    gradients are zeroed by the time on_step_end fires.
+    """
+    def __init__(self) -> None:
+        self._norms: dict[str, float] = {}
+
+    def on_train_begin(self, config) -> None:
+        # Subclass or patch training loop to populate _norms during backward
+        pass
+
+    def on_step_end(self, ctx: StepContext) -> None:
+        if self._norms:
+            wandb.log(
+                {f"grad_norm/{n}": v for n, v in self._norms.items()},
+                step=ctx.step,
+            )
+            self._norms.clear()
+```
+
+The pragmatic version: for a one-off gradient-norm histogram, just
+edit `scripts/train.py` to log it directly after the microbatch loop —
+the hook machinery adds complexity when you only ever need one
+logger.
+
+## See also
+
+- [Training loop § Metrics and hooks](training-loop.md#metrics-and-hooks)
+  — exact ordering of `tracker.end_step` vs `hook_runner.on_step_end`.
+- [Metrics and profiling](../metrics-and-profiling/index.md) —
+  `MetricsTracker`, the out-of-the-box logger your hook complements.
+- [Evaluation § In-loop](evaluation.md#in-loop-evaluation) — where
+  `on_eval_end` fires.
+- [Checkpointing](../checkpointing/index.md) — where
+  `on_checkpoint_save` fires.

--- a/docs/training/index.md
+++ b/docs/training/index.md
@@ -1,0 +1,51 @@
+# Training
+
+The training loop itself and the knobs around it: optimizers, LR
+schedulers, loss functions, gradient utilities, in-loop evaluation,
+sampling, and the `TrainingHook` extension point.
+
+The [Data flow](../architecture/data-flow.md) page is the one-slide
+overview of the step. This section zooms into each collaborator.
+
+```{toctree}
+:maxdepth: 1
+
+training-loop
+optimizers
+schedulers
+losses
+gradient-utilities
+evaluation
+generation
+hooks
+```
+
+- **[Training loop](training-loop.md)** — a reader's walkthrough of
+  [`scripts/train.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/train.py):
+  setup, the two step bodies (PP vs non-PP), phase transitions,
+  periodic work.
+- **[Optimizers](optimizers.md)** — `adamw`, `lion`, `muon`,
+  `schedule_free_adamw`: the four registered optimizers, when to pick
+  each, decay grouping, DTensor / FSDP2 notes.
+- **[Schedulers](schedulers.md)** — `cosine`, `linear`, `wsd`,
+  `constant`, `rex`, `none`: warmup and decay math, required fields.
+- **[Losses](losses.md)** — `cross_entropy`, `chunked_cross_entropy`,
+  and `z_loss` as a train-config regularizer (`train.z_loss_weight`).
+- **[Gradient utilities](gradient-utilities.md)** — `maybe_no_sync` for
+  accumulation, `clip_grad_norm_` for DTensor-aware clipping.
+- **[Evaluation](evaluation.md)** — `run_eval()`, `EvalConfig`, the PP
+  eval path, standalone
+  [`scripts/eval.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/eval.py).
+- **[Generation](generation.md)** — `generate()` from
+  [`kempnerforge/model/generate.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/model/generate.py),
+  top-k / top-p / temperature, KV cache, standalone
+  [`scripts/generate.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/generate.py).
+- **[Hooks](hooks.md)** — `TrainingHook`, `HookRunner`, lifecycle
+  events, when to fork `train.py` vs write a hook.
+
+## See also
+
+- [Data flow](../architecture/data-flow.md) — the one-page training
+  loop overview.
+- [Configuration § TrainConfig](../configuration/config-sections.md) —
+  every field this subsystem reads.

--- a/docs/training/losses.md
+++ b/docs/training/losses.md
@@ -1,0 +1,129 @@
+# Losses
+
+Two loss functions are registered in
+[`kempnerforge/training/loss.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/loss.py):
+`cross_entropy` and `chunked_cross_entropy`. z-loss is a regularizer
+that wraps *either* — not a separate registry entry.
+
+## `cross_entropy`
+
+```toml
+[train]
+loss_fn = "cross_entropy"
+```
+
+Direct call to `F.cross_entropy` over flattened
+`(batch·seq_len, vocab_size)` logits and `(batch·seq_len,)` labels.
+`ignore_index = -100` is hard-coded; labels with `-100` are skipped in
+the reduction. This is how
+[document-packed sequences](../data/index.md) mask out cross-document
+attention — tokens at packing boundaries get label `-100` so the loss
+doesn't cross document edges.
+
+Returns `0.0` (as a device tensor) when every label is `-100` — avoids
+a NaN from dividing by zero valid tokens.
+
+## `chunked_cross_entropy`
+
+```toml
+[train]
+loss_fn = "chunked_cross_entropy"
+ce_chunk_size = 4096                    # 0 -> auto 4096
+```
+
+Identical output to `cross_entropy`, but computed in chunks along the
+flattened token dimension. Use this when the full logit tensor would
+be large enough to matter — a 7B Llama-3 with `batch=4`, `seq=4096`,
+`vocab=128000` materializes an **8 GB** float32 cross-entropy
+intermediate if computed end-to-end.
+
+Mechanics:
+
+- The loop iterates `for i in range(0, num_tokens, chunk_size)` and
+  accumulates per-chunk loss with `reduction="sum"`.
+- At the end, divides by the number of non-ignored tokens across all
+  chunks to recover the mean.
+- `ignore_index = -100` is threaded through per chunk.
+
+Important: chunking saves memory **inside the loss kernel**, not in the
+output projection. The `(batch, seq_len, vocab_size)` logit tensor
+that the model produces is still materialized — `chunked_cross_entropy`
+only avoids the second full-size tensor that `F.cross_entropy`
+internally allocates for the softmax.
+
+`ce_chunk_size = 0` in the config is a sentinel for "use the default
+4096" — see
+[`build_loss_fn`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/loss.py).
+
+## z-loss (logit magnitude regularizer)
+
+```toml
+[train]
+loss_fn = "cross_entropy"               # or chunked_cross_entropy
+z_loss_weight = 1e-4                    # 0 -> disabled
+```
+
+z-loss penalizes large log-sum-exp values — equivalent to penalizing
+the softmax normalizer from running off. It is a PaLM / Gemma trick for
+keeping logits in a numerically sane range without clamping.
+
+Formula:
+
+```
+z_loss = z_loss_weight * mean(logsumexp(logits)^2)
+```
+
+How it wires in: `build_loss_fn` wraps the base loss with a closure
+that adds `z_loss(logits, z_weight)` to the returned loss. The wrap
+happens once at setup; the per-step overhead is one `logsumexp` over
+the logit tensor.
+
+Recommended weights from the literature:
+
+| Value | Source |
+|-------|--------|
+| `1e-4` | PaLM |
+| `1e-4` – `2e-4` | Gemma |
+| `0.0` | off; default |
+
+`z_loss_weight = 0.0` makes the wrap a no-op — the closure still runs
+but `z_loss()` returns `0.0` immediately without computing
+`logsumexp`.
+
+## MoE auxiliary loss is separate
+
+The MoE load-balancing loss is **not** part of this pipeline. It
+lives on the model (`model.get_moe_aux_loss()`) and is added to the
+base loss in the training loop:
+
+```python
+loss = loss_fn(logits, labels)
+if mc.is_moe:
+    loss = loss + mc.moe_aux_loss_weight * model.get_moe_aux_loss()
+```
+
+See [MoE](../moe/index.md) for how `get_moe_aux_loss()` sums the
+per-layer router aux losses.
+
+## Picking one
+
+| Situation | Loss | z-loss |
+|-----------|------|--------|
+| Small model, tight compile, small vocab | `cross_entropy` | off |
+| 7B+ with large vocab (≥ 50K) | `chunked_cross_entropy` | optional |
+| Muon / aggressive LRs / long runs | either | `1e-4` |
+| PaLM / Gemma-style recipe | `chunked_cross_entropy` | `1e-4` |
+
+The shipped
+[`7b_16gpu_muon.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_muon.toml)
+is the reference combination: Muon + chunked cross-entropy +
+z-loss — exercises all three paths together.
+
+## See also
+
+- [Training loop § Non-PP step](training-loop.md#non-pp-step-pp_enabled-is-false)
+  — where `loss_fn(logits, labels)` is called.
+- [Configuration § TrainConfig](../configuration/config-sections.md) —
+  `loss_fn`, `ce_chunk_size`, `z_loss_weight`.
+- [MoE](../moe/index.md) — how the MoE aux loss composes with the
+  cross-entropy / z-loss stack.

--- a/docs/training/optimizers.md
+++ b/docs/training/optimizers.md
@@ -1,0 +1,165 @@
+# Optimizers
+
+Four optimizers are registered in
+[`kempnerforge/training/optimizer.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/optimizer.py):
+`adamw`, `lion`, `muon`, `schedule_free_adamw`. All are constructed by
+`build_optimizer(model, config)`, which routes by `config.name` through
+the registry.
+
+## Shared setup: decay grouping
+
+Before any optimizer is constructed, `build_optimizer` splits the
+parameters into two groups:
+
+| Group | Condition | `weight_decay` |
+|-------|-----------|----------------|
+| decay | `param.ndim > 1` and `"bias"` not in name | `config.weight_decay` |
+| no-decay | 1D tensors, biases, norm scales | `0.0` |
+
+The rule is `_should_decay(name, param)` in
+[`optimizer.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/optimizer.py) —
+shared by all four optimizers. No decay on biases / norms is the
+Llama / GPT convention; Muon's 1D fallback AdamW inherits the same
+grouping.
+
+## `adamw`
+
+```toml
+[optimizer]
+name = "adamw"
+lr = 3e-4
+betas = [0.9, 0.95]
+eps = 1e-8
+weight_decay = 0.1
+fused = true
+```
+
+Direct wrapper of `torch.optim.AdamW`. `fused = true` enables the
+fused CUDA kernel on PyTorch 2.x + CUDA; falls back to foreach
+implementation otherwise. The `fused` kernel is the default in every
+shipped dense config.
+
+Memory: 2 optimizer-state tensors per parameter (exp_avg, exp_avg_sq)
+in fp32 — the master-weight budget most estimators assume.
+
+## `lion`
+
+```toml
+[optimizer]
+name = "lion"
+lr = 1e-4
+betas = [0.9, 0.99]
+weight_decay = 0.01
+```
+
+Sign-momentum optimizer. The update rule is
+`update = sign(β₁·m + (1-β₁)·g)`, with one momentum buffer per
+parameter — roughly half AdamW's optimizer-state memory.
+
+Notes from the code:
+
+- **LR is ~3-10× smaller than AdamW's** — Lion's sign-valued update is
+  O(1) per coordinate regardless of gradient scale.
+- **Decoupled weight decay**: `p.data.mul_(1 - lr * wd)` before the
+  sign-update step (no interaction with momentum).
+- **No `eps`** — Lion's update never divides by a state tensor.
+
+## `schedule_free_adamw`
+
+```toml
+[optimizer]
+name = "schedule_free_adamw"
+lr = 0.025
+betas = [0.9, 0.999]
+eps = 1e-8
+schedule_free_warmup_steps = 2000
+
+[scheduler]
+name = "none"                           # required
+```
+
+Defazio's Schedule-Free AdamW. Replaces the external LR schedule with
+an internal Polyak-averaging trick that tracks an iterate `z`, a
+running average `x`, and a weight sum. The TOML-visible `scheduler.name
+= "none"` is required — adding an external cosine or linear schedule
+breaks the internal averaging.
+
+Gotchas:
+
+- **Eval mode switch**: call `optimizer.eval_params()` before
+  validation and `optimizer.train_params()` after, to swap in the
+  averaged weights `x` and restore the iterate `z`. This is not
+  automatic in the current loop.
+- **Internal warmup**: `schedule_free_warmup_steps` is the optimizer's
+  own linear warmup, independent of any external scheduler. Zero
+  disables it.
+- **LR is 10-100× larger than AdamW's** — the Polyak averaging absorbs
+  aggressive step sizes.
+
+## `muon`
+
+```toml
+[optimizer]
+name = "muon"
+lr = 0.02
+muon_momentum = 0.95
+muon_ns_steps = 5
+# muon_adam_lr omitted -> use same LR as Muon for 1D params
+weight_decay = 0.1
+betas = [0.9, 0.95]                     # used by internal AdamW for 1D params
+eps = 1e-8
+```
+
+Keller Jordan's Muon. Applies Newton-Schulz orthogonalization to the
+momentum buffer of each 2D weight before stepping; 1D parameters
+(biases, norms, highly rectangular matrices) fall through to an
+internal AdamW with the same hyperparameters.
+
+How it decides which path each parameter takes
+(`_is_muon_eligible`):
+
+- 2D weight, aspect ratio ≤ 10 → Muon orthogonalized update.
+- 1D, or ratio > 10 → internal AdamW fallback.
+
+DTensor / FSDP2 notes:
+
+- Muon's orthogonalization runs on the **local shard**, not the full
+  weight. It calls `_get_local_tensor(p)` to unwrap DTensors before
+  Newton-Schulz. Empirically fine in practice; not mathematically
+  identical to full-matrix orthogonalization.
+- Momentum buffers match the parameter dtype (`torch.zeros_like(p.grad)`),
+  so DCP serializes them correctly on resume.
+- `muon_adam_lr` unset (default) makes the internal AdamW use the same
+  LR as Muon. Pass a smaller value (e.g. `muon_adam_lr = 1e-4`) if you
+  want 1D params on a gentler schedule.
+
+Newton-Schulz coefficients (hard-coded): `a = 3.4445, b = -4.7750, c =
+2.0315`, Frobenius-normalized input — standard values from the Muon
+paper.
+
+The shipped
+[`7b_16gpu_muon.toml`](https://github.com/KempnerInstitute/KempnerForge/blob/main/configs/train/7b_16gpu_muon.toml)
+combines Muon with z-loss + chunked cross-entropy as an integration
+test of all three features together.
+
+## Picking one
+
+| Situation | Pick |
+|-----------|------|
+| Default, known-good | `adamw` with `fused = true` |
+| Half the optimizer-state memory, accept LR re-tuning | `lion` |
+| Want to skip scheduler tuning | `schedule_free_adamw` (`scheduler.name = "none"`) |
+| Research recipe for large dense runs | `muon` |
+
+For any optimizer, the decay-vs-no-decay grouping is handled
+automatically — no need to thread `no_decay_params` through your config.
+
+## See also
+
+- [Schedulers](schedulers.md) — the `scheduler.*` side, including
+  `"none"` for schedule-free.
+- [Configuration § OptimizerConfig](../configuration/config-sections.md) —
+  every field and its default.
+- [Training loop § Optimizer step](training-loop.md#optimizer-and-scheduler-step)
+  — where `optimizer.step()` fires and how phase LR scaling layers on
+  after.

--- a/docs/training/schedulers.md
+++ b/docs/training/schedulers.md
@@ -1,0 +1,162 @@
+# Schedulers
+
+Six schedulers are registered in
+[`kempnerforge/training/scheduler.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/training/scheduler.py):
+`cosine`, `linear`, `wsd`, `constant`, `rex`, `none`. All return a
+`torch.optim.lr_scheduler.LambdaLR` — a single callable that multiplies
+the optimizer's base LR by a schedule-dependent factor at each
+`scheduler.step()`.
+
+## Shared warmup
+
+Every schedule (except `"none"`) warms up linearly from `0` to `1.0`
+over `warmup_steps`. The helper is
+
+```python
+def _warmup_factor(step, warmup_steps):
+    return min(1.0, step / warmup_steps)
+```
+
+So all the fields below describe the **decay** phase, after warmup
+completes.
+
+## `cosine`
+
+```toml
+[scheduler]
+name = "cosine"
+warmup_steps = 2000
+# decay_steps omitted -> max_steps - warmup_steps
+min_lr_ratio = 0.1
+```
+
+Classic cosine decay from `1.0` to `min_lr_ratio` over `decay_steps`:
+
+```
+factor = min_ratio + 0.5 * (1 - min_ratio) * (1 + cos(π · progress))
+```
+
+where `progress = (step - warmup_steps) / decay_steps`, clamped to `[0,
+1]`. After `decay_steps`, LR stays flat at `base_lr * min_lr_ratio`.
+
+## `linear`
+
+```toml
+[scheduler]
+name = "linear"
+warmup_steps = 2000
+# decay_steps omitted -> max_steps - warmup_steps
+min_lr_ratio = 0.0
+```
+
+Linear decay from `1.0` to `min_lr_ratio`:
+
+```
+factor = 1 - (1 - min_ratio) · progress
+```
+
+Straight line in LR space. Most commonly used with `min_lr_ratio =
+0.0` for strict linear-to-zero cooldowns.
+
+## `wsd`
+
+```toml
+[scheduler]
+name = "wsd"
+warmup_steps = 2000
+stable_steps = 80000
+decay_steps = 18000
+min_lr_ratio = 0.0
+wsd_decay_type = "cosine"               # "cosine", "linear", or "sqrt"
+```
+
+Warmup-Stable-Decay: three segments.
+
+| Phase | Steps | LR factor |
+|-------|-------|-----------|
+| warmup | `[0, warmup_steps)` | linear `0 → 1` |
+| stable | `[warmup_steps, warmup_steps + stable_steps)` | `1.0` |
+| decay | `[warmup + stable, warmup + stable + decay_steps)` | selected shape down to `min_lr_ratio` |
+
+`wsd_decay_type` picks the cooldown shape:
+
+- `"cosine"` — `min_ratio + 0.5 · (1 - min_ratio) · (1 + cos(π · p))`
+- `"linear"` — `1 - (1 - min_ratio) · p`
+- `"sqrt"` — `min_ratio + (1 - min_ratio) · sqrt(1 - p)`
+
+WSD pairs well with curriculum-style data schedules — the flat stable
+phase is a natural time to anneal data mixtures, then the decay phase
+hardens the model on the final mixture.
+
+## `constant`
+
+```toml
+[scheduler]
+name = "constant"
+warmup_steps = 2000
+```
+
+Warmup to `1.0`, then hold. No decay. Useful for short experiments and
+for debugging the interaction of loss / optimizer with the rest of the
+stack without a moving LR.
+
+## `rex`
+
+```toml
+[scheduler]
+name = "rex"
+warmup_steps = 2000
+# decay_steps omitted -> max_steps - warmup_steps
+min_lr_ratio = 0.1
+rex_alpha = 1.0
+```
+
+Polynomial decay (REX):
+
+```
+factor = max(min_ratio, (1 - progress) ** alpha)
+```
+
+`rex_alpha = 1.0` is a linear decay; `< 1` is concave (fast early,
+slow late); `> 1` is convex (slow early, fast late). Reasonable values
+are in `[0.5, 2.0]`.
+
+## `none`
+
+```toml
+[scheduler]
+name = "none"
+```
+
+Returns a constant `1.0`. No warmup, no decay. Pair with
+`schedule_free_adamw`, which manages its own warmup internally —
+adding any external schedule on top will interfere with the internal
+Polyak averaging.
+
+## Choosing a scheduler
+
+| Situation | Pick |
+|-----------|------|
+| Default dense pretraining | `cosine` to `min_lr_ratio=0.1` |
+| Need to continue training beyond `decay_steps` | `constant` or `wsd` (keeps LR schedulable) |
+| Anneal data mix then cool down | `wsd` with `wsd_decay_type="linear"` |
+| Schedule-free optimizer | `none` |
+| Linear cooldown to zero | `linear` with `min_lr_ratio=0.0` |
+
+## How phase LR scaling layers on top
+
+The training loop applies `phase_lr_scale` *after* `scheduler.step()`
+each step (see
+[Training loop § Optimizer step](training-loop.md#optimizer-and-scheduler-step)).
+The scheduler computes the base LR; the phase scales it. So a cosine
+schedule with `phase.lr_scale = 0.5` in a curriculum phase halves the
+cosine LR for that phase without touching the scheduler's own state.
+
+## See also
+
+- [Optimizers](optimizers.md) — in particular `schedule_free_adamw`,
+  which requires `scheduler.name = "none"`.
+- [Configuration § SchedulerConfig](../configuration/config-sections.md) —
+  the dataclass with defaults.
+- [Data § Phase schedule](../data/index.md) — curriculum phases that
+  can overlay `lr_scale` on whatever the scheduler produces.

--- a/docs/training/training-loop.md
+++ b/docs/training/training-loop.md
@@ -1,0 +1,207 @@
+# Training loop
+
+Companion to [Data flow](../architecture/data-flow.md): where that page
+maps the whole step onto one diagram,
+[`scripts/train.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/scripts/train.py)
+zooms into the two step bodies (PP vs non-PP), the conditional paths,
+and the periodic work.
+
+## Two step bodies
+
+`scripts/train.py` has a single outer loop but two internal step bodies
+selected on `pp_enabled = config.distributed.pp > 1`. The paths diverge
+on how microbatching interacts with the communication pattern.
+
+### Non-PP step (`pp_enabled is False`)
+
+```python
+for micro_step in range(tc.grad_accum_steps):
+    batch = next(data_iter)
+    with maybe_no_sync(model, micro_step, tc.grad_accum_steps):
+        if mc.is_moe:
+            model.set_moe_step(step, tc.max_steps)
+        logits = model(input_ids, doc_ids=doc_ids)
+        loss   = loss_fn(logits, labels)
+        if mc.is_moe:
+            loss = loss + mc.moe_aux_loss_weight * model.get_moe_aux_loss()
+        (loss / tc.grad_accum_steps).backward()
+```
+
+Key mechanics:
+
+- **`maybe_no_sync`** (see [Gradient utilities](gradient-utilities.md))
+  disables FSDP2's reduce-scatter on all but the last microbatch. One
+  collective fires per optimizer step instead of `grad_accum_steps`.
+- **Per-dataset metrics** — if the dataloader is a `MixtureDataset`,
+  per-dataset loss is computed inside the `no_sync` block while logits
+  are still alive (`scripts/train.py` lines 606-622).
+- **Loss scaling** — `loss / grad_accum_steps` keeps the effective
+  learning rate invariant to the accumulation factor.
+
+### PP step (`pp_enabled is True`)
+
+```python
+input_ids_list, labels_list = [], []
+for _ in range(tc.grad_accum_steps):
+    batch = next(data_iter)
+    input_ids_list.append(batch["input_ids"].to(device))
+    labels_list.append(batch["labels"].to(device))
+
+full_input  = torch.cat(input_ids_list, dim=0)
+full_labels = torch.cat(labels_list, dim=0)
+
+if is_first: pp_schedule.step(full_input, target=full_labels, losses=pp_losses)
+elif is_last: pp_schedule.step(target=full_labels, losses=pp_losses)
+else:        pp_schedule.step()
+```
+
+Under PP, microbatches are collected up front and handed as one tensor
+to the schedule (`1f1b` / `gpipe`, built by
+[`build_pipeline_schedule`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/pipeline_parallel.py)).
+The schedule splits along dim 0 internally; the Python loop only sees
+one `step()` call. Loss is meaningful only on the last stage and is
+broadcast across the PP dimension for logging
+(`scripts/train.py` lines 556-571).
+
+## Gradient clipping and NaN check
+
+After the step body (either branch):
+
+```python
+grad_norm = clip_grad_norm_(model, tc.grad_clip_norm)
+if not nan_detector.check_loss(avg_loss, step):
+    optimizer.zero_grad()
+    if nan_detector.should_rollback:
+        break
+    step += 1; continue
+```
+
+`clip_grad_norm_` is the DTensor-aware wrapper from
+[`kempnerforge.distributed.utils`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/distributed/utils.py) —
+see [Gradient utilities](gradient-utilities.md).
+`NaNDetector.check_loss` returns `False` on NaN / Inf, zeroes grads,
+and escalates to `should_rollback` after
+`nan_consecutive_max` bad steps (see
+[Resilience](../resilience/index.md)).
+
+## Optimizer and scheduler step
+
+```python
+optimizer.step()
+scheduler.step()
+if phase_lr_scale != 1.0:
+    for pg in optimizer.param_groups: pg["lr"] *= phase_lr_scale
+optimizer.zero_grad()
+```
+
+Phase LR scaling runs *after* the scheduler — it multiplies the base
+LR that `scheduler.step()` just computed. This lets a curriculum phase
+(see [Data](../data/index.md)) halve the LR for a cooldown segment
+without rewriting the scheduler.
+
+## Phase transitions
+
+```python
+while current_phase_idx < len(active_phases) \
+        and step >= active_phases[current_phase_idx].start_step:
+    phase = active_phases[current_phase_idx]
+    new_weights = [phase.dataset_weights.get(name, original_weights_dict[name])
+                   for name in mixture_dataset.dataset_names]
+    sampler.update_weights(new_weights, temperature=config.data.mix_temperature)
+    phase_lr_scale = phase.lr_scale
+    current_phase_idx += 1
+    data_iter = None   # force refresh so new weights take effect
+```
+
+`data_iter = None` forces a fresh iterator on the next microbatch —
+without it, the already-materialized iterator would keep emitting
+batches from the old weights for one more step.
+
+## Metrics and hooks
+
+Metrics fire first, hooks second:
+
+```python
+step_metrics = tracker.end_step(step=step, loss=avg_loss,
+                                grad_norm=grad_norm_val, lr=current_lr,
+                                tokens_in_step=tokens_in_step)
+hook_runner.on_step_end(StepContext(
+    step=step, loss=avg_loss, grad_norm=grad_norm_val, lr=current_lr,
+    tokens_seen=tokens_seen, model=model, optimizer=optimizer,
+))
+```
+
+`StepContext` freezes the full step state for hooks that need to read
+gradients or parameter values before the next iteration. See
+[Hooks](hooks.md).
+
+MoE-specific metrics (`moe/aux_loss`, per-expert token counts) are
+logged immediately after, only when `step_metrics is not None` — that
+is, only on `metrics.log_interval` boundaries.
+
+## Periodic work
+
+After the step body, before advancing:
+
+| Tick | Trigger | What it does |
+|------|---------|--------------|
+| NCCL health | `step % tc.nccl_health_check_interval == 0` | Small all-reduce; break on failure |
+| Eval | `step % eval_config.interval == 0` | [`run_eval`](evaluation.md), `on_eval_end` hook |
+| Profiler | every step | `prof.step()` advances the schedule |
+| Checkpoint | `step % checkpoint.interval == 0` | `ckpt_mgr.save(step)`, `on_checkpoint_save` hook |
+| Shutdown | SIGTERM / SIGUSR1 pending | `ckpt_mgr.save(emergency=True)`, break |
+
+`nccl_health_check_interval = 0` disables the all-reduce probe — it is
+off in every shipped config but worth enabling for long multi-node
+runs. See [Resilience § NCCL health](../resilience/index.md).
+
+## Entry-point setup
+
+Before the loop:
+
+1. `load_config(path, cli_args)` — TOML + CLI overrides into a
+   `JobConfig` dataclass.
+2. `init_distributed(config.distributed, seed=...)` — `dist.init_process_group`,
+   `DeviceMesh`, seeded RNG.
+3. `build_loss_fn(tc)` — loss registry lookup with optional z-loss wrap
+   (see [Losses](losses.md)).
+4. `build_parallel_model(...)` — architecture + full parallelism stack
+   (see [Parallelism order](../architecture/parallelism-order.md)).
+5. `build_optimizer(model, config.optimizer)` — decay grouping +
+   registry lookup (see [Optimizers](optimizers.md)).
+6. `build_scheduler(optimizer, config.scheduler, max_steps=tc.max_steps)` —
+   warmup + decay LambdaLR (see [Schedulers](schedulers.md)).
+7. `CheckpointManager(...)`, `resolve_resume_path(...)` — auto-resume
+   from the `latest` symlink.
+8. `MetricsTracker`, `HookRunner`, data pipeline, optional eval
+   dataloader, optional profiler.
+
+The full list with links lives in
+[Data flow § Startup, once](../architecture/data-flow.md#startup-once).
+
+## Shutdown
+
+After the loop:
+
+```python
+prof.stop()
+ckpt_mgr.wait()                        # drain last async save
+hook_runner.on_train_end(step, tokens_seen)
+tracker.close()
+destroy_distributed()
+```
+
+`ckpt_mgr.wait()` is load-bearing — without it, a rank can exit before
+its async DCP write completes, corrupting the checkpoint for
+everyone else on the same save. See
+[Checkpointing § Async save](../checkpointing/index.md).
+
+## See also
+
+- [Data flow](../architecture/data-flow.md) — the same loop, as a
+  single diagram.
+- [Optimizers](optimizers.md), [Schedulers](schedulers.md),
+  [Losses](losses.md) — the collaborators this loop composes.
+- [Gradient utilities](gradient-utilities.md) — `maybe_no_sync`,
+  `clip_grad_norm_`.
+- [Hooks](hooks.md) — the extension points this loop fires.

--- a/examples/quickstart.md
+++ b/examples/quickstart.md
@@ -1,97 +1,19 @@
-# KempnerForge Quick Start
+# Quickstart has moved
 
-A 5-minute walkthrough that trains a tiny model so you can
-verify your install and see the training loop end-to-end.
+The 5-minute walkthrough now lives in the hosted Sphinx documentation:
 
-> **Tip**: when you change `model.vocab_size`, `model.dim`, or any other shape-affecting field between runs, use a fresh `--checkpoint.dir` or delete the old one first. `train.py` auto-resumes from the latest checkpoint in the directory, which will fail with a shape mismatch if the architecture changed. Examples below use `/tmp/` paths so runs don't collide.
+- **Source**: [`docs/getting-started/quickstart.md`](../docs/getting-started/quickstart.md)
+- **Rendered**: published on GitHub Pages on every push to `main` (see
+  [Docs workflow](../.github/workflows/docs.yml) for deployment details).
 
-## 1. Install
+The `examples/` directory still hosts runnable files that complement the
+docs:
 
-```bash
-git clone git@github.com:KempnerInstitute/KempnerForge.git
-cd KempnerForge
-uv sync
-```
+- [`custom_hook.py`](custom_hook.py) — four training-hook examples
+  (gradient-norm histogram, learning-dynamics, early stopping, MoE
+  expert load balance).
+- [`notebooks/`](notebooks/) — six single-GPU Jupyter notebooks for
+  model inspection, interpretability, and MoE diagnostics.
 
-## 2. Run a 20M-parameter debug model on a single GPU
-
-```bash
-uv run python scripts/train.py configs/train/debug.toml \
-  --checkpoint.dir=/tmp/kf_quickstart/step2
-```
-
-You should see per-step loss / MFU / step_time logs. The run takes <1 minute.
-It uses synthetic data (no dataset download) — useful for sanity-checking the
-install before pointing at real data.
-
-## 3. Multi-GPU on a single node (FSDP2)
-
-```bash
-uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/debug.toml \
-  --distributed.dp_shard=4 \
-  --checkpoint.dir=/tmp/kf_quickstart/step3
-```
-
-## 4. Point at your own tokenized data
-
-Pre-tokenized `.bin` or `.npy` shards work directly:
-
-```bash
-uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/debug.toml \
-  --data.dataset_path=/path/to/your/shards \
-  --data.file_pattern='tokenized_*.bin' \
-  --model.vocab_size=128256 \
-  --checkpoint.dir=/tmp/kf_quickstart/step4
-```
-
-Or stream from HuggingFace:
-
-```bash
-uv run python scripts/train.py configs/train/hf_wikitext.toml \
-  --checkpoint.dir=/tmp/kf_quickstart/step4_hf
-```
-
-## 5. Try a different optimizer
-
-Swap AdamW for Muon without touching code:
-
-```bash
-uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/debug.toml \
-  --optimizer.name=muon \
-  --checkpoint.dir=/tmp/kf_quickstart/step5
-```
-
-Available: `adamw`, `muon`, `lion`, `schedule_free_adamw`.
-
-## 6. Enable MoE
-
-```bash
-uv run python scripts/train.py configs/train/debug_moe.toml \
-  --checkpoint.dir=/tmp/kf_quickstart/step6
-```
-
-Or turn on MoE via CLI:
-
-```bash
-uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/debug.toml \
-  --model.num_experts=8 --model.moe_top_k=2 --model.moe_router=sigmoid_topk \
-  --checkpoint.dir=/tmp/kf_quickstart/step6_cli
-```
-
-## 7. Extend the training loop without forking `train.py`
-
-See [`custom_hook.py`](custom_hook.py) for four example hooks:
-
-- `GradNormHistogramHook` — per-layer gradient norms to WandB
-- `LearningDynamicsHook` — weight norms and gradient SNR
-- `EarlyStoppingHook` — stop if eval loss plateaus
-- `ExpertLoadBalanceHook` — MoE expert utilization metrics
-
-Register them in your own script by subclassing `TrainingHook`.
-
-## Next steps
-
-- **Scale up**: see [README § Training Configurations](../README.md#training-configurations) for 7B / 13B / 70B configs
-- **Run on SLURM**: [README § Quick Start](../README.md#quick-start) for single- and multi-node launch scripts
-- **Measured performance**: [`benchmarks/mfu_scaling/mfu_scaling.md`](../benchmarks/mfu_scaling/mfu_scaling.md) for MFU/throughput numbers across 1–32 GPUs
-- **Contribute**: [CONTRIBUTING.md](../CONTRIBUTING.md) walks through the issue → branch → PR flow
+For the notebook catalogue with short descriptions, see
+[`docs/getting-started/notebooks.md`](../docs/getting-started/notebooks.md).


### PR DESCRIPTION
## Summary
<!-- Bullet points of what this PR does -->

## Testing
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors)
- [x] `uv run pytest tests/unit/ -v --timeout=60` passes
- [x] If distributed code changed: `uv run torchrun --nproc_per_node=4 -m pytest tests/distributed/ -v`
- [x] If training loop / parallelism / optimizers changed: `uv run pytest tests/e2e/ --e2e -v`

- Adds 79 narrative pages across 12 sections: getting-started (5),
  architecture (4), how-to (14), configuration (5), reference (5),
  training (9), distributed (7), MoE (5), data (6), checkpointing (6),
  metrics-and-profiling (7), resilience (6).
- Adds `docs/contributing.md` that renders root `CONTRIBUTING.md` via
  the myst-parser `{include}` directive, keeping one source of truth
  for the contributor guide.
- Refreshes the landing page (themed nav, flagship how-to callout),
  sets `conf.py` copyright and author to the full institute name, and
  replaces `examples/quickstart.md` with a stub pointing to the hosted
  walkthrough.

