### PR TITLE
Enforce per-op timeouts on init and coordination collectives

### DIFF
--- a/kempnerforge/checkpoint/manager.py
+++ b/kempnerforge/checkpoint/manager.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import shutil
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,11 @@ logger = logging.getLogger(__name__)
 # Filename for non-distributed training state within a checkpoint directory
 _TRAIN_STATE_FILE = "train_state.pt"
 _METADATA_FILE = "metadata.json"
+
+# Per-operation timeout for the train_state broadcast. Generous enough to
+# cover a cold-NFS torch.load on rank 0, but short enough that a wedged
+# rank surfaces well before the 1800s process-group default.
+_TRAIN_STATE_BROADCAST_TIMEOUT_SEC = 600.0
 
 
 class CheckpointManager:
@@ -183,10 +189,26 @@ class CheckpointManager:
         if train_state_path.exists():
             train_state = torch.load(train_state_path, map_location="cpu", weights_only=False)
 
-            # Broadcast from rank 0 to all ranks
+            # Broadcast from rank 0 to all ranks with a per-op timeout so
+            # a wedged rank surfaces well before the 1800s PG default.
             if dist.is_initialized():
                 object_list = [train_state if self._rank == 0 else None]
-                dist.broadcast_object_list(object_list, src=0)
+                work = dist.broadcast_object_list(object_list, src=0, async_op=True)
+                try:
+                    done = work.wait(timeout=timedelta(seconds=_TRAIN_STATE_BROADCAST_TIMEOUT_SEC))
+                except RuntimeError as e:
+                    raise RuntimeError(
+                        f"train_state broadcast timed out after "
+                        f"{_TRAIN_STATE_BROADCAST_TIMEOUT_SEC}s. If rank 0's "
+                        f"torch.load is slow (cold NFS, large pickle), raise "
+                        f"_TRAIN_STATE_BROADCAST_TIMEOUT_SEC in manager.py; "
+                        f"otherwise a rank is wedged. Underlying: {e}"
+                    ) from e
+                if done is False:
+                    raise RuntimeError(
+                        f"train_state broadcast timed out after "
+                        f"{_TRAIN_STATE_BROADCAST_TIMEOUT_SEC}s."
+                    )
                 train_state = object_list[0]
 
             assert train_state is not None, "train_state broadcast failed"

--- a/kempnerforge/checkpoint/manager.py
+++ b/kempnerforge/checkpoint/manager.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json
 import logging
 import shutil
-from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -29,11 +28,6 @@ logger = logging.getLogger(__name__)
 # Filename for non-distributed training state within a checkpoint directory
 _TRAIN_STATE_FILE = "train_state.pt"
 _METADATA_FILE = "metadata.json"
-
-# Per-operation timeout for the train_state broadcast. Generous enough to
-# cover a cold-NFS torch.load on rank 0, but short enough that a wedged
-# rank surfaces well before the 1800s process-group default.
-_TRAIN_STATE_BROADCAST_TIMEOUT_SEC = 600.0
 
 
 class CheckpointManager:
@@ -189,26 +183,14 @@ class CheckpointManager:
         if train_state_path.exists():
             train_state = torch.load(train_state_path, map_location="cpu", weights_only=False)
 
-            # Broadcast from rank 0 to all ranks with a per-op timeout so
-            # a wedged rank surfaces well before the 1800s PG default.
+            # Broadcast from rank 0 to all ranks. PyTorch 2.11's
+            # broadcast_object_list does not accept async_op, so a per-op
+            # timeout cannot be wired here — this call inherits the 1800s
+            # process-group default. A wedged rank will still surface, just
+            # later than the other fast-fail paths in this patch.
             if dist.is_initialized():
                 object_list = [train_state if self._rank == 0 else None]
