### PR TITLE
Fix broken PyTorch intersphinx URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ myst_heading_anchors = 3
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "torch": ("https://pytorch.org/docs/main", None),
+    "torch": ("https://docs.pytorch.org/docs/main/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ myst_heading_anchors = 3
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "torch": ("https://docs.pytorch.org/docs/stable", None),
+    "torch": ("https://pytorch.org/docs/main", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  - Update `docs/conf.py:71` from `https://docs.pytorch.org/docs/stable` to `https://pytorch.org/docs/main`. PyTorch retired the `/stable/` alias on `docs.pytorch.org`, so the old URL returns 404 and trips `sphinx-build -W`, failing the Docs CI workflow.                                                                                                                                                                    
  - The new URL tracks the upstream main branch — same lifecycle as the `docs.python.org/3` and `numpy.org/doc/stable` entries already in this `intersphinx_mapping`. No periodic version bumps required.
                                              
  ## Why                                                                                                                                                                                                                                                                                                                                                                                                                          
  
  The `Docs` workflow runs `sphinx-build -W --keep-going` on every PR that touches `docs/**`, `kempnerforge/**`, `pyproject.toml`, or `uv.lock`. The intersphinx fetch surfaces as a warning, and `-W` converts it to a fatal error.                                                                                                                                                                                              
                                          
  URL probe results, taken just before this PR:                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  | URL | Status |
  |---|---|                                                                                                                                                                                                                                                                                                                                                                                                                       
  | `pytorch.org/docs/stable/objects.inv` | 404 (broken alias) |
  | `pytorch.org/docs/main/objects.inv` | **200** ✓ |                                                                                                                                                                                                                                                                                                                                                                             
  | `pytorch.org/docs/2.4/objects.inv` | 200 |
                                          
  `pytorch.org/docs/2.4` (matching the project's `torch>=2.4` constraint) is a viable alternative if the team prefers version-pinned cross-references, but it would need bumping every minor torch release.

## Testing
- [x] `uv run sphinx-build -W --keep-going -b html docs docs/_build/html` exits 0 locally with the new URL (verified on macOS arm64, Python 3.13, sphinx 9.1.0)
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors)
- [x] `uv run pytest tests/unit/ -v --timeout=60` passes
- [ N/A] If distributed code changed: `uv run torchrun --nproc_per_node=4 -m pytest tests/distributed/ -v`
- [ N/A] If training loop / parallelism / optimizers changed: `uv run pytest tests/e2e/ --e2e -v`

## Notes                                                                                                                                                                                                                                                                                                                                                                                                                        
   
  This unblocks the in-flight "Pin Python ≥3.12" PR (#72 ), which is currently failing the same workflow on this same warning. Once this lands, that PR can rebase onto `main` and re-run CI cleanly.

Closes #73 
