### PR TITLE
Add install-and-verify plugin skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `install-and-verify` plugin skill: runs `uv sync`, asserts Python ≥ 3.12, then runs the four CI gate checks (`ruff check`, `ruff format --check`, `pyright`, `pytest tests/unit/`). Canonical first command after cloning.
 - `.python-version` pinned to `>=3.12` so uv resolves the interpreter explicitly. Teammates on 3.13 use 3.13 (no download); 3.11-only users get 3.12 auto-fetched.
 
 ### Changed
 - `docs/getting-started/install.md` Prerequisites: documents `.python-version` and uv's auto-fetch behavior.
 - `README.md` and `kempnerforge/README.md` Prerequisites: clarify that uv auto-fetches Python 3.12 via `.python-version`.
+- `docs/claude-ready.md` first-run flow: `/kempnerforge:install-and-verify` runs before `/kempnerforge:cluster-config`.
+- `README.md` and `kempnerforge/README.md`: skill count updated from six to seven.
 
 ## [0.1.0] — 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/getting-started/install.md` Prerequisites: documents `.python-version` and uv's auto-fetch behavior.
 - `README.md` and `kempnerforge/README.md` Prerequisites: clarify that uv auto-fetches Python 3.12 via `.python-version`.
 - `docs/claude-ready.md` first-run flow: `/kempnerforge:install-and-verify` runs before `/kempnerforge:cluster-config`.
