### PR TITLE
Replace dead nlphuji/coco_karpathy default with sayakpaul/coco-30-val-2014

### DIFF
--- a/configs/train/vlm_7b.toml
+++ b/configs/train/vlm_7b.toml
@@ -12,8 +12,9 @@
 # Usage:
 #   uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/vlm_7b.toml
 #
-# Defaults point at the public COCO Karpathy split on HF Hub. Override
-# the dataset and tokenizer via CLI for other corpora:
+# Default points at a 30-sample COCO val substitute (sayakpaul/coco-30-val-2014)
+# so a fresh clone runs without external setup. For real training, override
+# the dataset (and tokenizer) via CLI:
 #   --data.hf_dataset_name=<dataset> --data.tokenizer_path=<tokenizer>
 #
 # Swap the vision encoder via [model.vlm].vision_encoder: "random"
@@ -64,7 +65,7 @@ warmup_steps = 3
 min_lr_ratio = 0.1
 
 [data]
-hf_dataset_name = "nlphuji/coco_karpathy"
+hf_dataset_name = "sayakpaul/coco-30-val-2014"
 hf_dataset_split = "train"
 hf_dataset_image_field = "image"
 hf_dataset_text_field = "caption"

--- a/configs/train/vlm_7b_ac.toml
+++ b/configs/train/vlm_7b_ac.toml
@@ -13,8 +13,9 @@
 #   uv run torchrun --nproc_per_node=4 scripts/train.py \
 #       configs/train/vlm_7b_ac.toml
 #
-# Defaults point at the public COCO Karpathy split on HF Hub. Override
-# the dataset and tokenizer via CLI for other corpora:
+# Default points at a 30-sample COCO val substitute (sayakpaul/coco-30-val-2014)
+# so a fresh clone runs without external setup. For real training, override
+# the dataset (and tokenizer) via CLI:
 #   --data.hf_dataset_name=<dataset> --data.tokenizer_path=<tokenizer>
 
 [model]
@@ -62,7 +63,7 @@ warmup_steps = 5
 min_lr_ratio = 0.1
 
 [data]
-hf_dataset_name = "nlphuji/coco_karpathy"
+hf_dataset_name = "sayakpaul/coco-30-val-2014"
 hf_dataset_split = "train"
 hf_dataset_image_field = "image"
 hf_dataset_text_field = "caption"

--- a/configs/train/vlm_7b_cross_attn.toml
+++ b/configs/train/vlm_7b_cross_attn.toml
@@ -24,8 +24,9 @@
 #   uv run torchrun --nproc_per_node=4 scripts/train.py \
 #       configs/train/vlm_7b_cross_attn.toml
 #
-# Defaults point at the public COCO Karpathy split on HF Hub. Override
-# the dataset and tokenizer via CLI for other corpora:
+# Default points at a 30-sample COCO val substitute (sayakpaul/coco-30-val-2014)
+# so a fresh clone runs without external setup. For real training, override
+# the dataset (and tokenizer) via CLI:
 #   --data.hf_dataset_name=<dataset> --data.tokenizer_path=<tokenizer>
 #
 # Swap the vision encoder via [model.vlm].vision_encoder: "random"
@@ -77,7 +78,7 @@ warmup_steps = 3
 min_lr_ratio = 0.1
 
 [data]
-hf_dataset_name = "nlphuji/coco_karpathy"
+hf_dataset_name = "sayakpaul/coco-30-val-2014"
 hf_dataset_split = "train"
 hf_dataset_image_field = "image"
 hf_dataset_text_field = "caption"

--- a/configs/train/vlm_7b_freeze_schedule.toml
+++ b/configs/train/vlm_7b_freeze_schedule.toml
@@ -17,8 +17,9 @@
 #   uv run torchrun --nproc_per_node=4 scripts/train.py \
 #       configs/train/vlm_7b_freeze_schedule.toml
 #