-                work = dist.broadcast_object_list(object_list, src=0, async_op=True)
-                try:
-                    done = work.wait(timeout=timedelta(seconds=_TRAIN_STATE_BROADCAST_TIMEOUT_SEC))
-                except RuntimeError as e:
-                    raise RuntimeError(
-                        f"train_state broadcast timed out after "
-                        f"{_TRAIN_STATE_BROADCAST_TIMEOUT_SEC}s. If rank 0's "
-                        f"torch.load is slow (cold NFS, large pickle), raise "
-                        f"_TRAIN_STATE_BROADCAST_TIMEOUT_SEC in manager.py; "
-                        f"otherwise a rank is wedged. Underlying: {e}"
-                    ) from e
-                if done is False:
-                    raise RuntimeError(
-                        f"train_state broadcast timed out after "
-                        f"{_TRAIN_STATE_BROADCAST_TIMEOUT_SEC}s."
-                    )
+                dist.broadcast_object_list(object_list, src=0)
                 train_state = object_list[0]
 
             assert train_state is not None, "train_state broadcast failed"

--- a/kempnerforge/distributed/setup.py
+++ b/kempnerforge/distributed/setup.py
@@ -107,7 +107,7 @@ def _barrier_with_timeout(seconds: float, reason: str) -> None:
     """
     work = dist.barrier(async_op=True)
     try:
-        done = work.wait(timeout=timedelta(seconds=seconds))
+        done = work.wait(timeout=timedelta(seconds=seconds))  # type: ignore[reportOptionalMemberAccess]
     except RuntimeError as e:
         raise RuntimeError(
             f"Barrier timed out after {seconds}s during {reason}. "

--- a/kempnerforge/distributed/setup.py
+++ b/kempnerforge/distributed/setup.py
@@ -82,6 +82,42 @@ def _set_nccl_env() -> None:
     os.environ.setdefault("NCCL_IB_DISABLE", "0")
     os.environ.setdefault("NCCL_NET_GDR_LEVEL", "2")
 
+    # Ensure NCCL actually enforces the process-group timeout. The default in
+    # PyTorch 2.2+ is "1", but a user shell/SLURM prolog may override it to
+    # "0", at which point the PG timeout becomes advisory and stuck collectives
+    # can hang indefinitely. Set a safe default and warn loudly if the user
+    # has explicitly disabled it.
+    existing = os.environ.get("TORCH_NCCL_ASYNC_ERROR_HANDLING")
+    if existing == "0":
+        logger.warning(
+            "TORCH_NCCL_ASYNC_ERROR_HANDLING=0 detected — NCCL timeouts "
+            "are advisory; stuck collectives can hang indefinitely."
+        )
+    else:
+        os.environ.setdefault("TORCH_NCCL_ASYNC_ERROR_HANDLING", "1")
+
+
+def _barrier_with_timeout(seconds: float, reason: str) -> None:
+    """dist.barrier with an explicit per-op timeout and a diagnostic log.
+
+    The process-group default timeout (``config.nccl_timeout_sec``) is sized
+    for training collectives (minutes of reduce on large tensors). Init-path
+    barriers should fail fast so mesh or env misconfiguration does not block
+    a job for 30 minutes before surfacing a useful error.
+    """
+    work = dist.barrier(async_op=True)
+    try:
+        done = work.wait(timeout=timedelta(seconds=seconds))
+    except RuntimeError as e:
+        raise RuntimeError(
+            f"Barrier timed out after {seconds}s during {reason}. "
+            f"Common causes: MASTER_ADDR/MASTER_PORT disagreement across ranks, "
+            f"a rank missing from the job, or the IB interface unreachable. "
+            f"Underlying: {e}"
+        ) from e
+    if done is False:
+        raise RuntimeError(f"Barrier timed out after {seconds}s during {reason}.")
+
 
 def _set_seed(seed: int, rank: int, pp_rank: int = 0) -> None:
     """Set deterministic seeds for reproducibility.
@@ -209,8 +245,10 @@ def init_distributed(config: DistributedConfig, seed: int = 42) -> DeviceMesh | 
         mesh_dim_names=tuple(mesh_dims),
     )
 
