### PR TITLE
Update tokenizer caching instructions for clarity

### DIFF
--- a/docs/how-to/end-to-end-training-run.md
+++ b/docs/how-to/end-to-end-training-run.md
@@ -33,9 +33,8 @@ uv sync           # creates .venv and installs all deps
 
 ## 2. Cache the tokenizer
 
-The reference config uses the GPT-2 tokenizer. Compute nodes
-typically don't have internet access, so pre-cache it on the login
-node:
+The reference config uses the GPT-2 tokenizer. Compute nodes typically have restricted or much slower 
+internet access (~1 Gbps vs. ~100 Gbps on login nodes), so it’s best to pre-cache it on the login node:
 
 ```bash
 python -c "from transformers import AutoTokenizer; AutoTokenizer.from_pretrained('gpt2')"


### PR DESCRIPTION
Clarify the need to pre-cache the GPT-2 tokenizer on the login node due to internet access limitations.

## Summary
<!-- Bullet points of what this PR does -->

## Testing
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors)
- [x] `uv run pytest tests/unit/ -v --timeout=60` passes
- [x] If distributed code changed: `uv run torchrun --nproc_per_node=4 -m pytest tests/distributed/ -v`
- [x] If training loop / parallelism / optimizers changed: `uv run pytest tests/e2e/ --e2e -v`

Closes #