-# Defaults point at the public COCO Karpathy split on HF Hub. Override
-# the dataset and tokenizer via CLI for other corpora:
+# Default points at a 30-sample COCO val substitute (sayakpaul/coco-30-val-2014)
+# so a fresh clone runs without external setup. For real training, override
+# the dataset (and tokenizer) via CLI:
 #   --data.hf_dataset_name=<dataset> --data.tokenizer_path=<tokenizer>
 
 [model]
@@ -69,7 +70,7 @@ warmup_steps = 3
 min_lr_ratio = 0.1
 
 [data]
-hf_dataset_name = "nlphuji/coco_karpathy"
+hf_dataset_name = "sayakpaul/coco-30-val-2014"
 hf_dataset_split = "train"
 hf_dataset_image_field = "image"
 hf_dataset_text_field = "caption"

--- a/configs/train/vlm_7b_mot.toml
+++ b/configs/train/vlm_7b_mot.toml
@@ -25,9 +25,10 @@
 # Usage:
 #   uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/vlm_7b_mot.toml
 #
-# The default hf_dataset_name below points at the public Karpathy COCO
-# split for parity with vlm_7b.toml; if that name is unreachable, point
-# at any local HF Dataset directory (saved via datasets.save_to_disk):
+# Default points at a 30-sample COCO val substitute (sayakpaul/coco-30-val-2014)
+# so a fresh clone runs without external setup. For real training, override
+# either via the Hub or a local HF Dataset directory saved with
+# datasets.save_to_disk:
 #   --data.hf_dataset_name=/path/to/local/hf_dataset \
 #   --data.hf_dataset_text_field=caption
 # Swap the encoder via [model.vlm].vision_encoder = "siglip2" / "clip".
@@ -76,7 +77,7 @@ warmup_steps = 5
 min_lr_ratio = 0.1
 
 [data]
-hf_dataset_name = "nlphuji/coco_karpathy"
+hf_dataset_name = "sayakpaul/coco-30-val-2014"
 hf_dataset_split = "train"
 hf_dataset_image_field = "image"
 hf_dataset_text_field = "caption"

--- a/configs/train/vlm_7b_siglip2.toml
+++ b/configs/train/vlm_7b_siglip2.toml
@@ -13,8 +13,13 @@
 #   uv run torchrun --nproc_per_node=4 scripts/train.py configs/train/vlm_7b_siglip2.toml
 #
 # Data:
-#   Defaults point at COCO captions; swap for COYO-700M or LLaVA-style
-#   datasets via CLI overrides.
+#   Default hf_dataset_name is a 30-sample COCO val substitute
+#   (sayakpaul/coco-30-val-2014) so a fresh clone runs without external
+#   setup. This config runs 5000 steps; the 30-sample default will
+#   memorize in <1 epoch. Override via CLI for real training, e.g.:
+#     --data.hf_dataset_name=<larger-dataset-or-local-path>
+#   For a local Karpathy-split COCO dataset, see scripts/prep_vlm_coco_smoke.py
+#   which writes a save_to_disk directory you can point this field at.
 
 [model]
 dim = 4096
@@ -61,7 +66,7 @@ warmup_steps = 200
 min_lr_ratio = 0.1
 
 [data]
-hf_dataset_name = "nlphuji/coco_karpathy"
+hf_dataset_name = "sayakpaul/coco-30-val-2014"
 hf_dataset_split = "train"
 hf_dataset_image_field = "image"
 hf_dataset_text_field = "caption"

--- a/configs/train/vlm_7b_siglip2_cross_attn.toml
+++ b/configs/train/vlm_7b_siglip2_cross_attn.toml
@@ -17,8 +17,9 @@
 #   uv run torchrun --nproc_per_node=4 scripts/train.py \
 #       configs/train/vlm_7b_siglip2_cross_attn.toml
 #
-# Defaults point at the public COCO Karpathy split on HF Hub. Override
-# the dataset and tokenizer via CLI for other corpora:
+# Default points at a 30-sample COCO val substitute (sayakpaul/coco-30-val-2014)
+# so a fresh clone runs without external setup. For real training, override
+# the dataset (and tokenizer) via CLI:
 #   --data.hf_dataset_name=<dataset> --data.tokenizer_path=<tokenizer>
 
 [model]