-- `README.md` and `kempnerforge/README.md`: skill count updated from six to seven.
+- `README.md` and `kempnerforge/README.md`: list `install-and-verify` in the skill catalog and drop the hardcoded skill count.
 
 ## [0.1.0] — 2026-04-16
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ First-run flow, from a fresh clone (use the absolute path to your checkout; rela
 
 The `marketplace list` step is a sanity check: `kempnerforge` should appear under "Configured marketplaces". If it doesn't, the add silently failed; re-check the absolute path.
 
-v0.1 ships seven skills: `install-and-verify`, `cluster-config`, `smoke-test`, `slurm-launch`, `explain-architecture`, `add-optimizer`, `component-gaps`. Full catalog, install details, and how skills stay in sync with the code: [`docs/claude-ready.md`](docs/claude-ready.md).
+v0.1 ships these skills: `install-and-verify`, `cluster-config`, `smoke-test`, `slurm-launch`, `explain-architecture`, `add-optimizer`, `component-gaps`. Full catalog, install details, and how skills stay in sync with the code: [`docs/claude-ready.md`](docs/claude-ready.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ First-run flow, from a fresh clone (use the absolute path to your checkout; rela
 
 The `marketplace list` step is a sanity check: `kempnerforge` should appear under "Configured marketplaces". If it doesn't, the add silently failed; re-check the absolute path.
 
-v0.1 ships six skills: `cluster-config`, `smoke-test`, `slurm-launch`, `explain-architecture`, `add-optimizer`, `component-gaps`. Full catalog, install details, and how skills stay in sync with the code: [`docs/claude-ready.md`](docs/claude-ready.md).
+v0.1 ships seven skills: `install-and-verify`, `cluster-config`, `smoke-test`, `slurm-launch`, `explain-architecture`, `add-optimizer`, `component-gaps`. Full catalog, install details, and how skills stay in sync with the code: [`docs/claude-ready.md`](docs/claude-ready.md).
 
 ## Documentation
 

--- a/docs/claude-ready.md
+++ b/docs/claude-ready.md
@@ -42,7 +42,7 @@ Subsequent sessions on the same checkout skip both prompts. Reconfiguration is a
 
 ## v0.1 skill catalog
 
-Seven skills cover the end-to-end path from clone to real runs.
+These skills cover the end-to-end path from clone to real runs.
 
 | Skill | Category | Preflight tags | What it does |
 |-------|----------|----------------|--------------|

--- a/docs/claude-ready.md
+++ b/docs/claude-ready.md
@@ -27,22 +27,26 @@ Optional schema validation:
 
 ## First-run flow
 
-Once installed, the canonical first invocation is:
+Once installed, run these in order:
 
 ```
+/kempnerforge:install-and-verify
 /kempnerforge:cluster-config
 ```
 
-This calls `scripts/check_env.py --init`, which reads `SLURM_*` env vars as defaults, prompts for each field, and writes `configs/cluster/local.toml` atomically. The file is gitignored. Every other skill reads from it.
+`install-and-verify` runs `uv sync`, confirms the venv is on Python ≥ 3.12 (per `.python-version`), then runs the same four checks CI runs on every PR (`ruff check`, `ruff format --check`, `pyright`, `pytest tests/unit/`). A green pass means your environment matches what CI gates against. Skip it only if you have already run those four locally on this checkout.
 
-Subsequent sessions on the same checkout skip the prompt. Reconfiguration is a re-run of the same command.
+`cluster-config` calls `scripts/check_env.py --init`, which reads `SLURM_*` env vars as defaults, prompts for each field, and writes `configs/cluster/local.toml` atomically. The file is gitignored. Every other skill reads from it. Run this whenever you onboard onto a new SLURM cluster (skip it on CPU-only or non-SLURM dev boxes).
+
+Subsequent sessions on the same checkout skip both prompts. Reconfiguration is a re-run of the same command.
 
 ## v0.1 skill catalog
 
-Six skills cover the end-to-end path from clone to real runs.
+Seven skills cover the end-to-end path from clone to real runs.
 
 | Skill | Category | Preflight tags | What it does |
 |-------|----------|----------------|--------------|
+| `install-and-verify` | onboarding | baseline | Run `uv sync`, confirm Python ≥ 3.12, then run the four CI checks (ruff check / format, pyright, pytest unit). First step after cloning. |
 | `cluster-config` | onboarding | baseline | Write `configs/cluster/local.toml`. First step on any new cluster. |
 | `smoke-test` | run-training | `gpu` | Short one-GPU training loop. Confirms torch, CUDA, NCCL, uv, dataloader. |
 | `slurm-launch` | run-training | `slurm` (+ `multi-node`) | Submit `sbatch` for single- or multi-node jobs. Inject account, partition, QoS, time from `local.toml`. |
@@ -90,7 +94,7 @@ To add a new skill:
 3. If your skill runs a code path not yet covered by `check_env`, add a new tag to `scripts/check_env.py` and a unit test in `tests/unit/test_check_env.py`.
 4. Bump `plugins[0].version` in `.claude-plugin/marketplace.json` and the README badge.
 
-See the existing six skills under `plugins/kempnerforge/skills/` for the reference layout.
+See the existing skills under `plugins/kempnerforge/skills/` for the reference layout.
 
 ## Design choices worth knowing
 

--- a/kempnerforge/README.md
+++ b/kempnerforge/README.md
@@ -154,7 +154,7 @@ First-run flow, from a fresh clone (use the absolute path to your checkout; rela
 
 The `marketplace list` step is a sanity check: `kempnerforge` should appear under "Configured marketplaces". If it doesn't, the add silently failed; re-check the absolute path.
 
-v0.1 ships six skills: `cluster-config`, `smoke-test`, `slurm-launch`, `explain-architecture`, `add-optimizer`, `component-gaps`. Full catalog, install details, and how skills stay in sync with the code: [`docs/claude-ready.md`](docs/claude-ready.md).
+v0.1 ships seven skills: `install-and-verify`, `cluster-config`, `smoke-test`, `slurm-launch`, `explain-architecture`, `add-optimizer`, `component-gaps`. Full catalog, install details, and how skills stay in sync with the code: [`docs/claude-ready.md`](docs/claude-ready.md).
 
 ## Documentation
 

--- a/kempnerforge/README.md
+++ b/kempnerforge/README.md
@@ -154,7 +154,7 @@ First-run flow, from a fresh clone (use the absolute path to your checkout; rela
 
 The `marketplace list` step is a sanity check: `kempnerforge` should appear under "Configured marketplaces". If it doesn't, the add silently failed; re-check the absolute path.
 
-v0.1 ships seven skills: `install-and-verify`, `cluster-config`, `smoke-test`, `slurm-launch`, `explain-architecture`, `add-optimizer`, `component-gaps`. Full catalog, install details, and how skills stay in sync with the code: [`docs/claude-ready.md`](docs/claude-ready.md).
+v0.1 ships these skills: `install-and-verify`, `cluster-config`, `smoke-test`, `slurm-launch`, `explain-architecture`, `add-optimizer`, `component-gaps`. Full catalog, install details, and how skills stay in sync with the code: [`docs/claude-ready.md`](docs/claude-ready.md).
 
 ## Documentation
 

--- a/plugins/kempnerforge/skills/install-and-verify/SKILL.md
+++ b/plugins/kempnerforge/skills/install-and-verify/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: install-and-verify
+description: Run `uv sync` and the four CI gate checks (ruff check, ruff format, pyright, pytest unit). First command after cloning. Auto-handles non-CUDA hosts via `--no-sources`.
+---
+
+## When to use
+- Right after `git clone`, before any other skill.
+- After `git pull` brings new dependency changes (`pyproject.toml` or `uv.lock`).
+- When CI fails and you want to reproduce the four PR-gate checks locally.
+
+## Preflight
+
+1. Detect the host. The torch wheel pin in `pyproject.toml` is CUDA-only:
+
+       command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1 && echo CUDA || echo NO_CUDA
+
+   On `NO_CUDA`, **print this warning to the user verbatim** before proceeding, and append `--no-sources` to every `uv run` and `uv sync` invocation in this skill (the flag is per-command, not sticky):
+
+   > ⚠️ No CUDA GPU detected. Using `--no-sources` to fetch torch from PyPI instead of the CUDA wheel index. Sufficient for the dev loop (lint, type-check, CPU unit tests); training and GPU tests still need a Linux GPU box. Note: `--no-sources` also bypasses any other `[tool.uv.sources]` entries the project may add later.
+
+2. Baseline check (use the form matching your host):
+
+       uv run python scripts/check_env.py                  # CUDA
+       uv run --no-sources python scripts/check_env.py     # non-CUDA
+
+   Non-zero exit: print stdout verbatim and stop. Common: install uv (`curl -LsSf https://astral.sh/uv/install.sh | sh`) or `cd` into the KempnerForge checkout.
+
+## Context (auto-generated, do not edit)
+<!-- context-begin -->
+Lint scope: kempnerforge/ tests/ scripts/
+Type-check scope: kempnerforge/
+Dev group: ruff, pyright[nodejs], pytest, pytest-timeout, vulture
+GPU test paths (NOT here): tests/integration/, tests/distributed/, tests/e2e/
+Non-CUDA fallback: uv sync --no-sources (bypasses [tool.uv.sources] torch CUDA pin)
+<!-- context-end -->
+
+## Procedure
+On non-CUDA hosts, append `--no-sources` to every `uv` command below.
+
+1. Sync:
+
+       uv sync
+
+   Expected: ~30 s cached, 2–5 min cold.
+
+2. Confirm Python ≥ 3.12:
+
+       uv run python -c "import sys; assert sys.version_info >= (3, 12), sys.version_info; print(sys.version_info[:3])"
+
+3. Lint:
+
+       uv run ruff check kempnerforge/ tests/ scripts/
+
+4. Format check:
+
+       uv run ruff format --check kempnerforge/ tests/ scripts/
+
+5. Type check:
+
+       uv run pyright kempnerforge/
+
+6. Unit tests (CPU-only):
+
+       uv run pytest tests/unit/ -v --timeout=60
+
+   Expected: ~890 tests in 10–60 s.
+
+7. Report each step OK / FAIL. Next:
+   - SLURM login node → `/kempnerforge:cluster-config`
+   - GPU box → `/kempnerforge:smoke-test`
+   - Non-CUDA dev machine → re-state the warning so the user remembers this venv is dev-only.
+
+## Gotchas
+- `--no-sources` is per-command. Forgetting it on one call → that call fails with the torch wheel error.
+- Stale `.venv` from a different Python or torch flavor → `rm -rf .venv && uv sync`. Symptom: tests run on the wrong Python or pyright diverges from CI.
+- `tests/integration/` / `tests/distributed/` / `tests/e2e/` are GPU-only; skipped here. Use `/kempnerforge:smoke-test` for the GPU path.
+- The verify quartet mirrors `.github/workflows/ci.yml`. Local-vs-CI divergence: check `uv --version` against `astral-sh/setup-uv@v6`.
+
+## Related skills
+- `/kempnerforge:cluster-config` — first cluster onboarding step.
+- `/kempnerforge:smoke-test` — short single-GPU training to validate end-to-end.

--- a/plugins/kempnerforge/skills/install-and-verify/SKILL.md
+++ b/plugins/kempnerforge/skills/install-and-verify/SKILL.md
@@ -5,8 +5,10 @@ description: Run `uv sync` and the four CI gate checks (ruff check, ruff format,
 
 ## When to use
 - Right after `git clone`, before any other skill.
-- After `git pull` brings new dependency changes (`pyproject.toml` or `uv.lock`).
+- Optionally after `git pull` if the user asks for it.
 - When CI fails and you want to reproduce the four PR-gate checks locally.
+
+Run every step in the background so the user isn't blocked — in Claude Code, set `run_in_background=true` on each Bash call and report status as each completes.
 
 ## Preflight
 
@@ -16,7 +18,7 @@ description: Run `uv sync` and the four CI gate checks (ruff check, ruff format,
 
    On `NO_CUDA`, **print this warning to the user verbatim** before proceeding, and append `--no-sources` to every `uv run` and `uv sync` invocation in this skill (the flag is per-command, not sticky):
 
-   > ⚠️ No CUDA GPU detected. Using `--no-sources` to fetch torch from PyPI instead of the CUDA wheel index. Sufficient for the dev loop (lint, type-check, CPU unit tests); training and GPU tests still need a Linux GPU box. Note: `--no-sources` also bypasses any other `[tool.uv.sources]` entries the project may add later.
+   > No CUDA GPU detected. Using `--no-sources` to fetch torch from PyPI instead of the CUDA wheel index. Sufficient for the dev loop (lint, type-check, CPU unit tests); training and GPU tests still need a Linux GPU box. Note: `--no-sources` also bypasses any other `[tool.uv.sources]` entries the project may add later.
 
 2. Baseline check (use the form matching your host):
 


### PR DESCRIPTION
## Summary
New `/kempnerforge:install-and-verify` skill — runs `uv sync` and the four CI gate checks (`ruff check`, `ruff format --check`, `pyright`, `pytest tests/unit/`). On non-CUDA hosts (macOS, CPU-only Linux) it appends `--no-sources` to bypass the CUDA-only torch wheel pin and warns the user that this venv is dev-only.
                                          
  Skill catalog grows from six to seven. `README.md`, `kempnerforge/README.md`, and `docs/claude-ready.md` updated; CHANGELOG records the addition.

## Testing
- [x] Validated end-to-end on macOS arm64 (non-CUDA path) by a fresh-context Claude Code agent: 892 unit tests pass; ruff / pyright clean; CUDA detection + `--no-sources` warning behave as documented.
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors)
- [x] `uv run pytest tests/unit/ -v --timeout=60` passes
- [N/A] If distributed code changed: `uv run torchrun --nproc_per_node=4 -m pytest tests/distributed/ -v`
- [N/A] If training loop / parallelism / optimizers changed: `uv run pytest tests/e2e/ --e2e -v`

## Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
Stacked on PR #72.
