### PR TITLE
Update tokenizer caching instructions for clarity

### DIFF
--- a/docs/how-to/prepare-tokenized-data.md
+++ b/docs/how-to/prepare-tokenized-data.md
@@ -121,8 +121,9 @@ local directory.
 
 ### Cache the tokenizer first
 
-HuggingFace won't reach out to the hub from a compute node that
-doesn't have internet. Cache on the login node once:
+Hugging Face cannot access the hub from compute nodes with no or limited internet connectivity. 
+Since compute nodes also have much slower bandwidth (~1 Gbps vs. ~100 Gbps on login nodes), 
+cache the tokenizer once on the login node:
 
 ```bash
 python -c "from transformers import AutoTokenizer; AutoTokenizer.from_pretrained('gpt2')"


### PR DESCRIPTION
Clarify that Hugging Face cannot access the hub from compute nodes with limited internet and mention bandwidth differences.

## Summary
<!-- Bullet points of what this PR does -->

## Testing
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors)
- [x] `uv run pytest tests/unit/ -v --timeout=60` passes
- [x] If distributed code changed: `uv run torchrun --nproc_per_node=4 -m pytest tests/distributed/ -v`
- [x] If training loop / parallelism / optimizers changed: `uv run pytest tests/e2e/ --e2e -v`

Closes #
