### PR TITLE
Add auto-resume and FP8 7B regression smoke tests

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -44,6 +44,27 @@ def pytest_addoption(parser):
         default=50257,
         help="Vocab size matching the tokenizer (default: 50257 for gpt2)",
     )
+    group.addoption(
+        "--data-path",
+        type=str,
+        default=None,
+        help=(
+            "Pre-tokenized dataset directory. Required by tests that exercise "
+            "StatefulDataLoader (auto-resume, 7B FP8). Skipped when omitted."
+        ),
+    )
+    group.addoption(
+        "--file-pattern",
+        type=str,
+        default="tokenized_*.bin",
+        help="Glob pattern for tokenized shards (default: tokenized_*.bin)",
+    )
+    group.addoption(
+        "--data-vocab-size",
+        type=int,
+        default=128256,
+        help="Vocab size of the tokenizer used for --data-path (default: 128256 for Llama-3)",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +105,9 @@ def _detect_slurm_env(jobid: str | None) -> dict[str, str | int] | None:
         tasks_match = re.search(r"NumTasks=(\d+)", info)
         nodelist_match = re.search(r"(?<!\w)NodeList=(\S+)", info)
         state_match = re.search(r"JobState=(\w+)", info)
+        # AllocTRES reports the GPUs physically reserved for the job even on
+        # interactive salloc sessions where NumTasks defaults to 1.
+        gres_match = re.search(r"AllocTRES=[^\n]*gres/gpu=(\d+)", info)
 
         if not all([nodes_match, nodelist_match, state_match]):
             return None
@@ -92,7 +116,11 @@ def _detect_slurm_env(jobid: str | None) -> dict[str, str | int] | None:
 
         nodes = int(nodes_match.group(1))
         total_tasks = int(tasks_match.group(1)) if tasks_match else nodes
-        gpus_per_node = total_tasks // nodes
+        tasks_per_node = total_tasks // nodes
+        gres_per_node = int(gres_match.group(1)) // nodes if gres_match else 0
+        # Prefer the GPU count from GRES: salloc without --ntasks reports
+        # NumTasks=1 but still reserves the requested GPUs.
+        gpus_per_node = max(tasks_per_node, gres_per_node)
 
         # Resolve master address
         hostnames = (
@@ -175,3 +203,18 @@ def tokenizer_name(request) -> str:
 @pytest.fixture(scope="session")
 def vocab_size(request) -> int:
     return request.config.getoption("--vocab-size")
+
+
+@pytest.fixture(scope="session")
+def data_path(request) -> str | None:
+    return request.config.getoption("--data-path")
+
+
+@pytest.fixture(scope="session")
+def file_pattern(request) -> str:
+    return request.config.getoption("--file-pattern")
+
+
+@pytest.fixture(scope="session")
+def data_vocab_size(request) -> int:
+    return request.config.getoption("--data-vocab-size")

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -38,6 +38,7 @@ TRAIN_SCRIPT = str(PROJECT_ROOT / "scripts" / "train.py")
 EVAL_SCRIPT = str(PROJECT_ROOT / "scripts" / "eval.py")
 DEBUG_CONFIG = str(PROJECT_ROOT / "configs" / "train" / "debug.toml")
 DEBUG_MOE_CONFIG = str(PROJECT_ROOT / "configs" / "train" / "debug_moe.toml")
+FP8_7B_CONFIG = str(PROJECT_ROOT / "configs" / "train" / "7b_16gpu_fp8.toml")
 CKPT_ROOT = PROJECT_ROOT / "checkpoints" / "_smoke_test"
 
 # Port counter to avoid collisions between tests in the same session
@@ -533,6 +534,148 @@ class TestTrainFeatures:
             ),
         )
         _assert_train_ok(result)
