### PR TITLE
Promote Adapter to a registered component

### DIFF
--- a/kempnerforge/config/adapter.py
+++ b/kempnerforge/config/adapter.py
@@ -1,0 +1,63 @@
+"""Adapter configuration.
+
+``AdapterConfig`` selects which adapter the VLM wrapper instantiates and
+parameterizes the chosen adapter. Dispatched via the ``adapter`` registry
+at build time (see ``kempnerforge/model/adapter.py``).
+
+This module is registered-component-shaped (parallel to ``VisionEncoderConfig``,
+``VLMConfig``). A follow-up PR will flatten the VLM TOML schema to expose
+``[adapter]`` as a top-level section; until then ``build_vlm_wrapper``
+constructs an ``AdapterConfig`` internally from the existing ``VLMConfig``
+fields (``adapter_hidden_dim``, ``adapter_activation``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import kempnerforge.model.adapter  # noqa: F401 - triggers adapter registration
+from kempnerforge.config.registry import registry
+
+
+@dataclass
+class AdapterConfig:
+    """Selects the adapter type and parameterizes it.
+
+    Fields:
+        type: Registry key for the adapter builder. ``"mlp_2layer"`` (default)
+            or ``"linear"``. Custom adapters register additional names.
+        hidden_dim: Hidden width for ``mlp_2layer``. ``0`` means "match
+            ``out_dim``"; ignored by ``linear``.
+        activation: Activation between the two MLP projections. One of
+            ``"gelu"`` (default), ``"silu"``, ``"relu"``. Ignored by
+            ``linear``.
+    """
+
+    type: str = "mlp_2layer"
+    hidden_dim: int = 0
+    activation: str = "gelu"
+
+    def __post_init__(self) -> None:
+        registered = tuple(registry.list_adapters())
+        if self.type not in registered:
+            raise ValueError(
+                f"Unknown adapter.type: {self.type!r}. Registered: {sorted(registered)}."
+            )
+        if self.hidden_dim < 0:
+            raise ValueError(f"adapter.hidden_dim must be non-negative (got {self.hidden_dim})")
+        if self.activation not in ("gelu", "silu", "relu"):
+            raise ValueError(
+                f"Unknown adapter.activation: {self.activation!r}. Options: 'gelu', 'silu', 'relu'."
+            )
+
+    def extra_kwargs(self) -> dict[str, Any]:
+        """Builder kwargs beyond ``in_dim`` / ``out_dim``.
+
+        ``hidden_dim=0`` is mapped to ``None`` so the adapter falls back to
+        its own default (e.g., ``out_dim`` for ``MLP2LayerAdapter``).
+        """
+        return {
+            "hidden_dim": self.hidden_dim or None,
+            "activation": self.activation,
+        }

--- a/kempnerforge/config/registry.py
+++ b/kempnerforge/config/registry.py
@@ -162,6 +162,27 @@ class Registry:
     def list_modality_strategies(self) -> list[str]:
         return self.list("modality_strategy")
 
+    def register_adapter(self, name: str) -> Callable:
+        """Decorator to register an adapter builder.
+
+        Adapters project image features (``(B, N, feature_dim)``) into the
+        LLM embedding space (``(B, N, model.dim)``). Builders take
+        ``(in_dim, out_dim, **kwargs)`` and return an ``nn.Module`` with the
+        expected forward shape.
+        """
+
+        def decorator(fn: Callable) -> Callable:
+            self.register("adapter", name, fn)
+            return fn
+
+        return decorator
+
+    def get_adapter(self, name: str) -> Callable:
+        return self.get("adapter", name)
+
+    def list_adapters(self) -> list[str]:
+        return self.list("adapter")
+
 
 # Global registry instance
 registry = Registry()

--- a/kempnerforge/distributed/parallel.py
+++ b/kempnerforge/distributed/parallel.py
@@ -392,10 +392,11 @@ def _build_vlm(
       7. Freeze specs are applied via ``apply_freeze_specs`` and a fully
          frozen encoder is switched to ``eval()``.
     """
+    from kempnerforge.config.adapter import AdapterConfig
     from kempnerforge.distributed.expert_parallel import apply_expert_parallel
     from kempnerforge.distributed.tensor_parallel import apply_tensor_parallel
