### PR TITLE
Keep batches_yielded monotonic across StatefulDataLoader resumes

### DIFF
--- a/kempnerforge/data/dataloader.py
+++ b/kempnerforge/data/dataloader.py
@@ -67,8 +67,12 @@ class StatefulDataLoader:
 
     def __iter__(self):
         self.sampler.set_epoch(self._epoch)
+        # Re-apply skip on every iter() so double-resume within the same epoch
+        # stays aligned. The sampler consumes _skip once per iter(), and
+        # _batches_yielded persists across save/load so the skip is re-computable.
+        if self._batches_yielded > 0:
+            self.sampler.set_skip(self._batches_yielded * self.batch_size)
         self._iterator = iter(self._dataloader)
-        self._batches_yielded = 0
         return self
 
     def __next__(self) -> dict[str, torch.Tensor]:
@@ -97,16 +101,16 @@ class StatefulDataLoader:
         }
 
     def load_state_dict(self, state: dict) -> None:
-        """Restore from checkpoint. Restores sampler state and skips to saved batch position."""
+        """Restore from checkpoint. ``__iter__`` re-applies the sampler skip from
+        ``_batches_yielded``, so double-resume within the same epoch stays aligned.
+        """
         self._epoch = state.get("epoch", 0)
-        batches_yielded = state.get("batches_yielded", 0)
+        self._batches_yielded = state.get("batches_yielded", 0)
 
         # Set sampler state for resumption
         if "sampler" in state:
             self.sampler.load_state_dict(state["sampler"])
 
-        # Skip ahead to the correct position in the current epoch
-        if batches_yielded > 0:
-            self.sampler.set_skip(batches_yielded * self.batch_size)
-
-        logger.info(f"Resumed DataLoader: epoch={self._epoch}, skip_batches={batches_yielded}")
+        logger.info(
+            f"Resumed DataLoader: epoch={self._epoch}, skip_batches={self._batches_yielded}"
+        )

--- a/tests/integration/test_data_resumption.py
+++ b/tests/integration/test_data_resumption.py
@@ -102,3 +102,58 @@ class TestDataResumption:
         # Should be able to iterate
         batches_epoch2 = list(loader2)
         assert len(batches_epoch2) > 0
+
+    def test_double_resume_within_same_epoch(self, tmp_path):
+        """Two save/load cycles within a single epoch must preserve alignment.
+
+        Reproduces the pre-fix bug where batches_yielded was reset to 0 on
+        every iter() call and not restored from state_dict. The second resume
+        would re-skip only the delta of the middle run rather than the total
+        epoch position.
+        """
+        ds = _make_dataset(tmp_path, n_tokens=30000, seq_len=32)
+        bs = 4
+
+        # Ground truth: one continuous run, capture batches 40..49.
+        s_gt = DistributedSampler(ds, num_replicas=1, rank=0, shuffle=True, seed=42)
+        L_gt = StatefulDataLoader(ds, batch_size=bs, sampler=s_gt, config=_TEST_CONFIG)
+        it_gt = iter(L_gt)
+        for _ in range(40):
+            next(it_gt)
+        ground_truth = [next(it_gt) for _ in range(10)]
+
+        # Run 1: consume 30 batches, save.
+        s1 = DistributedSampler(ds, num_replicas=1, rank=0, shuffle=True, seed=42)
+        L1 = StatefulDataLoader(ds, batch_size=bs, sampler=s1, config=_TEST_CONFIG)
+        it1 = iter(L1)
+        for _ in range(30):
+            next(it1)
+        state1 = L1.state_dict()
+        assert state1["batches_yielded"] == 30
+
+        # Run 2: resume from state1, consume 10 more, save again.
+        s2 = DistributedSampler(ds, num_replicas=1, rank=0, shuffle=True, seed=42)
+        L2 = StatefulDataLoader(ds, batch_size=bs, sampler=s2, config=_TEST_CONFIG)
+        L2.load_state_dict(state1)
+        it2 = iter(L2)
+        for _ in range(10):
+            next(it2)
+        state2 = L2.state_dict()
+
+        # Pre-fix: state2["batches_yielded"] == 10. Post-fix: 40.
+        assert state2["batches_yielded"] == 40, (
+            f"Expected total epoch position 40, got {state2['batches_yielded']} "
+            "— save/load/iter lost prior resume offset"
+        )
+
+        # Run 3: resume from state2, consume 10 more — must match ground_truth.
+        s3 = DistributedSampler(ds, num_replicas=1, rank=0, shuffle=True, seed=42)
+        L3 = StatefulDataLoader(ds, batch_size=bs, sampler=s3, config=_TEST_CONFIG)
+        L3.load_state_dict(state2)
+        it3 = iter(L3)
+        resumed = [next(it3) for _ in range(10)]
+
+        for i, (gt, r) in enumerate(zip(ground_truth, resumed, strict=True)):
+            assert (gt["input_ids"] == r["input_ids"]).all(), (
+                f"Batch {i} misaligned after double-resume"
+            )


### PR DESCRIPTION
## Summary

- `StatefulDataLoader.load_state_dict` now writes to `self._batches_yielded` (previously read into a local and discarded).
- `__iter__` re-applies `sampler.set_skip(self._batches_yielded * self.batch_size)` on every call and no longer zeros `_batches_yielded`. The field advances monotonically within the epoch and resets only on `StopIteration`.
- Combined, the second and later resumes within a single epoch stay aligned with a continuous-run ground truth.

Closes #57

## Test plan

- [x] `uv run pytest tests/integration/test_data_resumption.py -v`: the new three-way resume test and all existing tests pass.
- [x] Full integration suite clean.