@@ -66,7 +67,7 @@ warmup_steps = 5
 min_lr_ratio = 0.1
 
 [data]
-hf_dataset_name = "nlphuji/coco_karpathy"
+hf_dataset_name = "sayakpaul/coco-30-val-2014"
 hf_dataset_split = "train"
 hf_dataset_image_field = "image"
 hf_dataset_text_field = "caption"

--- a/configs/train/vlm_debug.toml
+++ b/configs/train/vlm_debug.toml
@@ -48,8 +48,9 @@ warmup_steps = 5
 min_lr_ratio = 0.1
 
 [data]
-# Placeholder; override at the CLI with a real dataset.
-hf_dataset_name = "nlphuji/coco_karpathy"
+# 30-sample COCO val substitute (sayakpaul/coco-30-val-2014). For a real
+# training run, override via CLI: --data.hf_dataset_name=<your-dataset>
+hf_dataset_name = "sayakpaul/coco-30-val-2014"
 hf_dataset_split = "train"
 hf_dataset_image_field = "image"
 hf_dataset_text_field = "caption"

--- a/configs/train/vlm_debug_moe.toml
+++ b/configs/train/vlm_debug_moe.toml
@@ -60,8 +60,9 @@ warmup_steps = 5
 min_lr_ratio = 0.1
 
 [data]
-# Placeholder; override at the CLI with a real dataset.
-hf_dataset_name = "nlphuji/coco_karpathy"
+# 30-sample COCO val substitute (sayakpaul/coco-30-val-2014). For a real
+# training run, override via CLI: --data.hf_dataset_name=<your-dataset>
+hf_dataset_name = "sayakpaul/coco-30-val-2014"
 hf_dataset_split = "train"
 hf_dataset_image_field = "image"
 hf_dataset_text_field = "caption"

--- a/configs/train/vlm_debug_mot.toml
+++ b/configs/train/vlm_debug_mot.toml
@@ -47,7 +47,9 @@ warmup_steps = 5
 min_lr_ratio = 0.1
 
 [data]
-hf_dataset_name = "nlphuji/coco_karpathy"
+# 30-sample COCO val substitute (sayakpaul/coco-30-val-2014). For a real
+# training run, override via CLI: --data.hf_dataset_name=<your-dataset>
+hf_dataset_name = "sayakpaul/coco-30-val-2014"
 hf_dataset_split = "train"
 hf_dataset_image_field = "image"
 hf_dataset_text_field = "caption"

--- a/kempnerforge/data/vlm_dataset.py
+++ b/kempnerforge/data/vlm_dataset.py
@@ -119,7 +119,8 @@ class HuggingFaceVLMDataset(Dataset):
     """Map-style HF image-text dataset for Joint-Decoder training.
 
     Args:
-        dataset_name: HF dataset name (e.g. ``"nlphuji/coco_karpathy"``).
+        dataset_name: HF dataset name (e.g. ``"sayakpaul/coco-30-val-2014"``)
+            or a local directory written by ``datasets.save_to_disk``.
         split: Dataset split.
         image_field: Column name for the PIL image.
         text_field: Column name for the caption / target text.


### PR DESCRIPTION
Closes #84

## Summary
- All 10 VLM configs: `hf_dataset_name = "sayakpaul/coco-30-val-2014"`.
  Same Hub-load path; image/caption fields match what
  `HuggingFaceVLMDataset` expects.
- `vlm_7b_siglip2.toml` header: explicit note that 30 samples is for
  verification only and the user must override for real 5000-step training.
- `vlm_dataset.py:122` docstring example updated to match.

## Test plan
- [x] Live-loaded `sayakpaul/coco-30-val-2014`: keys=['image', 'caption'],
      caption is str, image is JpegImageFile
- [x] `grep -rn "nlphuji" --include="*.py" --include="*.toml" .` returns
      zero hits
- [x] 1207 unit tests pass, ruff clean
- [x] No logic changes (only configs + 1 docstring example update)