+
+
+# ============================================================================
+# Tests: Checkpoint auto-resume (post-release fix regression coverage)
+# ============================================================================
+
+
+def _assert_resume_markers(output: str, expected_resume_step: int) -> None:
+    """Assert the warm-resume log markers fire and carry the right step count."""
+    assert "Auto-resume: found latest checkpoint" in output, (
+        f"missing auto-resume marker:\n{output[-3000:]}"
+    )
+    assert "Restored RNG states" in output, f"missing RNG restore marker:\n{output[-3000:]}"
+    assert f"Resumed from step {expected_resume_step}" in output, (
+        f"did not resume at step {expected_resume_step}:\n{output[-3000:]}"
+    )
+    assert f"skip_batches={expected_resume_step}" in output, (
+        f"dataloader skip_batches not restored to {expected_resume_step}:\n{output[-3000:]}"
+    )
+    assert "Applied stashed dataloader state" in output, (
+        f"stashed dataloader state not applied:\n{output[-3000:]}"
+    )
+
+
+@pytest.mark.smoke
+class TestAutoResume:
+    """Train → save → relaunch → verify full state restoration.
+
+    Exercises the checkpoint save / auto-resume path end-to-end: init-path
+    barrier timeout, RNG restoration, StatefulDataLoader replay with monotonic
+    batches_yielded, train_state.pt ownership gate, and scheduler continuity.
+
+    Requires a pre-tokenized dataset (``--data-path``) because ``scripts/train.py``
+    falls back to synthetic ``torch.randint`` batches when no data source is
+    configured, which bypasses StatefulDataLoader entirely.
+    """
+
+    def _common_args(self, config, ckpt_name, data_path, file_pattern, data_vocab_size):
+        ckpt_dir = CKPT_ROOT / ckpt_name
+        return [
+            config,
+            f"--model.vocab_size={data_vocab_size}",
+            f"--data.dataset_path={data_path}",
+            f"--data.file_pattern={file_pattern}",
+            "--data.pack_sequences=false",
+            f"--checkpoint.dir={ckpt_dir}",
+            "--checkpoint.interval=10",
+            "--checkpoint.keep_last_n=2",
+            "--checkpoint.async_mode=disabled",
+            "--metrics.log_interval=5",
+            "--metrics.enable_wandb=false",
+            "--metrics.enable_tensorboard=false",
+        ]
+
+    def test_dense_fsdp_auto_resume(self, hw, data_path, file_pattern, data_vocab_size):
+        if data_path is None:
+            pytest.skip("Requires --data-path to exercise StatefulDataLoader")
+        skip_unless_gpus(hw, 2)
+
+        args = self._common_args(
+            DEBUG_CONFIG, "resume_dense_fsdp", data_path, file_pattern, data_vocab_size
+        )
+        r1 = _run(hw, TRAIN_SCRIPT, args + ["--train.max_steps=20"])
+        _assert_train_ok(r1, expected_steps=20)
+
+        r2 = _run(hw, TRAIN_SCRIPT, args + ["--train.max_steps=30"])
+        output2 = r2.stdout + r2.stderr
+        assert r2.returncode == 0, f"Resume failed:\n{output2[-3000:]}"
+        _assert_resume_markers(output2, expected_resume_step=20)
+        match = re.search(r"Training complete: (\d+) steps", output2)
+        assert match and int(match.group(1)) == 30, (
+            f"Expected 30 steps, got output:\n{output2[-1000:]}"
+        )
+
+    def test_moe_fsdp_auto_resume(self, hw, data_path, file_pattern, data_vocab_size):
+        if data_path is None:
+            pytest.skip("Requires --data-path to exercise StatefulDataLoader")
+        skip_unless_gpus(hw, 2)
+
+        args = self._common_args(
+            DEBUG_MOE_CONFIG, "resume_moe_fsdp", data_path, file_pattern, data_vocab_size
+        )
+        r1 = _run(hw, TRAIN_SCRIPT, args + ["--train.max_steps=20"])
+        _assert_train_ok(r1, expected_steps=20)
+
+        r2 = _run(hw, TRAIN_SCRIPT, args + ["--train.max_steps=30"])
+        output2 = r2.stdout + r2.stderr
+        assert r2.returncode == 0, f"MoE resume failed:\n{output2[-3000:]}"
+        _assert_resume_markers(output2, expected_resume_step=20)
+        assert "moe/aux_loss" in output2, (
+            f"MoE aux_loss metric missing post-resume:\n{output2[-1000:]}"
+        )
+
+
+# ============================================================================
+# Tests: Real-config sanity (post-release fix regression coverage)
+# ============================================================================
+
+
+@pytest.mark.smoke
+class TestRealConfigs:
+    """Run the published production configs at reduced scope to catch drift.
+
+    Complements TestTrainFeatures which exercises individual features via
+    ``debug.toml`` overrides. These tests execute the actual config file so
+    any silent rot (renamed field, stale comment, broken default) surfaces.
+    """
+
+    def test_fp8_7b_config(self, hw, data_path, file_pattern):
+        """7B FP8 training starts cleanly and applies Float8 + FSDP2 float8 all-gather."""
+        if data_path is None:
+            pytest.skip("Requires --data-path; 7B config uses dataset_path not synthetic")
+        skip_unless_gpus(hw, 4)
+        ckpt_dir = CKPT_ROOT / "fp8_7b"
+        result = _run(
+            hw,
+            TRAIN_SCRIPT,
+            [
+                FP8_7B_CONFIG,
+                f"--data.dataset_path={data_path}",
+                f"--data.file_pattern={file_pattern}",
+                "--data.pack_sequences=false",
+                "--train.max_steps=3",
+                "--train.batch_size=4",
+                "--train.grad_accum_steps=1",
+                "--train.compile_model=false",
+                f"--checkpoint.dir={ckpt_dir}",
+                "--checkpoint.interval=100",
+                "--checkpoint.async_mode=disabled",
+                "--metrics.enable_wandb=false",
+                "--metrics.enable_tensorboard=false",
+                "--metrics.log_interval=1",
+            ],
+            timeout=600,
+        )
+        output = result.stdout + result.stderr
+        assert result.returncode == 0, f"FP8 7B failed:\n{output[-3000:]}"
+        assert "Applied Float8 training" in output, f"Float8 was not applied:\n{output[-2000:]}"
+        assert "fsdp_float8_all_gather=True" in output, (
+            f"FSDP2 float8 all-gather was not enabled:\n{output[-2000:]}"
+        )
+        _assert_train_ok(result, expected_steps=3)
 
 
 # ============================================================================