-    # Ensure all ranks have finished mesh creation before proceeding
-    dist.barrier()
+    # Ensure all ranks have finished mesh creation before proceeding.
+    # A 60s bound fails fast on mesh misconfiguration rather than inheriting
+    # the 1800s PG timeout.
+    _barrier_with_timeout(60.0, reason="DeviceMesh construction")
 
     # Set seed (vary by PP rank for different dropout/stochastic depth per stage)
     pp_rank = 0

--- a/kempnerforge/resilience/health.py
+++ b/kempnerforge/resilience/health.py
@@ -235,7 +235,7 @@ def check_nccl_health(timeout_sec: float = 10.0) -> bool:
         # timeout; older/alternate backends may return False instead. Handle
         # both so the timeout is honored regardless of version.
         try:
-            done = work.wait(timeout=timedelta(seconds=timeout_sec))
+            done = work.wait(timeout=timedelta(seconds=timeout_sec))  # type: ignore[reportOptionalMemberAccess]
         except RuntimeError as e:
             logger.warning(f"NCCL health check timed out after {timeout_sec}s: {e}")
             return False

--- a/kempnerforge/resilience/health.py
+++ b/kempnerforge/resilience/health.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from datetime import timedelta
 
 import torch
 import torch.distributed as dist
@@ -211,19 +212,36 @@ def check_gpu_health(device: int = 0) -> dict[str, bool | str]:
 def check_nccl_health(timeout_sec: float = 10.0) -> bool:
     """Check NCCL communication health via a lightweight all-reduce.
 
+    The all-reduce runs with ``async_op=True`` so ``work.wait(timeout=...)``
+    enforces the caller's bound rather than falling back to the
+    process-group default timeout (``nccl_timeout_sec``, 1800s). Without
+    that, this function would sit for 30 minutes on a single stuck peer
+    regardless of the ``timeout_sec`` argument.
+
     Args:
-        timeout_sec: Timeout for the collective operation.
+        timeout_sec: Per-operation timeout for the collective. Returns
+            False if the all-reduce does not complete within this budget.
 
     Returns:
-        True if the all-reduce succeeded, False on timeout or error.
+        True on success, False on timeout, error, or world-size mismatch.
     """
     if not dist.is_initialized():
         return True  # No distributed, nothing to check
 
     try:
         tensor = torch.ones(1, device="cuda")
-        # Use a work handle with timeout
-        dist.all_reduce(tensor)
+        work = dist.all_reduce(tensor, async_op=True)
+        # In current PyTorch Work.wait(timeout=...) raises RuntimeError on
+        # timeout; older/alternate backends may return False instead. Handle
+        # both so the timeout is honored regardless of version.
+        try:
+            done = work.wait(timeout=timedelta(seconds=timeout_sec))
+        except RuntimeError as e:
+            logger.warning(f"NCCL health check timed out after {timeout_sec}s: {e}")
+            return False
+        if done is False:
+            logger.warning(f"NCCL health check timed out after {timeout_sec}s")
+            return False
         torch.cuda.synchronize()
         expected = dist.get_world_size()
         return abs(tensor.item() - expected) < 1e-5

--- a/kempnerforge/training/eval.py
+++ b/kempnerforge/training/eval.py
@@ -93,7 +93,7 @@ def run_eval(
             async_op=True,
         )
         try:
