### PR TITLE
Drop hardcoded SigLIP2 feature_dim/num_tokens; rely on encoder probe

### DIFF
--- a/configs/train/vlm_7b_siglip2.toml
+++ b/configs/train/vlm_7b_siglip2.toml
@@ -38,8 +38,9 @@ tie_embeddings = false
 arch = "joint_decoder"
 vision_encoder = "siglip2"
 vision_encoder_path = "google/siglip2-base-patch16-224"
-feature_dim = 768       # SigLIP2 base hidden size
-num_tokens = 196        # 14x14 patches for 224-input
+# feature_dim and num_tokens default to 0 = infer from the encoder at
+# build time. For siglip2-base-patch16-224 the encoder probes
+# feature_dim=768 and num_tokens=196 (14x14 patches, no CLS).
 max_text_len = 2048
 
 [train]

--- a/configs/train/vlm_7b_siglip2_cross_attn.toml
+++ b/configs/train/vlm_7b_siglip2_cross_attn.toml
@@ -39,8 +39,10 @@ tie_embeddings = false
 arch = "cross_attention"
 vision_encoder = "siglip2"
 vision_encoder_path = "google/siglip2-base-patch16-224"
-feature_dim = 768       # SigLIP2 base hidden size
-num_tokens = 196        # 14x14 patches for 224-input
+# feature_dim and num_tokens default to 0 = infer from the encoder at
+# build time. For siglip2-base-patch16-224 the encoder probes
+# feature_dim=768 and num_tokens=196. CA ignores num_tokens at runtime
+# (residual is text-only); kept here only as documentation.
 max_text_len = 2048
 
 [train]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -475,8 +475,11 @@ class TestTomlLoading:
         assert config.model.is_vlm is True
         assert config.model.vlm is not None
         assert config.model.vlm.vision_encoder == "siglip2"
-        assert config.model.vlm.num_tokens == 196
-        # 196 image + 2048 text = 2244 <= max_seq_len=2304
+        # num_tokens defaults to 0 = "infer from encoder at build time".
+        # The encoder probes 196 (14x14 patches, no CLS) for this path; the
+        # build-time max_seq_len cross-check in build_vlm_wrapper enforces
+        # 196 + 2048 = 2244 <= max_seq_len=2304.
+        assert config.model.vlm.num_tokens == 0
         config.validate(world_size=4)
 
     def test_vlm_freeze_schedule_loads_variadic_tuple(self, tmp_path):


### PR DESCRIPTION
Closes #86

## Summary
- Drop `feature_dim = 768` and `num_tokens = 196` from both SigLIP2
  configs. After #81's encoder fix, the probe returns these exact values
  for `google/siglip2-base-patch16-224`.
- Add an inline comment in each config naming the probed values so the
  context isn't lost.
- Update `test_load_vlm_7b_siglip2_toml`: the post-PR assertion checks
  the sentinel state (`num_tokens == 0`) rather than the now-absent
  override. The build-time check in `build_vlm_wrapper` still enforces
  `196 + 2048 <= max_seq_len`.

## Test plan
- [x] Live-verified `google/siglip2-base-patch16-224` config:
      hidden_size=768, image_size=224, patch_size=16, n_patches=196
- [x] 1207 unit tests pass, ruff clean
- [x] `test_load_vlm_7b_siglip2_toml` updated to match post-fix state