### PR DESCRIPTION
Closes #65.

## What

Two new smoke-test classes covering the cross-process and config-drift gaps left after the eight post-release fixes (#49, #51, #53, #55, #57, #59, #61, #63), plus a SLURM detection fix so they actually run on interactive `salloc`.

`tests/smoke/test_smoke.py`:

- `TestAutoResume::test_auto_resume_dense` and `test_auto_resume_moe`: train 20 steps with `checkpoint.interval=10`, relaunch with `max_steps=30`, assert the five resume log markers (latest-checkpoint discovery, RNG restore, resume-step, `skip_batches`, stashed-dataloader apply). MoE variant additionally checks `moe/aux_loss` logs post-resume. Exercises the init-path barrier timeout, RNG coverage across all four generators, the ownership-gated `train_state.pt` load, and monotonic `batches_yielded` end-to-end.
- `TestRealConfigs::test_fp8_7b_config`: runs `configs/train/7b_16gpu_fp8.toml` at reduced scope (3 steps, batch_size=4, compile off). Asserts both Float8 application and FSDP2 float8 all-gather are wired so silent drift in the shipped config surfaces in CI.

`tests/smoke/conftest.py`:

- New CLI flags `--data-path`, `--file-pattern`, `--data-vocab-size`. The auto-resume tests require `--data-path` because `scripts/train.py` otherwise falls back to synthetic `torch.randint` batches, which bypass `StatefulDataLoader` and would make the resume assertions a no-op.
- `_detect_slurm_env` now also parses `AllocTRES gres/gpu=N` and takes `max(tasks_per_node, gres_per_node)`. Interactive `salloc --gres=gpu:4` (no `--ntasks`) reports `NumTasks=1`, so the previous derivation returned `gpus_per_node=1` and silently skipped every multi-GPU test. Both `sbatch --ntasks-per-node=4` and bare `salloc` now resolve correctly.

## Verification

4xH200, jobid 7115669: TestAutoResume dense + MoE + TestRealConfigs::test_fp8_7b_config all pass in 7m37s.