### PR TITLE
Trim VLM config defaults and fix stale comments

### DIFF
--- a/configs/train/vlm_7b.toml
+++ b/configs/train/vlm_7b.toml
@@ -38,10 +38,6 @@ arch = "joint_decoder"
 vision_encoder = "random"
 feature_dim = 1024
 num_tokens = 256
-adapter_hidden_dim = 0
-adapter_activation = "gelu"
-max_text_len = 512
-freeze = [{module = "vision_encoder", frozen = true}]
 
 [train]
 batch_size = 16

--- a/configs/train/vlm_7b_ac.toml
+++ b/configs/train/vlm_7b_ac.toml
@@ -33,12 +33,9 @@ tie_embeddings = false
 [model.vlm]
 arch = "joint_decoder"
 vision_encoder = "random"
-feature_dim = 1024           # typical ViT-L/14 hidden size
-num_tokens = 256             # 16x16 patches at 224 input (CLS stripped)
-adapter_hidden_dim = 0       # 0 = use model.dim (4096)
-adapter_activation = "gelu"
-max_text_len = 512
-freeze = [{module = "vision_encoder", frozen = true}]
+# ViT-L/14-shaped dims (constructor inputs to RandomVisionEncoder, swap-in compatible)
+feature_dim = 1024
+num_tokens = 256
 
 [train]
 batch_size = 8

--- a/configs/train/vlm_7b_cross_attn.toml
+++ b/configs/train/vlm_7b_cross_attn.toml
@@ -48,18 +48,9 @@ tie_embeddings = false
 [model.vlm]
 arch = "cross_attention"
 vision_encoder = "random"
-feature_dim = 1024           # typical ViT-L/14 hidden size
-num_tokens = 256             # 16x16 patches at 224 input (CLS stripped)
-adapter_hidden_dim = 0       # 0 = use model.dim (4096)
-adapter_activation = "gelu"
-max_text_len = 512
-# Cross-attention placement. Cadence 4 with n_layers=32 yields 8 CA
-# blocks; n_kv_heads=0 resolves to n_heads on the cross path (MHA);
-# set a smaller positive value for GQA on the cross path.
-cross_attention_every_n_layers = 4
-cross_attention_n_heads = 0
-cross_attention_n_kv_heads = 0
-freeze = [{module = "vision_encoder", frozen = true}]
+# ViT-L/14-shaped dims (constructor inputs to RandomVisionEncoder, swap-in compatible)
+feature_dim = 1024
+num_tokens = 256
 
 [train]
 batch_size = 16

--- a/configs/train/vlm_7b_freeze_schedule.toml
+++ b/configs/train/vlm_7b_freeze_schedule.toml
@@ -39,13 +39,6 @@ arch = "cross_attention"
 vision_encoder = "random"
 feature_dim = 1024
 num_tokens = 256