+    from kempnerforge.model.adapter import build_adapter
     from kempnerforge.model.vlm import (
-        Adapter,
         VLMWrapper,
         _is_encoder_frozen,
         build_modality_strategy,
@@ -417,15 +418,15 @@ def _build_vlm(
 
     # 2. Transformer + Adapter on meta (when TP is active) or CPU.
     model_builder = registry.get_model(model_config.model_type)
+    adapter_config = AdapterConfig(
+        type="mlp_2layer",
+        hidden_dim=vlm.adapter_hidden_dim,
+        activation=vlm.adapter_activation,
+    )
     ctx = torch.device("meta") if tp_enabled else contextlib.nullcontext()
     with ctx:
         transformer = model_builder(model_config)
-        adapter = Adapter(
-            in_dim=in_dim,
-            out_dim=model_config.dim,
-            hidden_dim=vlm.adapter_hidden_dim or None,
-            activation=vlm.adapter_activation,
-        )
+        adapter = build_adapter(adapter_config, in_dim=in_dim, out_dim=model_config.dim)
 
     strategy = build_modality_strategy(vlm)
     wrapper = VLMWrapper(encoder, adapter, transformer, strategy)

--- a/kempnerforge/distributed/parallel.py
+++ b/kempnerforge/distributed/parallel.py
@@ -458,7 +458,11 @@ def _build_vlm(
         transformer.to_empty(device=device)
         transformer.init_weights_and_freqs()
         adapter.to_empty(device=device)
-        adapter.reset_parameters()
+        # Adapter contract (model/adapter.py): every registered adapter
+        # exposes reset_parameters() so meta-device builds can re-init the
+        # weights after to_empty. nn.Module itself does not declare the
+        # method, so pyright sees an unknown attr; suppress the report.
+        adapter.reset_parameters()  # type: ignore[reportCallIssue,reportAttributeAccessIssue]
     else:
         transformer.to(device=device)
         adapter.to(device=device)

--- a/kempnerforge/model/adapter.py
+++ b/kempnerforge/model/adapter.py
@@ -1,0 +1,128 @@
+"""Vision-to-LLM adapter modules.
+
+The adapter projects image features (shape ``(B, num_tokens, feature_dim)``)
+into the LLM embedding space (shape ``(B, num_tokens, model.dim)``). It sits
+between the vision encoder and the transformer in ``VLMWrapper``.
+
+Adapters register themselves under the ``adapter`` registry category. The
+default is ``mlp_2layer`` (a 2-layer MLP, the canonical adapter shape across
+LLaVA-family papers). ``linear`` is a single ``nn.Linear`` with no
+activation, useful for ablations.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from kempnerforge.config.registry import registry
+
+_ADAPTER_ACTIVATIONS: dict[str, type[nn.Module]] = {
+    "gelu": nn.GELU,
+    "silu": nn.SiLU,
+    "relu": nn.ReLU,
+}
+
+
+class MLP2LayerAdapter(nn.Module):
+    """2-layer MLP from image-feature dim to LLM embedding dim.
+
+    Architecture: ``Linear(in_dim, hidden) -> activation -> Linear(hidden, out_dim)``.
+    ``hidden_dim=None`` defaults to ``out_dim``.
+
+    ``reset_parameters`` is provided so callers that materialize adapters
+    from meta can re-initialize weights with the standard Linear defaults.
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        out_dim: int,
+        hidden_dim: int | None = None,
+        activation: str = "gelu",
+    ) -> None:
+        super().__init__()
+        if in_dim <= 0 or out_dim <= 0:
+            raise ValueError("MLP2LayerAdapter in_dim and out_dim must be positive")
+        if activation not in _ADAPTER_ACTIVATIONS:
+            raise ValueError(
+                f"Unknown adapter activation: {activation!r}. Options: {list(_ADAPTER_ACTIVATIONS)}"
+            )
+        hidden = hidden_dim if hidden_dim and hidden_dim > 0 else out_dim
+        self.proj1 = nn.Linear(in_dim, hidden, bias=True)
+        self.act = _ADAPTER_ACTIVATIONS[activation]()
+        self.proj2 = nn.Linear(hidden, out_dim, bias=True)
+
+    def reset_parameters(self) -> None:
+        """Re-run ``nn.Linear`` default init on both projections.
+
+        Used after ``to_empty(device=...)`` on a meta-device build.
+        """
+        self.proj1.reset_parameters()
+        self.proj2.reset_parameters()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj2(self.act(self.proj1(x)))
+
+
+class LinearAdapter(nn.Module):
+    """Single ``nn.Linear`` from image-feature dim to LLM embedding dim.
+
+    No activation, no hidden layer. Useful as an ablation baseline against
+    ``MLP2LayerAdapter``.
+    """
+
+    def __init__(self, in_dim: int, out_dim: int) -> None:
+        super().__init__()
+        if in_dim <= 0 or out_dim <= 0:
+            raise ValueError("LinearAdapter in_dim and out_dim must be positive")
+        self.proj = nn.Linear(in_dim, out_dim, bias=True)
+
+    def reset_parameters(self) -> None:
+        self.proj.reset_parameters()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(x)
+
+
+@registry.register_adapter("mlp_2layer")
+def _build_mlp_2layer(
+    in_dim: int,
+    out_dim: int,
+    hidden_dim: int | None = None,
+    activation: str = "gelu",
+    **_: Any,
+) -> MLP2LayerAdapter:
+    return MLP2LayerAdapter(
+        in_dim=in_dim,
+        out_dim=out_dim,
+        hidden_dim=hidden_dim,
+        activation=activation,
+    )
+
+
+@registry.register_adapter("linear")
+def _build_linear(
+    in_dim: int,
+    out_dim: int,
+    **_: Any,
+) -> LinearAdapter:
+    return LinearAdapter(in_dim=in_dim, out_dim=out_dim)
+
+
+def build_adapter(adapter_config, in_dim: int, out_dim: int) -> nn.Module:
+    """Dispatch to the registered adapter builder.
+
+    Args:
+        adapter_config: ``AdapterConfig`` (or compatible object exposing
+            ``type`` and ``extra_kwargs()``).
+        in_dim: Source feature dim (the vision encoder's ``feature_dim``).
+        out_dim: Target embedding dim (the transformer's ``dim``).
+
+    Returns:
+        An ``nn.Module`` with signature ``(B, N, in_dim) -> (B, N, out_dim)``.
+    """
+    builder = registry.get_adapter(adapter_config.type)
+    return builder(in_dim=in_dim, out_dim=out_dim, **adapter_config.extra_kwargs())

--- a/kempnerforge/model/vlm.py
+++ b/kempnerforge/model/vlm.py
@@ -1,14 +1,16 @@
 """Vision-language model wrapper.
 
-The wrapper composes a ``VisionEncoder`` (HF or test stub), a 2-layer
-MLP ``Adapter`` projecting image features into the LLM embedding
-space, and the existing ``Transformer``. The arch-specific work
-(composing ``pixel_values`` + ``input_ids`` into a
+The wrapper composes a ``VisionEncoder`` (HF or test stub), a registered
+adapter (``MLP2LayerAdapter`` by default; ``LinearAdapter`` available
+via the ``adapter`` registry) projecting image features into the LLM
+embedding space, and the existing ``Transformer``. The arch-specific
+work (composing ``pixel_values`` + ``input_ids`` into a
 ``ModalityContext``) lives on a ``ModalityStrategy`` that the wrapper
 holds, so adding a new arch is one new strategy decorator on
 ``@registry.register_modality_strategy`` plus one new ``VLMConfig``
-subclass — no edits to ``VLMWrapper.forward``, no ``isinstance``
-ladder.
+subclass, and adding a new adapter is one new builder under
+``@registry.register_adapter``. No edits to ``VLMWrapper.forward``,
+no ``isinstance`` ladder.
 
 Strategies registered today:
 
@@ -37,59 +39,14 @@ from typing import Protocol
 import torch
 import torch.nn as nn
 
+from kempnerforge.config.adapter import AdapterConfig
 from kempnerforge.config.registry import registry
 from kempnerforge.config.schema import ModelConfig
 from kempnerforge.config.vlm import FreezeSpec, VLMConfig
+from kempnerforge.model.adapter import build_adapter
 from kempnerforge.model.modality import ModalityContext
 from kempnerforge.model.transformer import Transformer
 from kempnerforge.model.vision import VisionEncoder
-
-_ADAPTER_ACTIVATIONS: dict[str, type[nn.Module]] = {
-    "gelu": nn.GELU,
-    "silu": nn.SiLU,
-    "relu": nn.ReLU,
-}
-
-
-class Adapter(nn.Module):
-    """2-layer MLP from image-feature dim to LLM embedding dim.
-
-    Architecture: ``Linear(in_dim, hidden) -> activation -> Linear(hidden, out_dim)``.
-    ``hidden_dim=None`` defaults to ``out_dim``.
-
-    ``reset_parameters`` is provided so callers that materialize adapters
-    from meta can re-initialize weights with the standard Linear defaults.
-    """
-
-    def __init__(
-        self,
-        in_dim: int,
-        out_dim: int,
-        hidden_dim: int | None = None,
-        activation: str = "gelu",
-    ) -> None:
-        super().__init__()
-        if in_dim <= 0 or out_dim <= 0:
-            raise ValueError("Adapter in_dim and out_dim must be positive")
-        if activation not in _ADAPTER_ACTIVATIONS:
-            raise ValueError(
-                f"Unknown adapter activation: {activation!r}. Options: {list(_ADAPTER_ACTIVATIONS)}"
-            )
-        hidden = hidden_dim if hidden_dim and hidden_dim > 0 else out_dim
-        self.proj1 = nn.Linear(in_dim, hidden, bias=True)
-        self.act = _ADAPTER_ACTIVATIONS[activation]()
-        self.proj2 = nn.Linear(hidden, out_dim, bias=True)
-
-    def reset_parameters(self) -> None:
-        """Re-run ``nn.Linear`` default init on both projections.
-
-        Used after ``to_empty(device=...)`` on a meta-device build.
-        """
-        self.proj1.reset_parameters()
-        self.proj2.reset_parameters()
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.proj2(self.act(self.proj1(x)))
 
 
 class ModalityStrategy(Protocol):
@@ -119,7 +76,10 @@ def _project_image_features(wrapper: VLMWrapper, pixel_values: torch.Tensor) -> 
     clash.
     """
     feats = wrapper.vision_encoder(pixel_values)
-    adapter_dtype = wrapper.adapter.proj1.weight.dtype
+    # Adapter-agnostic dtype lookup: use the first adapter parameter's
+    # dtype so any registered adapter (mlp_2layer, linear, ...) works
+    # without coupling to a specific submodule attribute.
+    adapter_dtype = next(wrapper.adapter.parameters()).dtype
     if feats.dtype != adapter_dtype:
         feats = feats.to(adapter_dtype)
     return wrapper.adapter(feats)
@@ -240,7 +200,7 @@ class VLMWrapper(nn.Module):
     def __init__(
         self,
         vision_encoder: VisionEncoder,
-        adapter: Adapter,
+        adapter: nn.Module,
         transformer: Transformer,
         strategy: ModalityStrategy,
     ) -> None:
@@ -315,10 +275,16 @@ def build_vlm_wrapper(model_config: ModelConfig) -> VLMWrapper:
 
     Used by tests and by ``build_parallel_model``. Constructs the
     vision encoder via the registry (HF weights loaded on CPU), builds
-    a fresh ``Adapter`` at the LLM ``dim``, looks up the right
-    ``ModalityStrategy`` by arch, and composes them with a raw
-    ``Transformer``. Callers that need meta-device / FSDP / freeze
-    handling go through ``build_parallel_model`` instead.
+    an adapter via the ``adapter`` registry at the LLM ``dim``, looks
+    up the right ``ModalityStrategy`` by arch, and composes them with
+    a raw ``Transformer``. Callers that need meta-device / FSDP /
+    freeze handling go through ``build_parallel_model`` instead.
+
+    The adapter type defaults to ``"mlp_2layer"`` (matches the pre-
+    registry behavior). A follow-up PR will expose ``[adapter]`` as a
+    top-level TOML section; in the meantime this builder synthesizes
+    an ``AdapterConfig`` from the existing ``VLMConfig`` fields
+    (``adapter_hidden_dim`` and ``adapter_activation``).
     """
     vlm: VLMConfig | None = model_config.vlm
     if vlm is None:
@@ -345,12 +311,12 @@ def build_vlm_wrapper(model_config: ModelConfig) -> VLMWrapper:
             f"vlm.max_text_len ({vlm.max_text_len}) = {required}"
         )
     in_dim = vlm.feature_dim or encoder.feature_dim
-    adapter = Adapter(
-        in_dim=in_dim,
-        out_dim=model_config.dim,
-        hidden_dim=vlm.adapter_hidden_dim or None,
+    adapter_config = AdapterConfig(
+        type="mlp_2layer",
+        hidden_dim=vlm.adapter_hidden_dim,
         activation=vlm.adapter_activation,
     )
+    adapter = build_adapter(adapter_config, in_dim=in_dim, out_dim=model_config.dim)
     transformer = Transformer(model_config)
     strategy = build_modality_strategy(vlm)
     return VLMWrapper(encoder, adapter, transformer, strategy)

--- a/tests/e2e/test_training_e2e.py
+++ b/tests/e2e/test_training_e2e.py
@@ -116,10 +116,15 @@ def _parse_last_loss(output: str) -> float | None:
 
 
 @pytest.mark.e2e
-def test_single_gpu_random_data():
+def test_single_gpu_random_data(tmp_path):
     """Single GPU training with random data — basic smoke test."""
     result = _run_training(
-        [DEBUG_CONFIG, "--train.max_steps=10", "--metrics.log_interval=5"],
+        [
+            DEBUG_CONFIG,
+            "--train.max_steps=10",
+            "--metrics.log_interval=5",
+            f"--checkpoint.dir={tmp_path}/ckpt",
+        ],
         nproc=1,
     )
     _assert_training_complete(result, expected_steps=10)
@@ -132,10 +137,15 @@ def test_single_gpu_random_data():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_fsdp_4gpu():
+def test_fsdp_4gpu(tmp_path):
     """4 GPU FSDP — tests build_parallel_model non-TP path."""
     result = _run_training(
-        [DEBUG_CONFIG, "--train.max_steps=10", "--metrics.log_interval=5"],
+        [
+            DEBUG_CONFIG,
+            "--train.max_steps=10",
+            "--metrics.log_interval=5",
+            f"--checkpoint.dir={tmp_path}/ckpt",
+        ],
         nproc=4,
     )
     _assert_training_complete(result, expected_steps=10)
@@ -148,7 +158,7 @@ def test_fsdp_4gpu():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_tp_only_4gpu():
+def test_tp_only_4gpu(tmp_path):
     """4 GPU TP — tests meta-device init + SequenceParallel path."""
     result = _run_training(
         [
@@ -157,6 +167,7 @@ def test_tp_only_4gpu():
             "--metrics.log_interval=5",
             "--distributed.tp=4",
             "--distributed.dp_shard=1",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -165,7 +176,7 @@ def test_tp_only_4gpu():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_tp_plus_fsdp():
+def test_tp_plus_fsdp(tmp_path):
     """4 GPU TP=2 + FSDP=2 — combined parallelism."""
     result = _run_training(
         [
@@ -174,6 +185,7 @@ def test_tp_plus_fsdp():
             "--metrics.log_interval=5",
             "--distributed.tp=2",
             "--distributed.dp_shard=2",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -187,7 +199,7 @@ def test_tp_plus_fsdp():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_pipeline_parallel():
+def test_pipeline_parallel(tmp_path):
     """4 GPU PP=2 + FSDP=2 — pipeline parallelism with 1F1B schedule."""
     result = _run_training(
         [
@@ -197,6 +209,7 @@ def test_pipeline_parallel():
             "--distributed.pp=2",
             "--distributed.dp_shard=2",
             "--train.grad_accum_steps=2",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -216,7 +229,7 @@ def test_pipeline_parallel():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_fp16_mixed_precision():
+def test_fp16_mixed_precision(tmp_path):
     """4 GPU FSDP with fp16 — verifies param_dtype config path."""
     result = _run_training(
         [
@@ -224,6 +237,7 @@ def test_fp16_mixed_precision():
             "--train.max_steps=10",
             "--metrics.log_interval=5",
             "--train.mixed_precision=fp16",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -237,7 +251,7 @@ def test_fp16_mixed_precision():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_synthetic_data_pipeline(synthetic_data_dir):
+def test_synthetic_data_pipeline(synthetic_data_dir, tmp_path):
     """4 GPU FSDP with synthetic .npy data — tests full data pipeline."""
     result = _run_training(
         [
@@ -246,6 +260,7 @@ def test_synthetic_data_pipeline(synthetic_data_dir):
             "--metrics.log_interval=5",
             f"--data.dataset_path={synthetic_data_dir}",
             "--data.file_pattern=*.npy",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -265,7 +280,7 @@ _HF_OVERRIDES = [
 
 
 @pytest.mark.e2e
-def test_hf_dataset_single_gpu():
+def test_hf_dataset_single_gpu(tmp_path):
     """Single GPU training with HuggingFace wikitext dataset."""
     result = _run_training(
         [
@@ -273,6 +288,7 @@ def test_hf_dataset_single_gpu():
             "--train.max_steps=5",
             "--metrics.log_interval=5",
             *_HF_OVERRIDES,
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=1,
     )
@@ -283,7 +299,7 @@ def test_hf_dataset_single_gpu():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_hf_dataset_4gpu():
+def test_hf_dataset_4gpu(tmp_path):
     """4 GPU FSDP with HuggingFace wikitext dataset."""
     result = _run_training(
         [
@@ -291,6 +307,7 @@ def test_hf_dataset_4gpu():
             "--train.max_steps=5",
             "--metrics.log_interval=5",
             *_HF_OVERRIDES,
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -300,7 +317,7 @@ def test_hf_dataset_4gpu():
 
 
 @pytest.mark.e2e
-def test_hf_streaming_single_gpu():
+def test_hf_streaming_single_gpu(tmp_path):
     """Single GPU training with streaming HuggingFace dataset."""
     result = _run_training(
         [
@@ -309,6 +326,7 @@ def test_hf_streaming_single_gpu():
             "--metrics.log_interval=5",
             *_HF_OVERRIDES,
             "--data.hf_streaming=true",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=1,
     )
@@ -319,7 +337,7 @@ def test_hf_streaming_single_gpu():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_hf_streaming_4gpu():
+def test_hf_streaming_4gpu(tmp_path):
     """4 GPU FSDP with streaming HuggingFace dataset."""
     result = _run_training(
         [
@@ -328,6 +346,7 @@ def test_hf_streaming_4gpu():
             "--metrics.log_interval=5",
             *_HF_OVERRIDES,
             "--data.hf_streaming=true",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -490,10 +509,15 @@ def test_sigterm_triggers_emergency_checkpoint(tmp_path):
 
 
 @pytest.mark.e2e
-def test_moe_single_gpu_random_data():
+def test_moe_single_gpu_random_data(tmp_path):
     """Single GPU MoE training with random data."""
     result = _run_training(
-        [DEBUG_MOE_CONFIG, "--train.max_steps=10", "--metrics.log_interval=5"],
+        [
+            DEBUG_MOE_CONFIG,
+            "--train.max_steps=10",
+            "--metrics.log_interval=5",
+            f"--checkpoint.dir={tmp_path}/ckpt",
+        ],
         nproc=1,
     )
     _assert_training_complete(result, expected_steps=10)
@@ -504,10 +528,15 @@ def test_moe_single_gpu_random_data():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_moe_fsdp_4gpu():
+def test_moe_fsdp_4gpu(tmp_path):
     """4 GPU FSDP with MoE model."""
     result = _run_training(
-        [DEBUG_MOE_CONFIG, "--train.max_steps=10", "--metrics.log_interval=5"],
+        [
+            DEBUG_MOE_CONFIG,
+            "--train.max_steps=10",
+            "--metrics.log_interval=5",
+            f"--checkpoint.dir={tmp_path}/ckpt",
+        ],
         nproc=4,
     )
     _assert_training_complete(result, expected_steps=10)
@@ -515,7 +544,7 @@ def test_moe_fsdp_4gpu():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_moe_tp_plus_fsdp():
+def test_moe_tp_plus_fsdp(tmp_path):
     """4 GPU TP=2 + FSDP=2 with MoE — experts replicated, attention TP-sharded."""
     result = _run_training(
         [
@@ -524,6 +553,7 @@ def test_moe_tp_plus_fsdp():
             "--metrics.log_interval=5",
             "--distributed.tp=2",
             "--distributed.dp_shard=2",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -581,7 +611,7 @@ _SIGMOID_MOE_OVERRIDES = [
 
 
 @pytest.mark.e2e
-def test_moe_sigmoid_single_gpu():
+def test_moe_sigmoid_single_gpu(tmp_path):
     """Single GPU MoE with sigmoid router, sequence aux loss, and gradient scaling."""
     result = _run_training(
         [
@@ -589,6 +619,7 @@ def test_moe_sigmoid_single_gpu():
             "--train.max_steps=10",
             "--metrics.log_interval=5",
             *_SIGMOID_MOE_OVERRIDES,
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=1,
     )
@@ -600,7 +631,7 @@ def test_moe_sigmoid_single_gpu():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_moe_sigmoid_fsdp_4gpu():
+def test_moe_sigmoid_fsdp_4gpu(tmp_path):
     """4 GPU FSDP with sigmoid router, sequence aux loss, and gradient scaling."""
     result = _run_training(
         [
@@ -608,6 +639,7 @@ def test_moe_sigmoid_fsdp_4gpu():
             "--train.max_steps=10",
             "--metrics.log_interval=5",
             *_SIGMOID_MOE_OVERRIDES,
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -621,7 +653,7 @@ def test_moe_sigmoid_fsdp_4gpu():
 
 @pytest.mark.e2e
 @requires_gpus(1)
-def test_fp8_single_gpu():
+def test_fp8_single_gpu(tmp_path):
     """Single GPU FP8 training — verifies Float8 conversion + forward/backward."""
     result = _run_training(
         [
@@ -629,6 +661,7 @@ def test_fp8_single_gpu():
             "--train.max_steps=10",
             "--metrics.log_interval=5",
             "--train.mixed_precision=fp8",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=1,
     )
@@ -641,7 +674,7 @@ def test_fp8_single_gpu():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_fp8_fsdp_4gpu():
+def test_fp8_fsdp_4gpu(tmp_path):
     """4 GPU FSDP with FP8 — tests Float8 + FSDP2 float8 all-gather."""
     result = _run_training(
         [
@@ -649,6 +682,7 @@ def test_fp8_fsdp_4gpu():
             "--train.max_steps=10",
             "--metrics.log_interval=5",
             "--train.mixed_precision=fp8",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -659,7 +693,7 @@ def test_fp8_fsdp_4gpu():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_fp8_moe_fsdp_4gpu():
+def test_fp8_moe_fsdp_4gpu(tmp_path):
     """4 GPU FSDP with FP8 + MoE — verifies expert Linears excluded from Float8."""
     result = _run_training(
         [
@@ -667,6 +701,7 @@ def test_fp8_moe_fsdp_4gpu():
             "--train.max_steps=10",
             "--metrics.log_interval=5",
             "--train.mixed_precision=fp8",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -682,7 +717,7 @@ def test_fp8_moe_fsdp_4gpu():
 
 @pytest.mark.e2e
 @requires_gpus(1)
-def test_z_loss_single_gpu():
+def test_z_loss_single_gpu(tmp_path):
     """Single GPU training with z-loss enabled — verifies logit regularizer integrates."""
     result = _run_training(
         [
@@ -690,6 +725,7 @@ def test_z_loss_single_gpu():
             "--train.max_steps=10",
             "--metrics.log_interval=5",
             "--train.z_loss_weight=1e-4",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=1,
     )
@@ -700,7 +736,7 @@ def test_z_loss_single_gpu():
 
 @pytest.mark.e2e
 @requires_gpus(1)
-def test_chunked_cross_entropy_single_gpu():
+def test_chunked_cross_entropy_single_gpu(tmp_path):
     """Single GPU training with chunked cross-entropy — verifies loss matches standard CE."""
     result = _run_training(
         [
@@ -709,6 +745,7 @@ def test_chunked_cross_entropy_single_gpu():
             "--metrics.log_interval=5",
             "--train.loss_fn=chunked_cross_entropy",
             "--train.ce_chunk_size=4096",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=1,
     )
@@ -719,7 +756,7 @@ def test_chunked_cross_entropy_single_gpu():
 
 @pytest.mark.e2e
 @requires_gpus(1)
-def test_muon_optimizer_single_gpu():
+def test_muon_optimizer_single_gpu(tmp_path):
     """Single GPU training with Muon optimizer — verifies Newton-Schulz + AdamW fallback."""
     result = _run_training(
         [
@@ -729,6 +766,7 @@ def test_muon_optimizer_single_gpu():
             "--optimizer.name=muon",
             "--optimizer.lr=0.02",
             "--optimizer.muon_momentum=0.95",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=1,
     )
@@ -739,7 +777,7 @@ def test_muon_optimizer_single_gpu():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_muon_fsdp_4gpu():
+def test_muon_fsdp_4gpu(tmp_path):
     """4 GPU FSDP with Muon optimizer — verifies Muon composes with FSDP2."""
     result = _run_training(
         [
@@ -748,6 +786,7 @@ def test_muon_fsdp_4gpu():
             "--metrics.log_interval=5",
             "--optimizer.name=muon",
             "--optimizer.lr=0.02",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -756,7 +795,7 @@ def test_muon_fsdp_4gpu():
 
 @pytest.mark.e2e
 @requires_gpus(4)
-def test_z_loss_chunked_ce_fsdp_4gpu():
+def test_z_loss_chunked_ce_fsdp_4gpu(tmp_path):
     """4 GPU FSDP with z-loss + chunked CE — verifies both compose with FSDP2."""
     result = _run_training(
         [
@@ -765,6 +804,7 @@ def test_z_loss_chunked_ce_fsdp_4gpu():
             "--metrics.log_interval=5",
             "--train.z_loss_weight=1e-4",
             "--train.loss_fn=chunked_cross_entropy",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
     )
@@ -779,7 +819,7 @@ def test_z_loss_chunked_ce_fsdp_4gpu():
 @pytest.mark.e2e
 @pytest.mark.slow
 @requires_gpus(4)
-def test_7b_tp_fsdp_compile():
+def test_7b_tp_fsdp_compile(tmp_path):
     """7B model with TP=2 + FSDP=2 + torch.compile — full production path.
 
     Uses random data, 5 steps. Verifies the heavy-weight path works:
@@ -792,6 +832,7 @@ def test_7b_tp_fsdp_compile():
             "--metrics.log_interval=5",
             "--distributed.tp=2",
             "--distributed.dp_shard=2",
+            f"--checkpoint.dir={tmp_path}/ckpt",
         ],
         nproc=4,
         timeout=300,

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1,0 +1,235 @@
+"""Unit tests for VLM adapters and the adapter registry."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+# Importing the module registers the builders under the shared registry.
+import kempnerforge.model.adapter  # noqa: F401
+from kempnerforge.config.adapter import AdapterConfig
+from kempnerforge.config.registry import registry
+from kempnerforge.model.adapter import (
+    LinearAdapter,
+    MLP2LayerAdapter,
+    build_adapter,
+)
+
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+# ---------------------------------------------------------------------------
+# MLP2LayerAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestMLP2LayerAdapter:
+    def test_forward_shape(self):
+        adapter = MLP2LayerAdapter(in_dim=384, out_dim=256).to(DEVICE)
+        x = torch.randn(2, 16, 384, device=DEVICE)
+        out = adapter(x)
+        assert out.shape == (2, 16, 256)
+
+    def test_hidden_dim_defaults_to_out_dim(self):
+        adapter = MLP2LayerAdapter(in_dim=128, out_dim=64)
+        assert adapter.proj1.out_features == 64
+
+    def test_hidden_dim_override(self):
+        adapter = MLP2LayerAdapter(in_dim=128, out_dim=64, hidden_dim=256)
+        assert adapter.proj1.out_features == 256
+        assert adapter.proj2.in_features == 256
+
+    def test_activations(self):
+        for act in ("gelu", "silu", "relu"):
+            adapter = MLP2LayerAdapter(in_dim=8, out_dim=8, activation=act)
+            out = adapter(torch.randn(1, 4, 8))
+            assert out.shape == (1, 4, 8)
+
+    def test_unknown_activation_raises(self):
+        with pytest.raises(ValueError, match="Unknown adapter activation"):
+            MLP2LayerAdapter(in_dim=8, out_dim=8, activation="tanh")
+
+    def test_rejects_zero_dim(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            MLP2LayerAdapter(in_dim=0, out_dim=8)
+
+    def test_backward_grads_flow(self):
+        adapter = MLP2LayerAdapter(in_dim=32, out_dim=16).to(DEVICE)
+        x = torch.randn(1, 4, 32, device=DEVICE, requires_grad=True)
+        adapter(x).sum().backward()
+        for p in adapter.parameters():
+            assert p.grad is not None
+            assert torch.isfinite(p.grad).all()
+
+    def test_reset_parameters_reinitializes(self):
+        adapter = MLP2LayerAdapter(in_dim=8, out_dim=4)
+        w1 = adapter.proj1.weight.clone()
+        adapter.reset_parameters()
+        # Not guaranteed bit-different (unlikely but possible), so just
+        # check it ran without error and weights are finite.
+        assert torch.isfinite(adapter.proj1.weight).all()
+        assert adapter.proj1.weight.shape == w1.shape
+
+
+# ---------------------------------------------------------------------------
+# LinearAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestLinearAdapter:
+    def test_forward_shape(self):
+        adapter = LinearAdapter(in_dim=384, out_dim=256).to(DEVICE)
+        x = torch.randn(2, 16, 384, device=DEVICE)
+        out = adapter(x)
+        assert out.shape == (2, 16, 256)
+
+    def test_rejects_zero_dim(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            LinearAdapter(in_dim=0, out_dim=8)
+
+    def test_backward_grads_flow(self):
+        adapter = LinearAdapter(in_dim=32, out_dim=16).to(DEVICE)
+        x = torch.randn(1, 4, 32, device=DEVICE, requires_grad=True)
+        adapter(x).sum().backward()
+        for p in adapter.parameters():
+            assert p.grad is not None
+            assert torch.isfinite(p.grad).all()
+
+    def test_reset_parameters_reinitializes(self):
+        adapter = LinearAdapter(in_dim=8, out_dim=4)
+        w1 = adapter.proj.weight.clone()
+        adapter.reset_parameters()
+        assert torch.isfinite(adapter.proj.weight).all()
+        assert adapter.proj.weight.shape == w1.shape
+
+    def test_no_hidden_dim_or_activation(self):
+        """LinearAdapter has a single ``proj`` Linear; no hidden_dim or
+        activation parameters exist. The builder must ignore them."""
+        # The dispatcher (build_adapter) passes hidden_dim/activation via
+        # AdapterConfig.extra_kwargs(); the linear builder swallows them.
+        cfg = AdapterConfig(type="linear", hidden_dim=42, activation="silu")
+        adapter = build_adapter(cfg, in_dim=8, out_dim=4)
+        assert isinstance(adapter, LinearAdapter)
+        # No proj1/proj2 attributes; only proj.
+        assert hasattr(adapter, "proj")
+        assert not hasattr(adapter, "proj1")
+        assert not hasattr(adapter, "proj2")
+
+
+# ---------------------------------------------------------------------------
+# Adapter registry
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterRegistry:
+    def test_mlp_2layer_is_registered(self):
+        builder = registry.get_adapter("mlp_2layer")
+        adapter = builder(in_dim=8, out_dim=4)
+        assert isinstance(adapter, MLP2LayerAdapter)
+
+    def test_linear_is_registered(self):
+        builder = registry.get_adapter("linear")
+        adapter = builder(in_dim=8, out_dim=4)
+        assert isinstance(adapter, LinearAdapter)
+
+    def test_list_includes_both(self):
+        names = registry.list_adapters()
+        assert "mlp_2layer" in names
+        assert "linear" in names
+
+    def test_unknown_key_raises(self):
+        with pytest.raises(KeyError, match="adapter"):
+            registry.get_adapter("not_a_real_adapter")
+
+    def test_double_register_raises(self):
+        @registry.register_adapter("adapter_smoke_test_dup")
+        def _build_first(in_dim, out_dim, **_):  # noqa: ARG001
+            return MLP2LayerAdapter(in_dim=in_dim, out_dim=out_dim)
+
+        with pytest.raises(ValueError, match="already registered"):
+
+            @registry.register_adapter("adapter_smoke_test_dup")
+            def _build_second(in_dim, out_dim, **_):  # noqa: ARG001
+                return MLP2LayerAdapter(in_dim=in_dim, out_dim=out_dim)
+
+
+# ---------------------------------------------------------------------------
+# AdapterConfig
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterConfig:
+    def test_defaults(self):
+        cfg = AdapterConfig()
+        assert cfg.type == "mlp_2layer"
+        assert cfg.hidden_dim == 0
+        assert cfg.activation == "gelu"
+
+    def test_unknown_type_rejected(self):
+        with pytest.raises(ValueError, match="Unknown adapter.type"):
+            AdapterConfig(type="not_a_real_type")
+
+    def test_negative_hidden_dim_rejected(self):
+        with pytest.raises(ValueError, match="must be non-negative"):
+            AdapterConfig(hidden_dim=-1)
+
+    def test_bad_activation_rejected(self):
+        with pytest.raises(ValueError, match="Unknown adapter.activation"):
+            AdapterConfig(activation="tanh")
+
+    def test_extra_kwargs_zero_hidden_dim_becomes_none(self):
+        cfg = AdapterConfig(hidden_dim=0)
+        kwargs = cfg.extra_kwargs()
+        assert kwargs["hidden_dim"] is None
+
+    def test_extra_kwargs_nonzero_hidden_dim_passes_through(self):
+        cfg = AdapterConfig(hidden_dim=256)
+        kwargs = cfg.extra_kwargs()
+        assert kwargs["hidden_dim"] == 256
+
+    def test_extra_kwargs_activation_passes_through(self):
+        cfg = AdapterConfig(activation="silu")
+        kwargs = cfg.extra_kwargs()
+        assert kwargs["activation"] == "silu"
+
+
+# ---------------------------------------------------------------------------
+# build_adapter dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAdapter:
+    def test_dispatches_to_mlp_2layer(self):
+        cfg = AdapterConfig(type="mlp_2layer")
+        adapter = build_adapter(cfg, in_dim=8, out_dim=4)
+        assert isinstance(adapter, MLP2LayerAdapter)
+
+    def test_dispatches_to_linear(self):
+        cfg = AdapterConfig(type="linear")
+        adapter = build_adapter(cfg, in_dim=8, out_dim=4)
+        assert isinstance(adapter, LinearAdapter)
+
+    def test_passes_in_out_dim(self):
+        cfg = AdapterConfig(type="mlp_2layer")
+        adapter = build_adapter(cfg, in_dim=32, out_dim=16)
+        out = adapter(torch.randn(1, 4, 32))
+        assert out.shape == (1, 4, 16)
+
+    def test_honors_hidden_dim_zero_sentinel(self):
+        """hidden_dim=0 (the sentinel) -> MLP2LayerAdapter falls back to
+        out_dim for the hidden width."""
+        cfg = AdapterConfig(type="mlp_2layer", hidden_dim=0)
+        adapter = build_adapter(cfg, in_dim=8, out_dim=64)
+        assert adapter.proj1.out_features == 64
+
+    def test_honors_hidden_dim_explicit(self):
+        cfg = AdapterConfig(type="mlp_2layer", hidden_dim=128)
+        adapter = build_adapter(cfg, in_dim=8, out_dim=64)
+        assert adapter.proj1.out_features == 128
+
+    def test_activation_passes_through_to_mlp(self):
+        cfg = AdapterConfig(type="mlp_2layer", activation="silu")
+        adapter = build_adapter(cfg, in_dim=8, out_dim=4)
+        import torch.nn as nn
+
+        assert isinstance(adapter.act, nn.SiLU)

--- a/tests/unit/test_vlm.py
+++ b/tests/unit/test_vlm.py
@@ -1,4 +1,8 @@
-"""Unit tests for Adapter, VLMWrapper, inner_transformer, _is_encoder_frozen."""
+"""Unit tests for VLMWrapper, inner_transformer, _is_encoder_frozen.
+
+Adapter unit tests moved to ``tests/unit/test_adapter.py`` when ``Adapter``
+was renamed to ``MLP2LayerAdapter`` and promoted to a registered component.
+"""
 
 from __future__ import annotations
 
@@ -16,7 +20,6 @@ from kempnerforge.config.vlm import (
 from kempnerforge.model.modality import ModalityContext
 from kempnerforge.model.transformer import Transformer
 from kempnerforge.model.vlm import (
-    Adapter,
     CrossAttentionStrategy,
     JointDecoderStrategy,
     MoTStrategy,
@@ -28,59 +31,6 @@ from kempnerforge.model.vlm import (
 )
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-
-# ---------------------------------------------------------------------------
-# Adapter
-# ---------------------------------------------------------------------------
-
-
-class TestAdapter:
-    def test_forward_shape(self):
-        adapter = Adapter(in_dim=384, out_dim=256).to(DEVICE)
-        x = torch.randn(2, 16, 384, device=DEVICE)
-        out = adapter(x)
-        assert out.shape == (2, 16, 256)
-
-    def test_hidden_dim_defaults_to_out_dim(self):
-        adapter = Adapter(in_dim=128, out_dim=64)
-        assert adapter.proj1.out_features == 64
-
-    def test_hidden_dim_override(self):
-        adapter = Adapter(in_dim=128, out_dim=64, hidden_dim=256)
-        assert adapter.proj1.out_features == 256
-        assert adapter.proj2.in_features == 256
-
-    def test_activations(self):
-        for act in ("gelu", "silu", "relu"):
-            adapter = Adapter(in_dim=8, out_dim=8, activation=act)
-            out = adapter(torch.randn(1, 4, 8))
-            assert out.shape == (1, 4, 8)
-
-    def test_unknown_activation_raises(self):
-        with pytest.raises(ValueError, match="Unknown adapter activation"):
-            Adapter(in_dim=8, out_dim=8, activation="tanh")
-
-    def test_rejects_zero_dim(self):
-        with pytest.raises(ValueError, match="must be positive"):
-            Adapter(in_dim=0, out_dim=8)
-
-    def test_backward_grads_flow(self):
-        adapter = Adapter(in_dim=32, out_dim=16).to(DEVICE)
-        x = torch.randn(1, 4, 32, device=DEVICE, requires_grad=True)
-        adapter(x).sum().backward()
-        for p in adapter.parameters():
-            assert p.grad is not None
-            assert torch.isfinite(p.grad).all()
-
-    def test_reset_parameters_reinitializes(self):
-        adapter = Adapter(in_dim=8, out_dim=4)
-        w1 = adapter.proj1.weight.clone()
-        adapter.reset_parameters()
-        # Not guaranteed bit-different (unlikely but possible), so just
-        # check it actually ran without error and weights are finite.
-        assert torch.isfinite(adapter.proj1.weight).all()
-        assert adapter.proj1.weight.shape == w1.shape
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #88

## Summary
- New `kempnerforge/model/adapter.py`: `MLP2LayerAdapter` (renamed from
  the old `Adapter`), `LinearAdapter` (new, single `nn.Linear`),
  registered builders, and `build_adapter()` dispatcher.
- New `kempnerforge/config/adapter.py`: `AdapterConfig` with
  type/hidden_dim/activation + `__post_init__` validation against
  `registry.list_adapters()`.
- `register_adapter`/`get_adapter`/`list_adapters` added to
  `config/registry.py` (now 11 registry categories).
- `build_vlm_wrapper` and `_build_vlm` construct an `AdapterConfig`
  internally from `VLMConfig.adapter_hidden_dim`/`adapter_activation`
  and dispatch via `build_adapter()`. Default 2-layer MLP behavior
  unchanged.
- `_project_image_features` uses `next(adapter.parameters()).dtype`
  so any registered adapter works without coupling to a specific
  submodule attribute.

## Bundled: e2e checkpoint-dir isolation

The e2e suite had a latent bug: 25 tests inherited the persistent
`[checkpoint].dir` from `debug.toml` (`checkpoints/debug/`). When stale
checkpoints from prior config shapes sat there, auto-resume loaded them
and failed at the size-mismatch sanity check. Each of those tests now
takes a `tmp_path` fixture and injects `--checkpoint.dir=<tmp_path>/ckpt`.
The 4 tests that explicitly exercise checkpoint save/resume/emergency
behavior already had this pattern and are unchanged.

## Test plan
- [x] Moved old `TestAdapter` from `test_vlm.py` to `test_adapter.py`
      as `TestMLP2LayerAdapter` (8 tests preserved)
- [x] Added `TestLinearAdapter`, `TestAdapterRegistry`,
      `TestAdapterConfig`, `TestBuildAdapter` (23 new tests)
- [x] 1230 unit tests pass
- [x] 68 integration tests pass on H200 (real GPU build/forward path,
      including the new `build_adapter` dispatch)
- [x] 10 single-GPU e2e tests pass on H200 via
      `uv run pytest tests/e2e/ --e2e`; 19 multi-GPU tests skipped on 1 GPU
- [x] Ruff lint + format clean
- [x] No TOML schema change; default config behavior unchanged

## Out of scope
- Top-level `[adapter]` TOML section: follow-up PR.