-            done = work.wait(timeout=timedelta(seconds=_EVAL_BROADCAST_TIMEOUT_SEC))
+            done = work.wait(timeout=timedelta(seconds=_EVAL_BROADCAST_TIMEOUT_SEC))  # type: ignore[reportOptionalMemberAccess]
         except RuntimeError as e:
             logger.error(
                 f"Eval loss broadcast timed out after {_EVAL_BROADCAST_TIMEOUT_SEC}s; "

--- a/kempnerforge/training/eval.py
+++ b/kempnerforge/training/eval.py
@@ -7,10 +7,19 @@ no unwrapping needed.
 
 from __future__ import annotations
 
+import logging
 import math
+from datetime import timedelta
 
 import torch
 import torch.distributed as dist
+
+logger = logging.getLogger(__name__)
+
+# Per-operation timeout for the PP eval loss broadcast. Shorter than the
+# 1800s process-group default so a diverged PP stage surfaces fast rather
+# than freezing eval for half an hour.
+_EVAL_BROADCAST_TIMEOUT_SEC = 300.0
 
 
 @torch.no_grad()
@@ -77,8 +86,29 @@ def run_eval(
             avg_loss = 0.0
 
         loss_tensor = torch.tensor([avg_loss], device=device)
-        dist.broadcast(loss_tensor, group_src=pp_size - 1, group=pp_group)  # type: ignore[reportOptionalOperand]
-        avg_loss = loss_tensor[0].item()
+        work = dist.broadcast(
+            loss_tensor,
+            group_src=pp_size - 1,  # type: ignore[reportOptionalOperand]
+            group=pp_group,
+            async_op=True,
+        )
+        try:
+            done = work.wait(timeout=timedelta(seconds=_EVAL_BROADCAST_TIMEOUT_SEC))
+        except RuntimeError as e:
+            logger.error(
+                f"Eval loss broadcast timed out after {_EVAL_BROADCAST_TIMEOUT_SEC}s; "
+                f"a PP stage is likely wedged. Reporting nan loss. Underlying: {e}"
+            )
+            avg_loss = float("nan")
+        else:
+            if done is False:
+                logger.error(
+                    f"Eval loss broadcast timed out after {_EVAL_BROADCAST_TIMEOUT_SEC}s; "
+                    "reporting nan loss."
+                )
+                avg_loss = float("nan")
+            else:
+                avg_loss = loss_tensor[0].item()
     else:
         # --- Standard eval path ---
         total_loss = 0.0

--- a/tests/unit/test_collective_timeouts.py
+++ b/tests/unit/test_collective_timeouts.py
@@ -1,0 +1,295 @@
+"""Tests for per-operation timeouts on distributed collectives.
+
+The process-group default timeout (``nccl_timeout_sec``, 1800s) is sized
+for training reduces on large tensors. Several init-path and coordination
+collectives should fail faster than that so misconfiguration or a wedged
+peer surfaces quickly. These tests verify that the per-op timeout actually
+flows through to ``Work.wait`` rather than being silently ignored.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import timedelta
+
+import pytest
+import torch
+
+# Hold the real ``torch.ones`` before any test monkey-patches it, so the
+# replacement wrapper can still build a tensor without recursion.
+_REAL_TORCH_ONES = torch.ones
+
+
+def _cpu_ones(*args, **kwargs) -> torch.Tensor:
+    """torch.ones with any ``device`` kwarg stripped.
+
+    Lets tests on CPU-only hosts monkey-patch ``torch.ones`` so the CUDA
+    branch inside ``check_nccl_health`` doesn't require a GPU. Uses the
+    pre-patch ``torch.ones`` captured at module load time.
+    """
+    kwargs.pop("device", None)
+    return _REAL_TORCH_ONES(*args, **kwargs)
+
+
+class _FakeWork:
+    """Stand-in for ``torch.distributed.Work`` that records wait() calls.
+
+    ``raises``: raise RuntimeError on wait() (simulates timeout enforcement).
+    ``returns``: return this value from wait() (False simulates legacy-
+    backend timeout; True simulates success).
+    ``sleep``: seconds to sleep before returning (simulates blocking wait).
+    """
+
+    def __init__(
+        self,
+        raises: BaseException | None = None,
+        returns: bool = True,
+        sleep: float = 0.0,
+    ) -> None:
+        self._raises = raises
+        self._returns = returns
+        self._sleep = sleep
+        self.wait_calls: list[object] = []
+
+    def wait(self, timeout=None):  # noqa: ANN001
+        self.wait_calls.append(timeout)
+        if self._raises is not None:
+            raise self._raises
+        if self._sleep > 0:
+            time.sleep(self._sleep)
+        return self._returns
+
+
+class TestCheckNcclHealthTimeout:
+    def test_passes_timedelta_to_work_wait(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """check_nccl_health must forward timeout_sec as a timedelta to Work.wait.
+
+        The buggy version called dist.all_reduce synchronously and ignored
+        timeout_sec entirely. The fix uses async_op=True and wait(timeout=...).
+        """
+        from kempnerforge.resilience import health
+
+        monkeypatch.setattr(health.dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(health.dist, "get_world_size", lambda: 2)
+
+        fake_work = _FakeWork(returns=True)
+
+        def fake_all_reduce(tensor, *args, async_op: bool = False, **kwargs):  # noqa: ANN001
+            assert async_op is True, (
+                "check_nccl_health called dist.all_reduce synchronously — "
+                "the caller-supplied timeout cannot be enforced"
+            )
+            tensor.fill_(2.0)  # world_size=2, simulates completed all-reduce
+            return fake_work
+
+        monkeypatch.setattr(health.dist, "all_reduce", fake_all_reduce)
+        monkeypatch.setattr(health.torch, "ones", lambda *a, **kw: _cpu_ones(*a, **kw))
+        monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+        ok = health.check_nccl_health(timeout_sec=0.5)
+        assert ok is True
+        assert fake_work.wait_calls, "Work.wait was never called"
+        forwarded = fake_work.wait_calls[0]
+        assert isinstance(forwarded, timedelta), (
+            f"Work.wait must receive a timedelta, got {type(forwarded).__name__}"
+        )
+        assert forwarded.total_seconds() == pytest.approx(0.5, rel=0.01)
+
+    def test_returns_false_on_timeout_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Modern PyTorch: Work.wait raises RuntimeError on timeout — catch, return False."""
+        from kempnerforge.resilience import health
+
+        monkeypatch.setattr(health.dist, "is_initialized", lambda: True)
+        fake_work = _FakeWork(raises=RuntimeError("Wait timeout: NCCL watchdog"))
+
+        def fake_all_reduce(tensor, *args, async_op: bool = False, **kwargs):  # noqa: ANN001, ARG001
+            return fake_work
+
+        monkeypatch.setattr(health.dist, "all_reduce", fake_all_reduce)
+        monkeypatch.setattr(health.torch, "ones", lambda *a, **kw: _cpu_ones(*a, **kw))
+        monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+        t0 = time.perf_counter()
+        ok = health.check_nccl_health(timeout_sec=0.1)
+        elapsed = time.perf_counter() - t0
+
+        assert ok is False, "timeout must produce False, not True"
+        assert elapsed < 1.0, (
+            f"timeout was not honored: took {elapsed:.2f}s (likely synchronous all_reduce)"
+        )
+
+    def test_returns_false_on_wait_returning_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Legacy backends: Work.wait returns False on timeout instead of raising."""
+        from kempnerforge.resilience import health
+
+        monkeypatch.setattr(health.dist, "is_initialized", lambda: True)
+        fake_work = _FakeWork(returns=False)
+
+        def fake_all_reduce(tensor, *args, async_op: bool = False, **kwargs):  # noqa: ANN001, ARG001
+            return fake_work
+
+        monkeypatch.setattr(health.dist, "all_reduce", fake_all_reduce)
+        monkeypatch.setattr(health.torch, "ones", lambda *a, **kw: _cpu_ones(*a, **kw))
+        monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+        ok = health.check_nccl_health(timeout_sec=0.1)
+        assert ok is False
+
+    def test_returns_true_when_not_initialized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No distributed → nothing to check → return True without touching work."""
+        from kempnerforge.resilience import health
+
+        monkeypatch.setattr(health.dist, "is_initialized", lambda: False)
+        assert health.check_nccl_health(timeout_sec=0.1) is True
+
+
+class TestBarrierWithTimeout:
+    def test_raises_runtime_error_with_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """_barrier_with_timeout surfaces a timeout with the reason string attached."""
+        from kempnerforge.distributed import setup as dsetup
+
+        monkeypatch.setattr(
+            dsetup.dist,
+            "barrier",
+            lambda async_op=False: _FakeWork(  # noqa: ARG005
+                raises=RuntimeError("Wait timeout: NCCL watchdog")
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="DeviceMesh construction"):
+            dsetup._barrier_with_timeout(5.0, reason="DeviceMesh construction")
+
+    def test_raises_when_wait_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Legacy-backend False return also translates to RuntimeError."""
+        from kempnerforge.distributed import setup as dsetup
+
+        monkeypatch.setattr(
+            dsetup.dist,
+            "barrier",
+            lambda async_op=False: _FakeWork(returns=False),  # noqa: ARG005
+        )
+
+        with pytest.raises(RuntimeError, match="timed out after 5.0s"):
+            dsetup._barrier_with_timeout(5.0, reason="init-check")
+
+    def test_returns_normally_on_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Happy path: Work.wait returns True → no exception."""
+        from kempnerforge.distributed import setup as dsetup
+
+        fake_work = _FakeWork(returns=True)
+        monkeypatch.setattr(
+            dsetup.dist,
+            "barrier",
+            lambda async_op=False: fake_work,  # noqa: ARG005
+        )
+
+        dsetup._barrier_with_timeout(5.0, reason="smoke")
+        assert fake_work.wait_calls
+        assert isinstance(fake_work.wait_calls[0], timedelta)
+
+
+class TestNcclAsyncErrorHandlingEnvGuard:
+    def test_defaults_to_1_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """_set_nccl_env forces TORCH_NCCL_ASYNC_ERROR_HANDLING=1 when unset."""
+        from kempnerforge.distributed import setup as dsetup
+
+        monkeypatch.delenv("TORCH_NCCL_ASYNC_ERROR_HANDLING", raising=False)
+        monkeypatch.setattr(dsetup, "_detect_ib_interface", lambda: None)
+        dsetup._set_nccl_env()
+        assert dsetup.os.environ.get("TORCH_NCCL_ASYNC_ERROR_HANDLING") == "1"
+
+    def test_preserves_explicit_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from kempnerforge.distributed import setup as dsetup
+
+        monkeypatch.setenv("TORCH_NCCL_ASYNC_ERROR_HANDLING", "1")
+        monkeypatch.setattr(dsetup, "_detect_ib_interface", lambda: None)
+        dsetup._set_nccl_env()
+        assert dsetup.os.environ.get("TORCH_NCCL_ASYNC_ERROR_HANDLING") == "1"
+
+    def test_warns_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Explicit "0" is user intent; do not override silently — warn loudly.
+
+        Uses a direct logger handler rather than pytest's caplog so the test
+        is robust to other tests mutating logger propagation.
+        """
+        import logging
+
+        from kempnerforge.distributed import setup as dsetup
+
+        monkeypatch.setenv("TORCH_NCCL_ASYNC_ERROR_HANDLING", "0")
+        monkeypatch.setattr(dsetup, "_detect_ib_interface", lambda: None)
+
+        records: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        handler = _Capture(level=logging.WARNING)
+        log = logging.getLogger("kempnerforge.distributed.setup")
+        prior_level = log.level
+        log.setLevel(logging.WARNING)
+        log.addHandler(handler)
+        try:
+            dsetup._set_nccl_env()
+        finally:
+            log.removeHandler(handler)
+            log.setLevel(prior_level)
+
+        assert dsetup.os.environ.get("TORCH_NCCL_ASYNC_ERROR_HANDLING") == "0"
+        assert any("TORCH_NCCL_ASYNC_ERROR_HANDLING=0" in r.getMessage() for r in records), (
+            "expected warning when TORCH_NCCL_ASYNC_ERROR_HANDLING=0"
+        )
+
+
+class TestCheckpointBroadcastTimeout:
+    def test_broadcast_object_list_honors_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CheckpointManager.load raises with a clear message if the object
+        broadcast does not complete within _TRAIN_STATE_BROADCAST_TIMEOUT_SEC."""
+        from unittest.mock import MagicMock
+
+        import kempnerforge.checkpoint.manager as mgr_mod
+        from kempnerforge.checkpoint.manager import CheckpointManager
+        from kempnerforge.config.schema import CheckpointConfig
+
+        # Build a step_1 dir with a benign train_state.pt so the load reaches
+        # the broadcast path.
+        tmp = pytest.importorskip("pathlib").Path
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            root = tmp(td)
+            ckpt_dir = root / "step_1"
+            ckpt_dir.mkdir()
+            torch.save({"step": 1, "tokens_seen": 0, "rng": {}}, ckpt_dir / "train_state.pt")
+            (root / "latest").symlink_to("step_1")
+
+            config = CheckpointConfig(dir=str(root))
+            model = MagicMock()
+            model.state_dict.return_value = {}
+            optimizer = MagicMock()
+            optimizer.state_dict.return_value = {}
+            manager = CheckpointManager(config=config, model=model, optimizer=optimizer)
+
+            # Force the "distributed" branches.
+            monkeypatch.setattr(mgr_mod.dist, "is_initialized", lambda: True)
+            monkeypatch.setattr(manager, "_rank", 0, raising=False)
+
+            # First call: the existence-flag broadcast — let it succeed.
+            # Second call: the object-list broadcast — simulate a hang by raising.
+            call_count = {"n": 0}
+
+            def fake_broadcast_object_list(obj_list, src=0, *, async_op: bool = False, **kwargs):  # noqa: ANN001, ARG001
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    # existence probe — not async
+                    return None
+                assert async_op is True, (
+                    "object_list broadcast on load must be async to enforce the timeout"
+                )
+                return _FakeWork(raises=RuntimeError("Wait timeout"))
+
+            monkeypatch.setattr(mgr_mod.dist, "broadcast_object_list", fake_broadcast_object_list)
+
+            with pytest.raises(RuntimeError, match="train_state broadcast timed out"):
+                manager.load(exclude_keys=["model", "optimizer"])

--- a/tests/unit/test_collective_timeouts.py
+++ b/tests/unit/test_collective_timeouts.py
@@ -242,54 +242,8 @@ class TestNcclAsyncErrorHandlingEnvGuard:
         )
 
 
-class TestCheckpointBroadcastTimeout:
-    def test_broadcast_object_list_honors_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """CheckpointManager.load raises with a clear message if the object
-        broadcast does not complete within _TRAIN_STATE_BROADCAST_TIMEOUT_SEC."""
-        from unittest.mock import MagicMock
-
-        import kempnerforge.checkpoint.manager as mgr_mod
-        from kempnerforge.checkpoint.manager import CheckpointManager
-        from kempnerforge.config.schema import CheckpointConfig
-
-        # Build a step_1 dir with a benign train_state.pt so the load reaches
-        # the broadcast path.
-        tmp = pytest.importorskip("pathlib").Path
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as td:
-            root = tmp(td)
-            ckpt_dir = root / "step_1"
-            ckpt_dir.mkdir()
-            torch.save({"step": 1, "tokens_seen": 0, "rng": {}}, ckpt_dir / "train_state.pt")
-            (root / "latest").symlink_to("step_1")
-
-            config = CheckpointConfig(dir=str(root))
-            model = MagicMock()
-            model.state_dict.return_value = {}
-            optimizer = MagicMock()
-            optimizer.state_dict.return_value = {}
-            manager = CheckpointManager(config=config, model=model, optimizer=optimizer)
-
-            # Force the "distributed" branches.
-            monkeypatch.setattr(mgr_mod.dist, "is_initialized", lambda: True)
-            monkeypatch.setattr(manager, "_rank", 0, raising=False)
-
-            # First call: the existence-flag broadcast — let it succeed.
-            # Second call: the object-list broadcast — simulate a hang by raising.
-            call_count = {"n": 0}
-
-            def fake_broadcast_object_list(obj_list, src=0, *, async_op: bool = False, **kwargs):  # noqa: ANN001, ARG001
-                call_count["n"] += 1
-                if call_count["n"] == 1:
-                    # existence probe — not async
-                    return None
-                assert async_op is True, (
-                    "object_list broadcast on load must be async to enforce the timeout"
-                )
-                return _FakeWork(raises=RuntimeError("Wait timeout"))
-
-            monkeypatch.setattr(mgr_mod.dist, "broadcast_object_list", fake_broadcast_object_list)
-
-            with pytest.raises(RuntimeError, match="train_state broadcast timed out"):
-                manager.load(exclude_keys=["model", "optimizer"])
+# NOTE: There is no TestCheckpointBroadcastTimeout class here. PyTorch 2.11's
+# ``dist.broadcast_object_list`` does not accept ``async_op``, so the load-path
+# train_state broadcast in CheckpointManager cannot enforce a per-op timeout
+# and inherits the 1800s process-group default. The other fast-fail paths in
+# this module (init barrier, NCCL health, eval loss broadcast) still apply.


### PR DESCRIPTION
Closes #63.

## What

Make declared per-op timeouts on init and coordination collectives actually enforce. Today they fall through to the 1800s process-group default, so a wedged peer hangs the job for 30 minutes regardless of the caller's intent.

- `kempnerforge/resilience/health.py::check_nccl_health` switches to `async_op=True` + `Work.wait(timeout=timedelta(seconds=timeout_sec))` and returns `False` on either timeout signaling path (RuntimeError on modern PyTorch, `False` return on legacy backends).
- `kempnerforge/distributed/setup.py` adds `_barrier_with_timeout(seconds, reason)` and uses it for the DeviceMesh-construction barrier with a 60s budget. Timeouts raise `RuntimeError` with the reason string attached so the failure points at the right phase of init.
- `kempnerforge/training/eval.py` wraps the PP eval loss broadcast in a 300s budget with a `nan` fallback so a wedged PP stage surfaces as a clear bad-iteration signal instead of a half-hour hang.
- `kempnerforge/distributed/setup.py::_set_nccl_env` `setdefault`s `TORCH_NCCL_ASYNC_ERROR_HANDLING=1` and logs a warning when a user has explicitly set it to `0`. Without this, every per-op bound in this patch is advisory.

## Known limit, train_state broadcast

The original commit also wired a 600s `async_op=True` budget around the train_state broadcast in `CheckpointManager.load`. PyTorch 2.11's `dist.broadcast_object_list` does not accept `async_op` (TypeError at runtime), so the second commit on this branch reverts that one site to the plain synchronous form and leaves an explanatory comment. The other three call sites still get fast-fail; a wedged rank surfaces via those before the broadcast hits the 1800s default.

## Tests

`tests/unit/test_collective_timeouts.py` (10 new tests, all passing locally):
- `TestCheckNcclHealthTimeout` covers `Work.wait(timedelta(...))` forwarding, `RuntimeError` and `False`-return timeout paths, and the not-initialized early return.
- `TestBarrierWithTimeout` covers the reason-string error message, the `False`-return path, and the success path.
- `TestNcclAsyncErrorHandlingEnvGuard` covers the unset/explicit-1/explicit-0 cases for `TORCH_NCCL_ASYNC_ERROR_HANDLING`.

The test file documents the absence of a `TestCheckpointBroadcastTimeout` class with a comment pointing at the PyTorch 2.11 limitation.