### PR TITLE
Seed all four RNGs on cold start to match checkpoint coverage

### DIFF
--- a/kempnerforge/distributed/setup.py
+++ b/kempnerforge/distributed/setup.py
@@ -8,10 +8,16 @@ from __future__ import annotations
 
 import logging
 import os
+
+# ``random`` is aliased to ``_random`` because ``init_distributed`` has a
+# function-local ``import random`` for SLURM-port derivation (a fresh
+# ``random.Random(int(job_id))`` factory isolated from the global RNG that
+# ``_set_seed`` mutates). The underscore keeps the two ``random`` bindings
+# unambiguous when grepping the file.
 import random as _random
 from datetime import timedelta
 
-import numpy as _np
+import numpy as np
 import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
@@ -100,7 +106,7 @@ def _set_seed(seed: int, rank: int, pp_rank: int = 0) -> None:
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(effective_seed)
     _random.seed(effective_seed)
-    _np.random.seed(effective_seed)
+    np.random.seed(effective_seed)
 
 
 def init_distributed(config: DistributedConfig, seed: int = 42) -> DeviceMesh | None:

--- a/kempnerforge/distributed/setup.py
+++ b/kempnerforge/distributed/setup.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 import logging
 import os
+import random as _random
 from datetime import timedelta
 
+import numpy as _np
 import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
@@ -88,11 +90,17 @@ def _set_seed(seed: int, rank: int, pp_rank: int = 0) -> None:
 
     - Same seed across data-parallel replicas (for consistent dropout)
     - Different seed across pipeline stages (for stochastic depth variation)
+    - Covers torch (CPU + all visible CUDA devices), Python's random, and
+      NumPy's legacy global RNG — matches the four generators captured by
+      ``checkpoint.state.get_rng_state`` so cold start and warm resume
+      seed the same set of generators.
     """
     effective_seed = seed + pp_rank
     torch.manual_seed(effective_seed)
     if torch.cuda.is_available():
-        torch.cuda.manual_seed(effective_seed)
+        torch.cuda.manual_seed_all(effective_seed)
+    _random.seed(effective_seed)
+    _np.random.seed(effective_seed)
 
 
 def init_distributed(config: DistributedConfig, seed: int = 42) -> DeviceMesh | None:

--- a/tests/unit/test_distributed_seed.py
+++ b/tests/unit/test_distributed_seed.py
@@ -1,0 +1,84 @@
+"""Unit tests for distributed seed coverage.
+
+Cold-start seeding must cover the same four RNGs captured on checkpoint
+(Python random, NumPy, torch CPU, torch CUDA) so that cold-start runs
+have the same reproducibility guarantees as warm-resumed runs.
+"""
+
+from __future__ import annotations
+
+import random
+
+import numpy as np
+import torch
+
+from kempnerforge.distributed.setup import _set_seed
+
+
+def test_set_seed_seeds_all_four_generators():
+    """_set_seed must make Python random, NumPy, and torch CPU deterministic."""
+    _set_seed(42, rank=0)
+    py_a = [random.random() for _ in range(4)]
+    np_a = np.random.rand(4).tolist()
+    torch_cpu_a = torch.randn(4).tolist()
+
+    _set_seed(42, rank=0)
+    py_b = [random.random() for _ in range(4)]
+    np_b = np.random.rand(4).tolist()
+    torch_cpu_b = torch.randn(4).tolist()
+
+    assert py_a == py_b, "Python random.random() is not deterministic — random.seed not called"
+    assert np_a == np_b, "np.random.rand() is not deterministic — np.random.seed not called"
+    assert torch_cpu_a == torch_cpu_b, (
+        "torch.randn() is not deterministic — torch.manual_seed broken"
+    )
+
+
+def test_set_seed_varies_with_pp_rank():
+    """Different PP stages must get different seeds (for per-stage dropout variation)."""
+    _set_seed(42, rank=0, pp_rank=0)
+    py_stage0 = [random.random() for _ in range(4)]
+
+    _set_seed(42, rank=0, pp_rank=1)
+    py_stage1 = [random.random() for _ in range(4)]
+
+    assert py_stage0 != py_stage1, "PP rank offset not applied to seed"
+
+
+def test_set_seed_same_across_dp_ranks():
+    """DP replicas must share the seed so dropout masks agree (within a PP stage)."""
+    _set_seed(42, rank=0, pp_rank=0)
+    py_dp0 = [random.random() for _ in range(4)]
+
+    _set_seed(42, rank=4, pp_rank=0)  # different DP rank, same PP stage
+    py_dp4 = [random.random() for _ in range(4)]
+
+    assert py_dp0 == py_dp4, (
+        "Same PP stage across DP replicas must produce the same Python random sequence"
+    )
+
+
+def test_set_seed_matches_checkpoint_coverage():
+    """Cold-start seeding must cover the same four RNGs the checkpoint path captures.
+
+    The checkpoint.state module captures {python, numpy, torch_cpu, torch_cuda}.
+    _set_seed should seed at least the three of those that are always present
+    (torch_cuda is conditional on availability).
+    """
+    from kempnerforge.checkpoint.state import get_rng_state
+
+    _set_seed(7, rank=0)
+    state_a = get_rng_state()
+
+    _set_seed(7, rank=0)
+    state_b = get_rng_state()
+
+    # Python random state must be identical after reseeding.
+    assert state_a["python"] == state_b["python"]
+    # NumPy state must be identical (tuple compare handles array contents).
+    np_a = state_a["numpy"]
+    np_b = state_b["numpy"]
+    assert np_a[0] == np_b[0]
+    assert (np_a[1] == np_b[1]).all()
+    # Torch CPU state must be identical.
+    assert torch.equal(state_a["torch_cpu"], state_b["torch_cpu"])

--- a/tests/unit/test_eval.py
+++ b/tests/unit/test_eval.py
@@ -82,9 +82,14 @@ class TestRunEval:
 
         dl = DataLoader(dataset, batch_size=4, collate_fn=collate_fn)
 
-        # Bias the output head to strongly predict class 0
+        # Bias the output head to strongly predict class 0.
+        # Also zero the embedding and set row 0 to ones so logits[0] is deterministically
+        # positive regardless of inherited global RNG state (otherwise loss depends on
+        # whether sum(embed(0)) lands above or below ~0.4, which is coin-flip-random).
         model = _TinyLM()
         with torch.no_grad():
+            model.embed.weight.zero_()
+            model.embed.weight[0, :] = 1.0
             model.head.weight.zero_()
             model.head.weight[0, :] = 10.0
 


### PR DESCRIPTION
## Summary

- In `_set_seed`, add `random.seed(effective_seed)` and `numpy.random.seed(effective_seed)` so Python's `random` and NumPy's legacy global RNG are deterministic on cold start. The checkpoint path already captures and restores both, so warm resume is no longer stricter than cold start.
- Swap `torch.cuda.manual_seed` for `torch.cuda.manual_seed_all` to cover every visible device, not just the current one.

Drive-by: `tests/unit/test_eval.py::TestRunEval::test_perfect_model_low_loss` relied on `sum(embed(0))` landing positive from inherited global RNG state. Zero the embedding and set row 0 to ones so the assertion is deterministic regardless of test ordering.

Closes #59

## Test plan

- [x] `uv run pytest tests/unit/test_distributed_seed.py tests/unit/test_eval.py -v`.
- [x] Full unit suite clean.