-adapter_hidden_dim = 0
-adapter_activation = "gelu"
-max_text_len = 512
-cross_attention_every_n_layers = 4
-cross_attention_n_heads = 0
-cross_attention_n_kv_heads = 0
-freeze = [{module = "vision_encoder", frozen = true}]
 freeze_schedule = [
     {start_step = 10, specs = [{module = "adapter", frozen = true}]},
     {start_step = 20, specs = [{module = "adapter", frozen = false}]},

--- a/configs/train/vlm_7b_mot.toml
+++ b/configs/train/vlm_7b_mot.toml
@@ -50,14 +50,6 @@ arch = "mot"
 vision_encoder = "random"
 feature_dim = 1024
 num_tokens = 256
-adapter_hidden_dim = 0
-adapter_activation = "gelu"
-max_text_len = 512
-mot_modalities = ["image", "text"]
-mot_image_n_heads = 0     # 0 = inherit model.n_heads (v1 enforces equality)
-mot_image_n_kv_heads = 0
-mot_warm_start_from_text = false
-freeze = [{module = "vision_encoder", frozen = true}]
 
 [train]
 batch_size = 8

--- a/configs/train/vlm_7b_siglip2.toml
+++ b/configs/train/vlm_7b_siglip2.toml
@@ -35,10 +35,7 @@ vision_encoder = "siglip2"
 vision_encoder_path = "google/siglip2-base-patch16-224"
 feature_dim = 768       # SigLIP2 base hidden size
 num_tokens = 196        # 14x14 patches for 224-input
-adapter_hidden_dim = 0  # 0 = use model.dim (4096)
-adapter_activation = "gelu"
 max_text_len = 2048
-freeze = [{module = "vision_encoder", frozen = true}]
 
 [train]
 batch_size = 4

--- a/configs/train/vlm_7b_siglip2_cross_attn.toml
+++ b/configs/train/vlm_7b_siglip2_cross_attn.toml
@@ -40,13 +40,7 @@ vision_encoder = "siglip2"
 vision_encoder_path = "google/siglip2-base-patch16-224"
 feature_dim = 768       # SigLIP2 base hidden size
 num_tokens = 196        # 14x14 patches for 224-input
-adapter_hidden_dim = 0  # 0 = use model.dim (4096)
-adapter_activation = "gelu"
 max_text_len = 2048
-cross_attention_every_n_layers = 4
-cross_attention_n_heads = 0
-cross_attention_n_kv_heads = 0
-freeze = [{module = "vision_encoder", frozen = true}]
 
 [train]
 batch_size = 4

--- a/configs/train/vlm_debug.toml
+++ b/configs/train/vlm_debug.toml
@@ -24,10 +24,6 @@ arch = "joint_decoder"
 vision_encoder = "random"
 feature_dim = 384
 num_tokens = 64
-adapter_hidden_dim = 0  # 0 = use model.dim
-adapter_activation = "gelu"
-max_text_len = 512
-freeze = [{module = "vision_encoder", frozen = true}]
 
 [train]
 batch_size = 2

--- a/configs/train/vlm_debug_moe.toml
+++ b/configs/train/vlm_debug_moe.toml
@@ -26,25 +26,16 @@ n_kv_heads = 2
 vocab_size = 50257       # gpt2 vocab
 norm_type = "rmsnorm"
 activation = "silu"
-max_seq_len = 576        # CA residual stream is text-only -> matches max_text_len
+max_seq_len = 576        # CA residual stream is text-only; >= max_text_len with headroom
 num_experts = 4
-moe_top_k = 2
 moe_frequency = 2        # MoE every 2 layers; layers 1, 3 are MoE; 0, 2 are dense
-moe_router = "softmax_topk"
-moe_aux_loss_weight = 0.01
 
 [model.vlm]
 arch = "cross_attention"
 vision_encoder = "random"
 feature_dim = 384
 num_tokens = 64
-adapter_hidden_dim = 0   # 0 = use model.dim
-adapter_activation = "gelu"
-max_text_len = 512
 cross_attention_every_n_layers = 2
-cross_attention_n_heads = 0
-cross_attention_n_kv_heads = 0
-freeze = [{module = "vision_encoder", frozen = true}]
 
 [train]
 batch_size = 2

--- a/configs/train/vlm_debug_mot.toml
+++ b/configs/train/vlm_debug_mot.toml
@@ -23,14 +23,6 @@ arch = "mot"
 vision_encoder = "random"
 feature_dim = 384
 num_tokens = 64
-adapter_hidden_dim = 0  # 0 = use model.dim
-adapter_activation = "gelu"
-max_text_len = 512
-mot_modalities = ["image", "text"]
-mot_image_n_heads = 0      # 0 = inherit model.n_heads
-mot_image_n_kv_heads = 0   # 0 = inherit
-mot_warm_start_from_text = false
-freeze = [{module = "vision_encoder", frozen = true}]
 
 [train]
 batch_size = 2


### PR DESCRIPTION
Closes #82

## Summary
- Drop 60 lines across 10 VLM configs where the value equals the
  dataclass default. `_apply_dict_to_dataclass` (`loader.py:205`)
  treats present-but-default keys identically to omitted keys.
- Rewrite stale inline comments in `vlm_debug_moe.toml`,
  `vlm_7b_ac.toml`, `vlm_7b_cross_attn.toml`.
- Keep SigLIP2 `num_tokens` / `feature_dim` for a follow-up PR.

## Test plan
- [x] Per-config trim verified against dataclass defaults (4+9+8+4+4+7+7+3+6+8 = 60)
- [x] No source changes, no test changes
- [x] 1207 unit tests pass, ruff clean