### PR TITLE
fix version rendering

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,12 @@
+.sidebar-brand {
+    text-align: center;
+}
+
+.sidebar-brand-text {
+    font-size: 0.85rem;
+    font-weight: 400;
+    text-align: center;
+    width: 100%;
+    display: block;
+    opacity: 0.75;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,8 +72,9 @@ intersphinx_mapping = {
 }
 
 html_theme = "furo"
-html_title = f"KempnerForge {version}"
+html_title = f"v{release}"
 html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 html_logo = "assets/logo.png"
 html_favicon = None
 html_theme_options = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,13 +6,14 @@ import importlib.metadata
 
 project = "KempnerForge"
 author = "Kempner Institute for the Study of Natural and Artificial Intelligence at Harvard University"
-copyright = "2026, Kempner Institute for the Study of Natural and Artificial Intelligence at Harvard University"
 
 try:
     release = importlib.metadata.version("kempnerforge")
 except importlib.metadata.PackageNotFoundError:
     release = "0.0.0"
 version = ".".join(release.split(".")[:2])
+
+copyright = f"2026, Kempner Institute for the Study of Natural and Artificial Intelligence at Harvard University · v{release}"
 
 extensions = [
     "sphinx.ext.autodoc",
@@ -72,12 +73,13 @@ intersphinx_mapping = {
 }
 
 html_theme = "furo"
-html_title = f"v{release}"
+html_title = "KempnerForge"
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 html_logo = "assets/logo.png"
 html_favicon = None
 html_theme_options = {
+    "sidebar_hide_name": True,
     "source_repository": "https://github.com/KempnerInstitute/KempnerForge",
     "source_branch": "main",
     "source_directory": "docs/",


### PR DESCRIPTION
## Summary
<!-- Bullet points of what this PR does -->

## Testing
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors)
- [x] `uv run pytest tests/unit/ -v --timeout=60` passes
- [x] If distributed code changed: `uv run torchrun --nproc_per_node=4 -m pytest tests/distributed/ -v`
- [x] If training loop / parallelism / optimizers changed: `uv run pytest tests/e2e/ --e2e -v`

Closes #
