### PR TITLE
Flatten [model.vlm] into top-level [vision_encoder]/[adapter]/[vlm]

### DIFF
--- a/configs/train/vlm_7b.toml
+++ b/configs/train/vlm_7b.toml
@@ -17,9 +17,9 @@
 # the dataset (and tokenizer) via CLI:
 #   --data.hf_dataset_name=<dataset> --data.tokenizer_path=<tokenizer>
 #
-# Swap the vision encoder via [model.vlm].vision_encoder: "random"
-# (stub, no download), "siglip2", or "clip". When pointing at a real
-# encoder also set vision_encoder_path.
+# Swap the vision encoder via [vision_encoder].type: "random" (stub, no
+# download), "siglip2", or "clip". When pointing at a real encoder also
+# set [vision_encoder].path.
 
 [model]
 dim = 4096
@@ -34,11 +34,13 @@ max_seq_len = 1024
 rope_theta = 500000.0
 tie_embeddings = false
 
-[model.vlm]
-arch = "joint_decoder"
-vision_encoder = "random"
+[vision_encoder]
+type = "random"
 feature_dim = 1024
 num_tokens = 256
+
+[vlm]
+arch = "joint_decoder"
 
 [train]
 batch_size = 16

--- a/configs/train/vlm_7b_ac.toml
+++ b/configs/train/vlm_7b_ac.toml
@@ -31,12 +31,14 @@ max_seq_len = 1024
 rope_theta = 500000.0
 tie_embeddings = false
 
-[model.vlm]
-arch = "joint_decoder"
-vision_encoder = "random"
+[vision_encoder]
+type = "random"
 # ViT-L/14-shaped dims (constructor inputs to RandomVisionEncoder, swap-in compatible)
 feature_dim = 1024
 num_tokens = 256
+
+[vlm]
+arch = "joint_decoder"
 
 [train]
 batch_size = 8

--- a/configs/train/vlm_7b_cross_attn.toml
+++ b/configs/train/vlm_7b_cross_attn.toml
@@ -29,9 +29,9 @@
 # the dataset (and tokenizer) via CLI:
 #   --data.hf_dataset_name=<dataset> --data.tokenizer_path=<tokenizer>
 #
-# Swap the vision encoder via [model.vlm].vision_encoder: "random"
-# (stub, no download), "siglip2", or "clip". When pointing at a real
-# encoder also set vision_encoder_path.
+# Swap the vision encoder via [vision_encoder].type: "random" (stub, no
+# download), "siglip2", or "clip". When pointing at a real encoder also
+# set [vision_encoder].path.
 
 [model]
 dim = 4096
@@ -46,12 +46,14 @@ max_seq_len = 1024
 rope_theta = 500000.0
 tie_embeddings = false
 
-[model.vlm]
-arch = "cross_attention"
-vision_encoder = "random"
+[vision_encoder]
+type = "random"
 # ViT-L/14-shaped dims (constructor inputs to RandomVisionEncoder, swap-in compatible)
 feature_dim = 1024
 num_tokens = 256
+
+[vlm]
+arch = "cross_attention"
 
 [train]
 batch_size = 16

--- a/configs/train/vlm_7b_freeze_schedule.toml
+++ b/configs/train/vlm_7b_freeze_schedule.toml
@@ -35,11 +35,13 @@ max_seq_len = 1024
 rope_theta = 500000.0
 tie_embeddings = false
 
-[model.vlm]
-arch = "cross_attention"
-vision_encoder = "random"
+[vision_encoder]
+type = "random"
 feature_dim = 1024
 num_tokens = 256
+
+[vlm]
+arch = "cross_attention"
 freeze_schedule = [
     {start_step = 10, specs = [{module = "adapter", frozen = true}]},
     {start_step = 20, specs = [{module = "adapter", frozen = false}]},

--- a/configs/train/vlm_7b_mot.toml
+++ b/configs/train/vlm_7b_mot.toml
@@ -31,7 +31,7 @@
 # datasets.save_to_disk:
 #   --data.hf_dataset_name=/path/to/local/hf_dataset \
 #   --data.hf_dataset_text_field=caption
-# Swap the encoder via [model.vlm].vision_encoder = "siglip2" / "clip".
+# Swap the encoder via [vision_encoder].type = "siglip2" / "clip".
 
 [model]
 dim = 4096
@@ -46,11 +46,13 @@ max_seq_len = 1024
 rope_theta = 500000.0
 tie_embeddings = false
 
-[model.vlm]
-arch = "mot"
-vision_encoder = "random"
+[vision_encoder]
+type = "random"
 feature_dim = 1024
 num_tokens = 256
+
+[vlm]
+arch = "mot"
 
 [train]
 batch_size = 8

--- a/configs/train/vlm_7b_siglip2.toml
+++ b/configs/train/vlm_7b_siglip2.toml
@@ -34,13 +34,15 @@ max_seq_len = 2304     # 256 image + 2048 text
 rope_theta = 500000.0
 tie_embeddings = false
 
-[model.vlm]
-arch = "joint_decoder"
-vision_encoder = "siglip2"
-vision_encoder_path = "google/siglip2-base-patch16-224"
+[vision_encoder]
+type = "siglip2"
+path = "google/siglip2-base-patch16-224"
 # feature_dim and num_tokens default to 0 = infer from the encoder at
 # build time. For siglip2-base-patch16-224 the encoder probes
 # feature_dim=768 and num_tokens=196 (14x14 patches, no CLS).
+
+[vlm]
+arch = "joint_decoder"
 max_text_len = 2048
 
 [train]

--- a/configs/train/vlm_7b_siglip2_cross_attn.toml
+++ b/configs/train/vlm_7b_siglip2_cross_attn.toml
@@ -35,14 +35,16 @@ max_seq_len = 2048      # CA residual stream is text-only (no image prefix)
 rope_theta = 500000.0
 tie_embeddings = false
 
-[model.vlm]
-arch = "cross_attention"
-vision_encoder = "siglip2"
-vision_encoder_path = "google/siglip2-base-patch16-224"
+[vision_encoder]
+type = "siglip2"
+path = "google/siglip2-base-patch16-224"
 # feature_dim and num_tokens default to 0 = infer from the encoder at
 # build time. For siglip2-base-patch16-224 the encoder probes
 # feature_dim=768 and num_tokens=196. CA ignores num_tokens at runtime
 # (residual is text-only); kept here only as documentation.
+
+[vlm]
+arch = "cross_attention"
 max_text_len = 2048
 
 [train]

--- a/configs/train/vlm_debug.toml
+++ b/configs/train/vlm_debug.toml
@@ -19,11 +19,13 @@ max_seq_len = 576      # 64 image + 512 text
 norm_type = "rmsnorm"
 activation = "silu"
 
-[model.vlm]
-arch = "joint_decoder"
-vision_encoder = "random"
+[vision_encoder]
+type = "random"
 feature_dim = 384
 num_tokens = 64
+
+[vlm]
+arch = "joint_decoder"
 
 [train]
 batch_size = 2

--- a/configs/train/vlm_debug_moe.toml
+++ b/configs/train/vlm_debug_moe.toml
@@ -30,11 +30,13 @@ max_seq_len = 576        # CA residual stream is text-only; >= max_text_len with
 num_experts = 4
 moe_frequency = 2        # MoE every 2 layers; layers 1, 3 are MoE; 0, 2 are dense
 
-[model.vlm]
-arch = "cross_attention"
-vision_encoder = "random"
+[vision_encoder]
+type = "random"
 feature_dim = 384
 num_tokens = 64
+
+[vlm]
+arch = "cross_attention"
 cross_attention_every_n_layers = 2
 
 [train]

--- a/configs/train/vlm_debug_mot.toml
+++ b/configs/train/vlm_debug_mot.toml
@@ -18,11 +18,13 @@ max_seq_len = 576      # 64 image + 512 text
 norm_type = "rmsnorm"
 activation = "silu"
 
-[model.vlm]
-arch = "mot"
-vision_encoder = "random"
+[vision_encoder]
+type = "random"
 feature_dim = 384
 num_tokens = 64
+
+[vlm]
+arch = "mot"
 
 [train]
 batch_size = 2

--- a/kempnerforge/config/adapter.py
+++ b/kempnerforge/config/adapter.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-import kempnerforge.model.adapter  # noqa: F401 - triggers adapter registration
 from kempnerforge.config.registry import registry
 
 
@@ -39,6 +38,13 @@ class AdapterConfig:
     activation: str = "gelu"
 
     def __post_init__(self) -> None:
+        # Late import: importing the adapter module triggers the
+        # ``@registry.register_adapter`` decorators that populate the registry.
+        # Doing this at module scope creates a circular import via
+        # ``kempnerforge.model.__init__`` -> ``transformer.py`` ->
+        # ``kempnerforge.config.schema`` -> ``adapter.py``.
+        import kempnerforge.model.adapter  # noqa: F401, PLC0415
+
         registered = tuple(registry.list_adapters())
         if self.type not in registered:
             raise ValueError(

--- a/kempnerforge/config/job.py
+++ b/kempnerforge/config/job.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from kempnerforge.config.adapter import AdapterConfig
 from kempnerforge.config.checkpoint import CheckpointConfig
 from kempnerforge.config.data import DataConfig
 from kempnerforge.config.distributed import DistributedConfig
@@ -14,11 +15,21 @@ from kempnerforge.config.optimizer import OptimizerConfig
 from kempnerforge.config.profiling import ProfilingConfig
 from kempnerforge.config.scheduler import SchedulerConfig
 from kempnerforge.config.training import TrainConfig
+from kempnerforge.config.vision import VisionEncoderConfig
+from kempnerforge.config.vlm import VLMConfig
 
 
 @dataclass
 class JobConfig:
-    """Top-level configuration aggregating all sub-configs."""
+    """Top-level configuration aggregating all sub-configs.
+
+    The VLM stack lives as three sibling top-level sections,
+    ``[vision_encoder]`` / ``[adapter]`` / ``[vlm]``. A pure text run
+    leaves all three at ``None`` and writes only ``[model]`` (plus the
+    other operational sections). A VLM run sets ``[vlm]`` and is
+    required to provide ``[vision_encoder]``; ``[adapter]`` defaults to
+    the registered 2-layer MLP and may be omitted.
+    """
 
     model: ModelConfig = field(default_factory=ModelConfig)
     train: TrainConfig = field(default_factory=TrainConfig)
@@ -30,9 +41,55 @@ class JobConfig:
     checkpoint: CheckpointConfig = field(default_factory=CheckpointConfig)
     metrics: MetricsConfig = field(default_factory=MetricsConfig)
     profiling: ProfilingConfig = field(default_factory=ProfilingConfig)
+    vision_encoder: VisionEncoderConfig | None = None
+    adapter: AdapterConfig | None = None
+    vlm: VLMConfig | None = None
+
+    def __post_init__(self) -> None:
+        """Cross-section invariants that fire at construction time.
+
+        ``validate(world_size)`` covers checks that depend on the
+        distributed world size; everything that is decidable from the
+        config alone runs here so loader-time mistakes surface before
+        any distributed init.
+        """
+        if self.vlm is not None:
+            if self.vision_encoder is None:
+                raise ValueError(
+                    "[vlm] is set but [vision_encoder] is missing; a VLM run requires a "
+                    "vision encoder section."
+                )
+            if self.adapter is None:
+                # Materialize the default adapter so downstream callers always
+                # see a non-None AdapterConfig once [vlm] is present.
+                self.adapter = AdapterConfig()
+            # max_seq_len cross-check. Effective residual-stream length is
+            # residual_stream_image_tokens(num_tokens) + max_text_len.
+            #   - Joint-Decoder / MoT: residual is num_tokens + max_text_len.
+            #   - Cross-Attention: residual is text-only (max_text_len), the
+            #     encoder's num_tokens flows side-channel into CA blocks.
+            # Only fires when num_tokens > 0; num_tokens == 0 (the "infer at
+            # build time" sentinel) defers the check to ``build_vlm_wrapper``
+            # / ``_build_vlm`` using the encoder's resolved value.
+            if self.vision_encoder.num_tokens > 0:
+                residual_image_tokens = self.vlm.residual_stream_image_tokens(
+                    self.vision_encoder.num_tokens
+                )
+                required = residual_image_tokens + self.vlm.max_text_len
+                if self.model.max_seq_len < required:
+                    raise ValueError(
+                        f"model.max_seq_len ({self.model.max_seq_len}) insufficient for VLM: "
+                        f"residual_image_tokens ({residual_image_tokens}) + "
+                        f"vlm.max_text_len ({self.vlm.max_text_len}) = {required}"
+                    )
+
+    @property
+    def is_vlm(self) -> bool:
+        """Whether this job builds a ``VLMWrapper`` around the text backbone."""
+        return self.vlm is not None
 
     def validate(self, world_size: int = 1) -> None:
-        """Run cross-config validations."""
+        """Run cross-config validations that depend on the world size."""
         self.distributed.validate_world_size(world_size)
 
         if self.train.seq_len > self.model.max_seq_len:
@@ -96,26 +153,28 @@ class JobConfig:
                     f"ep ({self.distributed.ep})"
                 )
 
-        if self.model.is_vlm:
-            vlm = self.model.vlm
-            assert vlm is not None  # narrowed by is_vlm
+        if self.is_vlm:
+            assert self.vlm is not None  # narrowed by is_vlm
+            assert self.vision_encoder is not None  # __post_init__ enforces this
             # train.seq_len drives the attention sequence length. The
             # effective residual-stream length is
-            # vlm.residual_stream_image_tokens() + max_text_len:
-            #   - Joint-Decoder: residual_stream_image_tokens == num_tokens
+            # vlm.residual_stream_image_tokens(num_tokens) + max_text_len:
+            #   - Joint-Decoder / MoT: residual_stream_image_tokens == num_tokens
             #     (image tokens prepended to text).
             #   - Cross-Attention: residual_stream_image_tokens == 0 (image
             #     features flow side-channel into CA blocks; residual is
             #     text-only).
             # num_tokens=0 is deferred to build_vlm_wrapper.
-            if vlm.num_tokens > 0:
-                residual_image_tokens = vlm.residual_stream_image_tokens()
-                required = residual_image_tokens + vlm.max_text_len
+            if self.vision_encoder.num_tokens > 0:
+                residual_image_tokens = self.vlm.residual_stream_image_tokens(
+                    self.vision_encoder.num_tokens
+                )
+                required = residual_image_tokens + self.vlm.max_text_len
                 if self.train.seq_len < required:
                     raise ValueError(
                         f"train.seq_len ({self.train.seq_len}) insufficient for VLM: "
                         f"residual_image_tokens ({residual_image_tokens}) + "
-                        f"vlm.max_text_len ({vlm.max_text_len}) = {required}"
+                        f"vlm.max_text_len ({self.vlm.max_text_len}) = {required}"
                     )
             if self.distributed.pp > 1:
                 raise ValueError(

--- a/kempnerforge/config/loader.py
+++ b/kempnerforge/config/loader.py
@@ -141,7 +141,7 @@ def _instantiate_from_dict(dc_type: type, data: dict[str, Any]) -> Any:
     """Construct a dataclass directly from a dict, without first building a
     default instance.
 
-    Used for nested Optional[dataclass] fields (e.g. ``ModelConfig.vlm``)
+    Used for nested Optional[dataclass] fields (e.g. ``JobConfig.vlm``)
     where the parent's default is ``None`` and the nested dataclass's
     ``__post_init__`` may reject an empty-default instance.
 
@@ -175,8 +175,8 @@ def _instantiate_from_dict(dc_type: type, data: dict[str, Any]) -> Any:
 
 
 def _resolve_vlm_subclass(data: dict[str, Any]) -> type:
-    """Resolve a TOML ``[model.vlm]`` table to the right ``VLMConfig``
-    subclass via the registered-arch lookup.
+    """Resolve a TOML ``[vlm]`` table to the right ``VLMConfig`` subclass
+    via the registered-arch lookup.
 
     Mirrors ``VLMConfig.for_arch`` error semantics so error type is
     independent of construction site (loader vs programmatic).

--- a/kempnerforge/config/model.py
+++ b/kempnerforge/config/model.py
@@ -6,8 +6,6 @@ import math
 from dataclasses import dataclass
 from enum import StrEnum
 
-from kempnerforge.config.vlm import VLMConfig
-
 
 class NormType(StrEnum):
     rmsnorm = "rmsnorm"
@@ -57,9 +55,6 @@ class ModelConfig:
     moe_bias_schedule: str = "constant"  # "constant", "cosine_decay", "linear_warmup"
     moe_packed_experts: bool = False  # Pack expert weights into one tensor per projection
 
-    # VLM (Joint-Decoder, etc.). Default None = pure text LLM, zero behavior change.
-    vlm: VLMConfig | None = None
-
     def __post_init__(self) -> None:
         if self.n_kv_heads is None:
             self.n_kv_heads = self.n_heads
@@ -105,35 +100,10 @@ class ModelConfig:
                     "Options: 'constant', 'cosine_decay', 'linear_warmup'"
                 )
 
-        # VLM max_seq_len cross-check. Effective residual-stream length is
-        # residual_stream_image_tokens() + max_text_len; for Cross-Attention this is
-        # max_text_len (residual stream is text-only), for Joint-Decoder / MoT it is
-        # num_tokens + max_text_len.
-        #
-        # This config-time check only fires when num_tokens > 0. When num_tokens = 0
-        # (the "infer from encoder at build time" sentinel), the check is skipped
-        # here and re-run in build_vlm_wrapper using the encoder's resolved
-        # num_tokens. That second check is the one that catches misconfigured
-        # max_seq_len when configs use the inference sentinel.
-        if self.vlm is not None and self.vlm.num_tokens > 0:
-            residual_image_tokens = self.vlm.residual_stream_image_tokens()
-            required = residual_image_tokens + self.vlm.max_text_len
-            if self.max_seq_len < required:
-                raise ValueError(
-                    f"max_seq_len ({self.max_seq_len}) insufficient for VLM: "
-                    f"residual_image_tokens ({residual_image_tokens}) + "
-                    f"vlm.max_text_len ({self.vlm.max_text_len}) = {required}"
-                )
-
     @property
     def is_moe(self) -> bool:
         """Whether this config uses Mixture-of-Experts."""
         return self.num_experts > 0
-
-    @property
-    def is_vlm(self) -> bool:
-        """Whether this config enables a VLM wrapper around the Transformer."""
-        return self.vlm is not None
 
     @property
     def head_dim(self) -> int:

--- a/kempnerforge/config/registry.py
+++ b/kempnerforge/config/registry.py
@@ -120,13 +120,16 @@ class Registry:
     def get_vision_encoder(self, name: str) -> Callable:
         return self.get("vision_encoder", name)
 
+    def list_vision_encoders(self) -> list[str]:
+        return self.list("vision_encoder")
+
     def register_vlm_config(self, name: str) -> Callable:
         """Decorator to register a ``VLMConfig`` subclass.
 
         Registers an arch discriminator (e.g. ``"joint_decoder"``,
         ``"cross_attention"``) so the loader can dispatch a TOML
-        ``[model.vlm]`` table with ``arch = "..."`` to the right
-        subclass and ``VLMConfig.for_arch`` can resolve programmatically.
+        ``[vlm]`` table with ``arch = "..."`` to the right subclass
+        and ``VLMConfig.for_arch`` can resolve programmatically.
         """
 
         def decorator(cls: Any) -> Any:

--- a/kempnerforge/config/schema.py
+++ b/kempnerforge/config/schema.py
@@ -1,5 +1,6 @@
 """Backward-compatible re-exports. Import from here or from submodules directly."""
 
+from kempnerforge.config.adapter import AdapterConfig  # noqa: F401
 from kempnerforge.config.checkpoint import AsyncCheckpointMode, CheckpointConfig  # noqa: F401
 from kempnerforge.config.data import DataConfig, DatasetSource, TrainingPhase  # noqa: F401
 from kempnerforge.config.distributed import DistributedConfig, PipelineSchedule  # noqa: F401
@@ -11,6 +12,7 @@ from kempnerforge.config.optimizer import OptimizerConfig  # noqa: F401
 from kempnerforge.config.profiling import ProfilingConfig  # noqa: F401
 from kempnerforge.config.scheduler import SchedulerConfig, SchedulerType  # noqa: F401
 from kempnerforge.config.training import ActivationCheckpointing, TrainConfig  # noqa: F401
+from kempnerforge.config.vision import VisionEncoderConfig  # noqa: F401
 from kempnerforge.config.vlm import (  # noqa: F401
     DEFAULT_MODULE_PATTERNS,
     FreezeSpec,

--- a/kempnerforge/config/vision.py
+++ b/kempnerforge/config/vision.py
@@ -1,0 +1,59 @@
+"""Vision-encoder configuration.
+
+``VisionEncoderConfig`` selects and parameterizes the vision encoder
+that the ``VLMWrapper`` composes alongside the text backbone and
+adapter. It is a top-level section in TOML (``[vision_encoder]``),
+sibling to ``[model]``, ``[adapter]``, and ``[vlm]``.
+
+Field summary:
+
+- ``type`` selects the encoder by registry key
+  (see ``registry.register_vision_encoder``). Defaults to ``"random"``
+  for tests; production configs set ``"siglip2"`` / ``"clip"`` etc.
+- ``path`` is the HF Hub id or local path passed to the encoder
+  builder. Empty string is accepted for stub encoders (``"random"``).
+- ``feature_dim`` is the output feature dim of the encoder. ``0`` means
+  "infer from the encoder at build time".
+- ``num_tokens`` is the number of image tokens the encoder produces per
+  image. ``0`` means "infer at build time". When ``> 0`` it is cross-
+  checked against ``model.max_seq_len`` at config time inside
+  ``JobConfig.__post_init__``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from kempnerforge.config.registry import registry
+
+
+@dataclass
+class VisionEncoderConfig:
+    """Configuration for the vision encoder component of a VLM."""
+
+    type: str = "random"
+    path: str = ""
+    feature_dim: int = 0
+    num_tokens: int = 0
+
+    def __post_init__(self) -> None:
+        # Late import: importing the encoder module triggers the
+        # ``@registry.register_vision_encoder`` decorators that populate the
+        # registry. Without this, ``list_vision_encoders()`` would return an
+        # empty list when this dataclass is constructed before any encoder
+        # module has been imported (e.g. in unit-test isolation).
+        import kempnerforge.model.vision  # noqa: F401, PLC0415
+
+        registered = tuple(registry.list_vision_encoders())
+        if self.type not in registered:
+            raise ValueError(
+                f"Unknown vision_encoder.type: {self.type!r}. Registered: {sorted(registered)}."
+            )
+        if self.feature_dim < 0:
+            raise ValueError(
+                f"vision_encoder.feature_dim must be non-negative (got {self.feature_dim})"
+            )
+        if self.num_tokens < 0:
+            raise ValueError(
+                f"vision_encoder.num_tokens must be non-negative (got {self.num_tokens})"
+            )

--- a/kempnerforge/config/vlm.py
+++ b/kempnerforge/config/vlm.py
@@ -1,15 +1,21 @@
 """VLM (vision-language model) configuration.
 
-``VLMConfig`` describes the vision stack attached to a backbone
-``Transformer``. It lives as ``ModelConfig.vlm``; when unset, models
-behave exactly as before.
+``VLMConfig`` carries the arch-level knobs of the vision-language
+model: which architecture to wire (``arch``), the fixed text padding
+length, and the freeze policy. The vision encoder and adapter are
+described by sibling top-level sections (``VisionEncoderConfig`` in
+``config/vision.py``, ``AdapterConfig`` in ``config/adapter.py``).
+
+In TOML, ``[vlm]`` is a top-level section, parallel to ``[model]``,
+``[vision_encoder]``, and ``[adapter]``. When ``[vlm]`` is absent the
+job is a pure text run.
 
 Architecture is a discriminated union on the ``arch`` field:
 
-- ``"joint_decoder"`` — image tokens prepended to the text sequence.
-- ``"cross_attention"`` — image K/V flows in via separate
+- ``"joint_decoder"`` image tokens prepended to the text sequence.
+- ``"cross_attention"`` image K/V flows in via separate
   cross-attention blocks at a configurable cadence.
-- ``"mot"`` — Mixture-of-Transformers: per-modality Q/K/V/O + per-
+- ``"mot"`` Mixture-of-Transformers: per-modality Q/K/V/O + per-
   modality FFN at every layer, single global self-attention.
 
 Each arch gets its own ``VLMConfig`` subclass, registered via
@@ -84,39 +90,19 @@ class VLMConfig:
 
     Field summary (full per-field docs are picked up from autodoc):
 
-    - ``arch`` — VLM architecture discriminator. Subclasses set this via
+    - ``arch`` VLM architecture discriminator. Subclasses set this via
       field default; direct construction with an arch name not backed by
       a registered subclass raises.
-    - ``vision_encoder`` — registry key
-      (see ``registry.register_vision_encoder``). Required.
-    - ``vision_encoder_path`` — HF Hub id or local path passed to the
-      encoder builder.
-    - ``feature_dim`` — output feature dim of the vision encoder. 0 means
-      infer from the encoder at build time.
-    - ``num_tokens`` — number of image tokens produced per image. 0 means
-      infer from the encoder at build time. When > 0 it is cross-checked
-      against ``max_seq_len``.
-    - ``adapter_hidden_dim`` — hidden dim of the 2-layer MLP adapter.
-      0 means use the backbone ``dim``.
-    - ``adapter_activation`` — activation inside the adapter. One of
-      ``"gelu"``, ``"silu"``, ``"relu"``.
-    - ``max_text_len`` — fixed text padding length used by ``VLMCollator``.
+    - ``max_text_len`` fixed text padding length used by ``VLMCollator``.
       Enforces rank-consistent batches under FSDP2.
-    - ``freeze`` — static freeze specs applied once at build time.
-    - ``freeze_schedule`` — step-boundary freeze transitions (reserved;
-      wiring into the training loop lands in a follow-up).
-    - ``module_patterns`` — map of module alias (``"transformer"``,
+    - ``freeze`` static freeze specs applied once at build time.
+    - ``freeze_schedule`` step-boundary freeze transitions.
+    - ``module_patterns`` map of module alias (``"transformer"``,
       ``"vision_encoder"``, ``"adapter"``, plus arch-specific additions)
       to fnmatch pattern list.
     """
 
     arch: str = "joint_decoder"
-    vision_encoder: str = ""
-    vision_encoder_path: str = ""
-    feature_dim: int = 0
-    num_tokens: int = 0
-    adapter_hidden_dim: int = 0
-    adapter_activation: str = "gelu"
     max_text_len: int = 512
     freeze: list[FreezeSpec] = field(default_factory=lambda: [FreezeSpec("vision_encoder", True)])
     freeze_schedule: list[FreezeStage] = field(default_factory=list)
@@ -137,19 +123,6 @@ class VLMConfig:
                 f"Registered: {sorted(registered)}. "
                 f"Reserved (not yet implemented): {sorted(_RESERVED_ARCHS)}."
             )
-        if not self.vision_encoder:
-            raise ValueError(
-                "vlm.vision_encoder must be set (registry key, e.g. 'random', 'siglip2', 'clip')"
-            )
-        if self.adapter_activation not in ("gelu", "silu", "relu"):
-            raise ValueError(
-                f"Unknown vlm.adapter_activation: {self.adapter_activation!r}. "
-                "Options: 'gelu', 'silu', 'relu'."
-            )
-        if self.feature_dim < 0 or self.num_tokens < 0:
-            raise ValueError("vlm.feature_dim and vlm.num_tokens must be non-negative")
-        if self.adapter_hidden_dim < 0:
-            raise ValueError("vlm.adapter_hidden_dim must be non-negative")
         if self.max_text_len <= 0:
             raise ValueError("vlm.max_text_len must be positive")
         if self.freeze_schedule:
@@ -157,29 +130,26 @@ class VLMConfig:
             if steps != sorted(steps) or len(steps) != len(set(steps)):
                 raise ValueError("vlm.freeze_schedule start_steps must be strictly monotonic")
 
-    def residual_stream_image_tokens(self, num_tokens: int | None = None) -> int:
-        """Number of image tokens this arch puts in the residual stream.
+    def residual_stream_image_tokens(self, num_tokens: int) -> int:
+        """Number of image tokens this arch places in the residual stream.
 
-        Used by ``ModelConfig`` and ``JobConfig`` to validate that
-        ``max_seq_len`` and ``train.seq_len`` are large enough to fit
+        Used by ``JobConfig`` to validate that ``model.max_seq_len`` and
+        ``train.seq_len`` are large enough to fit
         ``residual_stream_image_tokens + max_text_len`` along the
         attention sequence dimension.
 
-        - Joint-Decoder: ``num_tokens`` (image tokens prepended to text).
+        - Joint-Decoder / MoT: ``num_tokens`` (image tokens prepended to
+          text).
         - Cross-Attention: ``0`` (residual stream is text-only; image
           features flow side-channel into CA blocks).
 
         Args:
-            num_tokens: Override for ``self.num_tokens``. Pass the vision
-                encoder's resolved ``num_tokens`` at build time when the
-                config-level value is ``0`` (the "infer at build time"
-                sentinel). When ``None``, ``self.num_tokens`` is used —
-                matches the config-time call site in ``ModelConfig``.
-
-        Subclasses override as needed. Base default matches the
-        Joint-Decoder semantics.
+            num_tokens: The vision encoder's resolved ``num_tokens``.
+                Pass ``0`` when it is not known yet (the "infer at build
+                time" sentinel); cross-checks that depend on a concrete
+                value will skip and re-run at build time.
         """
-        return self.num_tokens if num_tokens is None else num_tokens
+        return num_tokens
 
     @classmethod
     def for_arch(cls, arch: str, **kwargs: Any) -> VLMConfig:
@@ -188,15 +158,13 @@ class VLMConfig:
         Raises:
             ValueError: ``arch`` is not registered.
             NotImplementedError: ``arch`` is reserved (in
-                ``_RESERVED_ARCHS``) — matches loader semantics so the
+                ``_RESERVED_ARCHS``) matches loader semantics so the
                 error type is independent of construction site.
 
         Example:
             >>> cfg = VLMConfig.for_arch(
             ...     "cross_attention",
-            ...     vision_encoder="random",
-            ...     feature_dim=1024,
-            ...     num_tokens=256,
+            ...     max_text_len=2048,
             ...     cross_attention_every_n_layers=4,
             ... )
         """
@@ -265,7 +233,7 @@ class CrossAttentionConfig(VLMConfig):
                 "vlm.cross_attention_n_heads and cross_attention_n_kv_heads must be non-negative"
             )
 
-    def residual_stream_image_tokens(self, num_tokens: int | None = None) -> int:  # noqa: ARG002
+    def residual_stream_image_tokens(self, num_tokens: int) -> int:  # noqa: ARG002
         """Cross-Attention does not extend the residual stream.
 
         Image features flow as K/V into separate CrossAttentionBlocks;
@@ -355,15 +323,11 @@ class MoTConfig(VLMConfig):
                 "non-empty filesystem path to a torch-saved JD or text-only state dict"
             )
 
-    def residual_stream_image_tokens(self, num_tokens: int | None = None) -> int:
+    def residual_stream_image_tokens(self, num_tokens: int) -> int:
         """MoT prepends ``num_tokens`` image tokens to the text sequence
         (same residual-stream layout as Joint-Decoder).
-
-        Accepts the same ``num_tokens`` override as the base method so
-        build-time call sites can pass the encoder's resolved value when
-        the config-level ``num_tokens`` is ``0``.
         """
-        return self.num_tokens if num_tokens is None else num_tokens
+        return num_tokens
 
     def resolved_image_heads(
         self, model_n_heads: int, model_n_kv_heads: int = 0

--- a/kempnerforge/distributed/parallel.py
+++ b/kempnerforge/distributed/parallel.py
@@ -11,7 +11,7 @@ Application order (critical — wrong order causes silent correctness bugs):
 
 For convenience, ``build_parallel_model`` combines all steps including
 model creation, meta-device initialization, and optional torch.compile.
-It also dispatches to a VLM branch when ``model_config.is_vlm`` is True.
+It also dispatches to a VLM branch when ``vlm_config`` is provided.
 """
 
 from __future__ import annotations
@@ -362,6 +362,9 @@ def _apply_fsdp_vlm(
 
 def _build_vlm(
     model_config,
+    vision_config,
+    adapter_config,
+    vlm_config,
     device: torch.device,
     device_mesh: DeviceMesh | None,
     *,
@@ -392,10 +395,10 @@ def _build_vlm(
       7. Freeze specs are applied via ``apply_freeze_specs`` and a fully
          frozen encoder is switched to ``eval()``.
     """
-    from kempnerforge.config.adapter import AdapterConfig
     from kempnerforge.distributed.expert_parallel import apply_expert_parallel
     from kempnerforge.distributed.tensor_parallel import apply_tensor_parallel
     from kempnerforge.model.adapter import build_adapter
+    from kempnerforge.model.transformer import Transformer
     from kempnerforge.model.vlm import (
         VLMWrapper,
         _is_encoder_frozen,
@@ -403,41 +406,41 @@ def _build_vlm(
     )
     from kempnerforge.training.freeze import apply_freeze_specs
 
-    vlm = model_config.vlm
-    assert vlm is not None, "_build_vlm requires model_config.vlm to be set"
+    assert vlm_config is not None, "_build_vlm requires vlm_config to be set"
+    assert vision_config is not None, "_build_vlm requires vision_config to be set"
+    assert adapter_config is not None, "_build_vlm requires adapter_config to be set"
     tp_enabled = device_mesh is not None and "tp" in device_mesh.mesh_dim_names  # type: ignore[reportOperatorIssue]
 
     # 1. Vision encoder on CPU (real HF weights).
-    encoder_builder = registry.get_vision_encoder(vlm.vision_encoder)
+    encoder_builder = registry.get_vision_encoder(vision_config.type)
     encoder = encoder_builder(
-        vlm.vision_encoder_path,
-        num_tokens=vlm.num_tokens if vlm.num_tokens > 0 else None,
-        feature_dim=vlm.feature_dim if vlm.feature_dim > 0 else None,
+        vision_config.path,
+        num_tokens=vision_config.num_tokens if vision_config.num_tokens > 0 else None,
+        feature_dim=vision_config.feature_dim if vision_config.feature_dim > 0 else None,
     )
-    in_dim = vlm.feature_dim or encoder.feature_dim
+    in_dim = vision_config.feature_dim or encoder.feature_dim
 
     # 2. Transformer + Adapter on meta (when TP is active) or CPU.
-    model_builder = registry.get_model(model_config.model_type)
-    adapter_config = AdapterConfig(
-        type="mlp_2layer",
-        hidden_dim=vlm.adapter_hidden_dim,
-        activation=vlm.adapter_activation,
-    )
+    # VLM path always constructs Transformer directly (the registry's
+    # text-only builder takes a single ModelConfig and cannot accept the
+    # extra vlm_config / num_image_tokens kwargs the VLM path needs).
     ctx = torch.device("meta") if tp_enabled else contextlib.nullcontext()
     with ctx:
-        transformer = model_builder(model_config)
+        transformer = Transformer(
+            model_config, vlm_config=vlm_config, num_image_tokens=encoder.num_tokens
+        )
         adapter = build_adapter(adapter_config, in_dim=in_dim, out_dim=model_config.dim)
 
-    strategy = build_modality_strategy(vlm)
+    strategy = build_modality_strategy(vlm_config)
     wrapper = VLMWrapper(encoder, adapter, transformer, strategy)
 
     # 3. Length cross-check now that num_tokens is resolved.
-    required = wrapper.num_image_tokens + vlm.max_text_len
+    required = wrapper.num_image_tokens + vlm_config.max_text_len
     if model_config.max_seq_len < required:
         raise ValueError(
             f"max_seq_len ({model_config.max_seq_len}) insufficient for VLM: "
             f"num_image_tokens ({wrapper.num_image_tokens}) + vlm.max_text_len "
-            f"({vlm.max_text_len}) = {required}"
+            f"({vlm_config.max_text_len}) = {required}"
         )
 
     # 4. TP / EP / Float8 / AC on the transformer only.
@@ -449,7 +452,7 @@ def _build_vlm(
     apply_ac(transformer, ac_mode)
 
     # 5. FSDP2 (before materialization when meta-device path is used).
-    encoder_frozen = _is_encoder_frozen(vlm.freeze)
+    encoder_frozen = _is_encoder_frozen(vlm_config.freeze)
     if device_mesh is not None:
         _apply_fsdp_vlm(wrapper, device_mesh, mp_policy, encoder_frozen=encoder_frozen)
 
@@ -471,7 +474,7 @@ def _build_vlm(
     adapter.to(dtype=param_dtype)
 
     # 7. Freeze specs + eval() for fully frozen encoder.
-    apply_freeze_specs(wrapper, vlm.freeze, vlm.module_patterns)
+    apply_freeze_specs(wrapper, vlm_config.freeze, vlm_config.module_patterns)
     if encoder_frozen:
         encoder.eval()
 
@@ -494,6 +497,9 @@ def build_parallel_model(
     device: torch.device,
     device_mesh: DeviceMesh | None,
     *,
+    vision_config=None,
+    adapter_config=None,
+    vlm_config=None,
     ac_mode: ActivationCheckpointing = ActivationCheckpointing.none,
     mp_policy: MixedPrecisionPolicy | None = None,
     param_dtype: torch.dtype = torch.bfloat16,
@@ -502,11 +508,11 @@ def build_parallel_model(
 ) -> torch.nn.Module:
     """Build a Transformer (or a VLMWrapper) with parallelism applied.
 
-    Dispatches on ``model_config.is_vlm``. Non-VLM configurations follow
-    the original order:
+    Dispatches on ``vlm_config`` (``None`` -> text-only path). Non-VLM
+    configurations follow the original order:
 
-      - TP enabled:  meta-device init → TP → EP → [Float8] → AC → FSDP → materialize
-      - TP disabled: create on device → EP → [Float8] → AC → FSDP
+      - TP enabled:  meta-device init -> TP -> EP -> [Float8] -> AC -> FSDP -> materialize
+      - TP disabled: create on device -> EP -> [Float8] -> AC -> FSDP
 
     VLM configurations follow the order documented on ``_build_vlm``.
 
@@ -517,6 +523,9 @@ def build_parallel_model(
         model_config: ModelConfig for the Transformer.
         device: Target device for the model.
         device_mesh: Full DeviceMesh (may contain tp, dp_shard, dp_replicate dims).
+        vision_config: VisionEncoderConfig (required iff vlm_config is set).
+        adapter_config: AdapterConfig (required iff vlm_config is set).
+        vlm_config: VLMConfig. None for a pure text-only run.
         ac_mode: Activation checkpointing mode.
         mp_policy: FSDP2 mixed-precision policy. Defaults to bf16 params + fp32 reduce.
         param_dtype: Dtype for model parameters.
@@ -526,9 +535,12 @@ def build_parallel_model(
     Returns:
         The parallelized model, ready for training.
     """
-    if getattr(model_config, "is_vlm", False):
+    if vlm_config is not None:
         return _build_vlm(
             model_config,
+            vision_config,
+            adapter_config,
+            vlm_config,
             device,
             device_mesh,
             ac_mode=ac_mode,

--- a/kempnerforge/model/transformer.py
+++ b/kempnerforge/model/transformer.py
@@ -16,7 +16,7 @@ import torch.nn as nn
 
 from kempnerforge.config.registry import registry
 from kempnerforge.config.schema import ModelConfig
-from kempnerforge.config.vlm import CrossAttentionConfig, MoTConfig
+from kempnerforge.config.vlm import CrossAttentionConfig, MoTConfig, VLMConfig
 from kempnerforge.model.attention import Attention, KVCache
 from kempnerforge.model.cross_attention import CrossAttentionBlock
 from kempnerforge.model.embedding import OutputHead, TokenEmbedding
@@ -100,7 +100,13 @@ class Transformer(nn.Module):
     Embedding → TransformerBlocks → Norm → Output Head
     """
 
-    def __init__(self, config: ModelConfig) -> None:
+    def __init__(
+        self,
+        config: ModelConfig,
+        *,
+        vlm_config: VLMConfig | None = None,
+        num_image_tokens: int = 0,
+    ) -> None:
         super().__init__()
         self.config = config
 
@@ -110,11 +116,14 @@ class Transformer(nn.Module):
         # MoT branch: build MoTBlocks instead of TransformerBlocks. v1
         # enforces equal head counts across modalities (single global
         # SDPA over the concatenated multi-modality sequence).
+        # num_image_tokens flows in from the vision encoder via the VLM
+        # build path; it is unused for non-MoT arches but kept as a single
+        # constructor arg so the signature is uniform across arches.
         self._mot_modalities: tuple[str, ...] = ()
         self._mot_n_image: int = 0
-        if isinstance(config.vlm, MoTConfig):
+        if isinstance(vlm_config, MoTConfig):
             text_n_kv_heads = config.n_kv_heads if config.n_kv_heads is not None else config.n_heads
-            img_n_heads, img_n_kv_heads = config.vlm.resolved_image_heads(
+            img_n_heads, img_n_kv_heads = vlm_config.resolved_image_heads(
                 config.n_heads, text_n_kv_heads
             )
             if img_n_heads != config.n_heads or img_n_kv_heads != text_n_kv_heads:
@@ -123,8 +132,8 @@ class Transformer(nn.Module):
                     f"image=({img_n_heads}, {img_n_kv_heads}) vs "
                     f"text=({config.n_heads}, {text_n_kv_heads})"
                 )
-            self._mot_modalities = config.vlm.mot_modalities
-            self._mot_n_image = config.vlm.num_tokens
+            self._mot_modalities = vlm_config.mot_modalities
+            self._mot_n_image = num_image_tokens
             self.layers = nn.ModuleDict(
                 {
                     str(i): MoTBlock(config, modalities=self._mot_modalities, layer_idx=i)
@@ -137,15 +146,15 @@ class Transformer(nn.Module):
                 {str(i): TransformerBlock(config, layer_idx=i) for i in range(config.n_layers)}
             )
 
-        # Cross-Attention layers (only populated when vlm is a
+        # Cross-Attention layers (only populated when vlm_config is a
         # CrossAttentionConfig). Empty ModuleDict registers no
         # state_dict keys, so JD checkpoints load unchanged on builds
         # where this dict ends up empty.
         self.cross_attention_layers: nn.ModuleDict = nn.ModuleDict()
         self._ca_cadence: int = 0
-        if isinstance(config.vlm, CrossAttentionConfig):
-            self._ca_cadence = config.vlm.cross_attention_every_n_layers
-            n_h, n_kv = config.vlm.resolved_heads(config.n_heads)
+        if isinstance(vlm_config, CrossAttentionConfig):
+            self._ca_cadence = vlm_config.cross_attention_every_n_layers
+            n_h, n_kv = vlm_config.resolved_heads(config.n_heads)
             num_ca_blocks = config.n_layers // self._ca_cadence
             for k in range(num_ca_blocks):
                 self.cross_attention_layers[str(k)] = CrossAttentionBlock(

--- a/kempnerforge/model/vlm.py
+++ b/kempnerforge/model/vlm.py
@@ -42,6 +42,7 @@ import torch.nn as nn
 from kempnerforge.config.adapter import AdapterConfig
 from kempnerforge.config.registry import registry
 from kempnerforge.config.schema import ModelConfig
+from kempnerforge.config.vision import VisionEncoderConfig
 from kempnerforge.config.vlm import FreezeSpec, VLMConfig
 from kempnerforge.model.adapter import build_adapter
 from kempnerforge.model.modality import ModalityContext
@@ -270,8 +271,13 @@ def _is_encoder_frozen(specs: Iterable[FreezeSpec]) -> bool:
     return all(s.frozen for s in relevant)
 
 
-def build_vlm_wrapper(model_config: ModelConfig) -> VLMWrapper:
-    """Build a ``VLMWrapper`` from a ``ModelConfig`` with ``vlm`` set.
+def build_vlm_wrapper(
+    model_config: ModelConfig,
+    vision_config: VisionEncoderConfig,
+    adapter_config: AdapterConfig,
+    vlm_config: VLMConfig,
+) -> VLMWrapper:
+    """Build a ``VLMWrapper`` from the four top-level configs.
 
     Used by tests and by ``build_parallel_model``. Constructs the
     vision encoder via the registry (HF weights loaded on CPU), builds
@@ -280,43 +286,35 @@ def build_vlm_wrapper(model_config: ModelConfig) -> VLMWrapper:
     a raw ``Transformer``. Callers that need meta-device / FSDP /
     freeze handling go through ``build_parallel_model`` instead.
 
-    The adapter type defaults to ``"mlp_2layer"`` (matches the pre-
-    registry behavior). A follow-up PR will expose ``[adapter]`` as a
-    top-level TOML section; in the meantime this builder synthesizes
-    an ``AdapterConfig`` from the existing ``VLMConfig`` fields
-    (``adapter_hidden_dim`` and ``adapter_activation``).
+    All four configs are required: the schema flip lifted the vision /
+    adapter / VLM sections out of ``ModelConfig`` and made them parallel
+    siblings.
     """
-    vlm: VLMConfig | None = model_config.vlm
-    if vlm is None:
-        raise ValueError("build_vlm_wrapper requires model_config.vlm to be set")
-    encoder_builder = registry.get_vision_encoder(vlm.vision_encoder)
+    encoder_builder = registry.get_vision_encoder(vision_config.type)
     encoder = encoder_builder(
-        vlm.vision_encoder_path,
-        num_tokens=vlm.num_tokens if vlm.num_tokens > 0 else None,
-        feature_dim=vlm.feature_dim if vlm.feature_dim > 0 else None,
+        vision_config.path,
+        num_tokens=vision_config.num_tokens if vision_config.num_tokens > 0 else None,
+        feature_dim=vision_config.feature_dim if vision_config.feature_dim > 0 else None,
     )
     # Build-time max_seq_len cross-check using the encoder's resolved
-    # num_tokens. ModelConfig.__post_init__ runs the same check at config
-    # time only when vlm.num_tokens > 0; when the user leaves num_tokens=0
-    # (the "infer from encoder at build time" sentinel) the config-time
-    # check is skipped and the residual-stream allocation goes unchecked
-    # until the model actually runs. This guard fills that gap.
-    residual_image_tokens = vlm.residual_stream_image_tokens(encoder.num_tokens)
-    required = residual_image_tokens + vlm.max_text_len
+    # num_tokens. ``JobConfig.__post_init__`` runs the same check at config
+    # time only when ``vision_encoder.num_tokens > 0``; when the user leaves
+    # num_tokens=0 (the "infer from encoder at build time" sentinel) the
+    # config-time check is skipped and the residual-stream allocation goes
+    # unchecked until the model actually runs. This guard fills that gap.
+    residual_image_tokens = vlm_config.residual_stream_image_tokens(encoder.num_tokens)
+    required = residual_image_tokens + vlm_config.max_text_len
     if model_config.max_seq_len < required:
         raise ValueError(
             f"max_seq_len ({model_config.max_seq_len}) insufficient for VLM at build time: "
             f"encoder.num_tokens ({encoder.num_tokens}) -> "
             f"residual_image_tokens ({residual_image_tokens}) + "
-            f"vlm.max_text_len ({vlm.max_text_len}) = {required}"
+            f"vlm.max_text_len ({vlm_config.max_text_len}) = {required}"
         )
-    in_dim = vlm.feature_dim or encoder.feature_dim
-    adapter_config = AdapterConfig(
-        type="mlp_2layer",
-        hidden_dim=vlm.adapter_hidden_dim,
-        activation=vlm.adapter_activation,
-    )
+    in_dim = vision_config.feature_dim or encoder.feature_dim
     adapter = build_adapter(adapter_config, in_dim=in_dim, out_dim=model_config.dim)
-    transformer = Transformer(model_config)
-    strategy = build_modality_strategy(vlm)
+    transformer = Transformer(
+        model_config, vlm_config=vlm_config, num_image_tokens=encoder.num_tokens
+    )
+    strategy = build_modality_strategy(vlm_config)
     return VLMWrapper(encoder, adapter, transformer, strategy)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -94,6 +94,10 @@ def main() -> None:
 
     tc = config.train
     mc = config.model
+    vlm_cfg = config.vlm
+    vision_cfg = config.vision_encoder
+    adapter_cfg = config.adapter
+    is_vlm = config.is_vlm
     pp_enabled = config.distributed.pp > 1
     mp_policy = default_mp_policy(tc.param_dtype)
 
@@ -167,6 +171,9 @@ def main() -> None:
             config.model,
             device,
             device_mesh,
+            vision_config=vision_cfg,
+            adapter_config=adapter_cfg,
+            vlm_config=vlm_cfg,
             ac_mode=tc.activation_checkpointing,
             mp_policy=mp_policy,
             param_dtype=tc.param_dtype,
@@ -209,16 +216,16 @@ def main() -> None:
         # via metadata.json before invoking load() so the comparison
         # uses the same step the checkpoint was written at.
         vlm_freeze_expected = None
-        if mc.is_vlm:
-            assert mc.vlm is not None
+        if is_vlm:
+            assert vlm_cfg is not None
             probe_step = ckpt_mgr.peek_saved_step(str(resume_path) if resume_path else None) or 0
             # valid_modules: the set of aliases the current config knows
             # about. effective_freeze raises ValueError if any FreezeSpec
             # references an alias not in this set, catching TOML typos at
             # config-load time rather than silently no-op'ing the freeze.
-            valid_modules = set(mc.vlm.module_patterns.keys())
+            valid_modules = set(vlm_cfg.module_patterns.keys())
             vlm_freeze_expected = canonical_freeze_meta(
-                effective_freeze(probe_step, mc.vlm.freeze, mc.vlm.freeze_schedule, valid_modules)
+                effective_freeze(probe_step, vlm_cfg.freeze, vlm_cfg.freeze_schedule, valid_modules)
             )
         step, tokens_seen, ckpt_extra_loaded = ckpt_mgr.load(
             path=str(resume_path) if resume_path else None,
@@ -233,22 +240,22 @@ def main() -> None:
         # None or step == 0); a real resume of an in-flight MoT run
         # already has the MoT-shaped state in the checkpoint and skips
         # this hook.
-        if isinstance(mc.vlm, MoTConfig) and mc.vlm.mot_warm_start_from_text and step == 0:
-            source = torch.load(mc.vlm.mot_warm_start_path, map_location="cpu", weights_only=True)
+        if isinstance(vlm_cfg, MoTConfig) and vlm_cfg.mot_warm_start_from_text and step == 0:
+            source = torch.load(vlm_cfg.mot_warm_start_path, map_location="cpu", weights_only=True)
             if isinstance(source, dict) and "model" in source:
                 source = source["model"]
             mot_warm_start_from_text_stack(inner_transformer(model), source)  # type: ignore[arg-type]
             logger.info(
-                f"MoT warm-start: copied dense block weights from {mc.vlm.mot_warm_start_path}"
+                f"MoT warm-start: copied dense block weights from {vlm_cfg.mot_warm_start_path}"
             )
         # Apply effective freeze at the resumed step so requires_grad
         # reflects the post-transition state of any stages with
         # start_step <= loaded_step. Build-time apply only handles
         # the base freeze list.
-        if mc.vlm is not None and mc.vlm.freeze_schedule:
-            valid_modules = set(mc.vlm.module_patterns.keys())
-            specs = effective_freeze(step, mc.vlm.freeze, mc.vlm.freeze_schedule, valid_modules)
-            apply_freeze_specs(model, specs, mc.vlm.module_patterns)
+        if vlm_cfg is not None and vlm_cfg.freeze_schedule:
+            valid_modules = set(vlm_cfg.module_patterns.keys())
+            specs = effective_freeze(step, vlm_cfg.freeze, vlm_cfg.freeze_schedule, valid_modules)
+            apply_freeze_specs(model, specs, vlm_cfg.module_patterns)
             logger.info(f"Resumed at step={step}; applied effective freeze ({len(specs)} specs)")
 
     # --- Metrics ---
@@ -279,7 +286,7 @@ def main() -> None:
 
             eos_token_id = _AT.from_pretrained(config.data.tokenizer_path).eos_token_id
 
-    if mc.is_vlm:
+    if is_vlm:
         # --- VLM (Joint-Decoder) data path ---
         # Mixing VLM + text-only datasets in one run is out of scope on this
         # branch. DatasetSource doesn't describe image sources yet; follow-up.
@@ -289,14 +296,14 @@ def main() -> None:
 
         from kempnerforge.data.vlm_dataset import HuggingFaceVLMDataset, VLMCollator
 
-        assert mc.vlm is not None  # narrowed by is_vlm
+        assert vlm_cfg is not None  # narrowed by is_vlm
         dataset = HuggingFaceVLMDataset(
             dataset_name=config.data.hf_dataset_name,
             split=config.data.hf_dataset_split,
             image_field=config.data.hf_dataset_image_field,
             text_field=config.data.hf_dataset_text_field,
             tokenizer_path=config.data.tokenizer_path,
-            max_text_len=mc.vlm.max_text_len,
+            max_text_len=vlm_cfg.max_text_len,
             prompt_field=config.data.hf_dataset_prompt_field or None,
             image_size=config.data.hf_image_size,
             dataset_config=config.data.hf_dataset_config,
@@ -310,7 +317,7 @@ def main() -> None:
         _pad_id = _tok.pad_token_id
         if _pad_id is None:
             _pad_id = _tok.eos_token_id if _tok.eos_token_id is not None else 0
-        collator = VLMCollator(pad_id=int(_pad_id), max_text_len=mc.vlm.max_text_len)
+        collator = VLMCollator(pad_id=int(_pad_id), max_text_len=vlm_cfg.max_text_len)
         sampler = DistributedSampler(
             dataset, num_replicas=dp_size, rank=dp_rank, shuffle=True, seed=tc.seed
         )
@@ -486,7 +493,7 @@ def main() -> None:
 
     eval_config = config.eval
     eval_dataloader = None
-    _build_eval, _warn_vlm_eval = should_build_eval_dataloader(eval_config.enabled, mc.is_vlm)
+    _build_eval, _warn_vlm_eval = should_build_eval_dataloader(eval_config.enabled, is_vlm)
     if _warn_vlm_eval:
         logger.warning(
             "eval.enabled=true is ignored for VLM configs on this branch. "
@@ -684,7 +691,7 @@ def main() -> None:
             avg_loss = loss_tensor[0].item()
             grad_norm_val = loss_tensor[1].item()
 
-        elif mc.is_vlm:
+        elif is_vlm:
             # --- VLM training step (no PP, VLM Joint-Decoder) ---
             total_loss = 0.0
             total_text_tokens = 0
@@ -827,12 +834,12 @@ def main() -> None:
         # before we flip requires_grad. Otherwise a save started at
         # step S-1 could write metadata after the transition, attaching
         # the post-transition spec to pre-transition shards.
-        if mc.is_vlm and mc.vlm is not None and mc.vlm.freeze_schedule:
-            pending_stages = [s for s in mc.vlm.freeze_schedule if s.start_step == step]
+        if is_vlm and vlm_cfg is not None and vlm_cfg.freeze_schedule:
+            pending_stages = [s for s in vlm_cfg.freeze_schedule if s.start_step == step]
             if pending_stages:
                 ckpt_mgr.flush_pending_save()
                 for stage in pending_stages:
-                    flipped = apply_freeze_specs(model, stage.specs, mc.vlm.module_patterns)
+                    flipped = apply_freeze_specs(model, stage.specs, vlm_cfg.module_patterns)
                     logger.info(f"FreezeStage at step={step}: applied {flipped}")
 
         # Phase transition check
@@ -893,7 +900,7 @@ def main() -> None:
         # still reports sequence positions processed. The counter is DP-local
         # on each rank, so all-reduce it to the global text-token count
         # before logging.
-        if mc.is_vlm and step_metrics is not None:
+        if is_vlm and step_metrics is not None:
             global_text_tokens = total_text_tokens
             if dist.is_initialized():
                 _t = torch.tensor([total_text_tokens], device=device, dtype=torch.long)
@@ -947,14 +954,14 @@ def main() -> None:
         ckpt_extra: dict = {"phase_idx": current_phase_idx} if active_phases else {}
         if config.metrics.wandb_run_id:
             ckpt_extra["wandb_run_id"] = config.metrics.wandb_run_id
-        if mc.is_vlm:
-            assert mc.vlm is not None
+        if is_vlm:
+            assert vlm_cfg is not None
             # Use effective_freeze so the saved metadata reflects the
             # post-transition state when a FreezeStage has fired.
             # valid_modules pins typo-catching at save time too.
-            valid_modules = set(mc.vlm.module_patterns.keys())
+            valid_modules = set(vlm_cfg.module_patterns.keys())
             ckpt_extra["vlm_freeze"] = canonical_freeze_meta(
-                effective_freeze(step, mc.vlm.freeze, mc.vlm.freeze_schedule, valid_modules)
+                effective_freeze(step, vlm_cfg.freeze, vlm_cfg.freeze_schedule, valid_modules)
             )
         if step % config.checkpoint.interval == 0:
             ckpt_mgr.save(

--- a/tests/distributed/test_vlm_cross_attn_fsdp.py
+++ b/tests/distributed/test_vlm_cross_attn_fsdp.py
@@ -25,8 +25,10 @@ import torch
 import torch.distributed as dist
 
 from kempnerforge.checkpoint.manager import CheckpointManager
+from kempnerforge.config.adapter import AdapterConfig
 from kempnerforge.config.model import ModelConfig
 from kempnerforge.config.schema import CheckpointConfig, OptimizerConfig
+from kempnerforge.config.vision import VisionEncoderConfig
 from kempnerforge.config.vlm import CrossAttentionConfig, FreezeSpec
 from kempnerforge.distributed.parallel import build_parallel_model
 from kempnerforge.model.vlm import VLMWrapper, inner_transformer
@@ -50,17 +52,12 @@ def _tiny_ca_cfg(
     feature_dim: int = 96,
     cadence: int = 2,
     freeze: list[FreezeSpec] | None = None,
-) -> ModelConfig:
-    return ModelConfig(
-        dim=64,
-        n_layers=4,
-        n_heads=4,
-        vocab_size=256,
-        max_seq_len=128,
-        vlm=CrossAttentionConfig(
-            vision_encoder="random",
-            feature_dim=feature_dim,
-            num_tokens=num_image_tokens,
+) -> tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, CrossAttentionConfig]:
+    return (
+        ModelConfig(dim=64, n_layers=4, n_heads=4, vocab_size=256, max_seq_len=128),
+        VisionEncoderConfig(type="random", feature_dim=feature_dim, num_tokens=num_image_tokens),
+        AdapterConfig(),
+        CrossAttentionConfig(
             max_text_len=32,
             cross_attention_every_n_layers=cadence,
             freeze=freeze if freeze is not None else [FreezeSpec("vision_encoder", True)],
@@ -69,16 +66,20 @@ def _tiny_ca_cfg(
 
 
 def _build(
-    cfg: ModelConfig,
+    cfg: tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, CrossAttentionConfig],
     mesh,
     *,
     param_dtype: torch.dtype = torch.bfloat16,
     compile_model: bool = False,
 ) -> VLMWrapper:
+    mc, vc, ac, lc = cfg
     model = build_parallel_model(
-        cfg,
+        mc,
         device=torch.device("cuda"),
         device_mesh=mesh,
+        vision_config=vc,
+        adapter_config=ac,
+        vlm_config=lc,
         param_dtype=param_dtype,
         compile_model=compile_model,
     )
@@ -194,7 +195,7 @@ class TestFreezeStageUnderFsdp:
         apply_freeze_specs(
             wrapper,
             [FreezeSpec("adapter", False)],
-            cfg.vlm.module_patterns,  # type: ignore[union-attr]
+            cfg[3].module_patterns,  # type: ignore[union-attr]
         )
         # Run another backward (must zero grads first since prior backward
         # left frozen-param grads as None and trainable-param grads populated).
@@ -249,30 +250,31 @@ class TestMoEWithVLM:
         TransformerBlocks selected by moe_frequency. Exercises the
         EP-aware FSDP block wrap (Fix 5) on the VLM path.
         """
-        from kempnerforge.config.model import ModelConfig as _MC
         from kempnerforge.model.moe import MoEMLP
 
         torch.manual_seed(42 + dist.get_rank())
-        mc = _MC(
-            dim=256,
-            n_layers=4,
-            n_heads=4,
-            n_kv_heads=2,
-            vocab_size=32000,
-            max_seq_len=128,
-            num_experts=4,
-            moe_top_k=2,
-            moe_frequency=2,
-            vlm=CrossAttentionConfig(
-                vision_encoder="random",
-                feature_dim=96,
-                num_tokens=8,
+        cfg = (
+            ModelConfig(
+                dim=256,
+                n_layers=4,
+                n_heads=4,
+                n_kv_heads=2,
+                vocab_size=32000,
+                max_seq_len=128,
+                num_experts=4,
+                moe_top_k=2,
+                moe_frequency=2,
+            ),
+            VisionEncoderConfig(type="random", feature_dim=96, num_tokens=8),
+            AdapterConfig(),
+            CrossAttentionConfig(
                 max_text_len=64,
                 cross_attention_every_n_layers=2,
                 freeze=[FreezeSpec("vision_encoder", True)],
             ),
         )
-        wrapper = _build(mc, distributed_env, param_dtype=torch.float32)
+        mc = cfg[0]
+        wrapper = _build(cfg, distributed_env, param_dtype=torch.float32)
         # 4 layers, frequency=2 -> 2 MoE blocks; cadence=2 -> 2 CA blocks.
         moe_blocks = sum(
             1 for layer in wrapper.transformer.layers.values() if isinstance(layer.mlp, MoEMLP)
@@ -333,7 +335,7 @@ class TestCheckpointRoundtrip:
         ckpt_cfg = CheckpointConfig(dir=str(path_str), interval=1)
         mgr = CheckpointManager(ckpt_cfg, wrapper, opt)
         freeze = canonical_freeze_meta(
-            effective_freeze(0, cfg.vlm.freeze, cfg.vlm.freeze_schedule)  # type: ignore[union-attr]
+            effective_freeze(0, cfg[3].freeze, cfg[3].freeze_schedule)  # type: ignore[union-attr]
         )
         mgr.save(step=1, extra={"vlm_freeze": freeze})
         dist.barrier()

--- a/tests/distributed/test_vlm_fsdp.py
+++ b/tests/distributed/test_vlm_fsdp.py
@@ -21,8 +21,10 @@ import torch
 import torch.distributed as dist
 
 from kempnerforge.checkpoint.manager import CheckpointManager
+from kempnerforge.config.adapter import AdapterConfig
 from kempnerforge.config.model import ModelConfig
 from kempnerforge.config.schema import CheckpointConfig, OptimizerConfig
+from kempnerforge.config.vision import VisionEncoderConfig
 from kempnerforge.config.vlm import FreezeSpec, VLMConfig
 from kempnerforge.distributed.parallel import build_parallel_model
 from kempnerforge.model.vlm import VLMWrapper, inner_transformer
@@ -40,17 +42,12 @@ def _tiny_cfg(
     num_image_tokens: int = 8,
     feature_dim: int = 96,
     freeze: list[FreezeSpec] | None = None,
-) -> ModelConfig:
-    return ModelConfig(
-        dim=64,
-        n_layers=2,
-        n_heads=4,
-        vocab_size=256,
-        max_seq_len=128,
-        vlm=VLMConfig(
-            vision_encoder="random",
-            feature_dim=feature_dim,
-            num_tokens=num_image_tokens,
+) -> tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, VLMConfig]:
+    return (
+        ModelConfig(dim=64, n_layers=2, n_heads=4, vocab_size=256, max_seq_len=128),
+        VisionEncoderConfig(type="random", feature_dim=feature_dim, num_tokens=num_image_tokens),
+        AdapterConfig(),
+        VLMConfig(
             max_text_len=32,
             freeze=freeze if freeze is not None else [FreezeSpec("vision_encoder", True)],
         ),
@@ -58,16 +55,20 @@ def _tiny_cfg(
 
 
 def _build(
-    cfg: ModelConfig,
+    cfg: tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, VLMConfig],
     mesh,
     *,
     param_dtype: torch.dtype = torch.bfloat16,
     compile_model: bool = False,
 ) -> VLMWrapper:
+    mc, vc, ac, lc = cfg
     model = build_parallel_model(
-        cfg,
+        mc,
         device=torch.device("cuda"),
         device_mesh=mesh,
+        vision_config=vc,
+        adapter_config=ac,
+        vlm_config=lc,
         param_dtype=param_dtype,
         compile_model=compile_model,
     )

--- a/tests/distributed/test_vlm_mot_fsdp.py
+++ b/tests/distributed/test_vlm_mot_fsdp.py
@@ -30,8 +30,10 @@ import torch
 import torch.distributed as dist
 
 from kempnerforge.checkpoint.manager import CheckpointManager
+from kempnerforge.config.adapter import AdapterConfig
 from kempnerforge.config.model import ModelConfig
 from kempnerforge.config.schema import CheckpointConfig, OptimizerConfig
+from kempnerforge.config.vision import VisionEncoderConfig
 from kempnerforge.config.vlm import FreezeSpec, JointDecoderConfig, MoTConfig
 from kempnerforge.distributed.parallel import build_parallel_model
 from kempnerforge.model.mot import mot_warm_start_from_text_stack
@@ -57,21 +59,22 @@ def _tiny_mot_cfg(
     n_layers: int = 2,
     freeze: list[FreezeSpec] | None = None,
     moe: bool = False,
-) -> ModelConfig:
-    return ModelConfig(
-        dim=64,
-        n_layers=n_layers,
-        n_heads=4,
-        vocab_size=256,
-        max_seq_len=128,
-        ffn_hidden_dim=128,
-        num_experts=4 if moe else 0,
-        moe_top_k=2 if moe else 2,
-        moe_frequency=2 if moe else 1,
-        vlm=MoTConfig(
-            vision_encoder="random",
-            feature_dim=feature_dim,
-            num_tokens=num_image_tokens,
+) -> tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, MoTConfig]:
+    return (
+        ModelConfig(
+            dim=64,
+            n_layers=n_layers,
+            n_heads=4,
+            vocab_size=256,
+            max_seq_len=128,
+            ffn_hidden_dim=128,
+            num_experts=4 if moe else 0,
+            moe_top_k=2 if moe else 2,
+            moe_frequency=2 if moe else 1,
+        ),
+        VisionEncoderConfig(type="random", feature_dim=feature_dim, num_tokens=num_image_tokens),
+        AdapterConfig(),
+        MoTConfig(
             max_text_len=32,
             freeze=freeze if freeze is not None else [FreezeSpec("vision_encoder", True)],
         ),
@@ -79,16 +82,20 @@ def _tiny_mot_cfg(
 
 
 def _build(
-    cfg: ModelConfig,
+    cfg: tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, MoTConfig],
     mesh,
     *,
     param_dtype: torch.dtype = torch.bfloat16,
     compile_model: bool = False,
 ) -> VLMWrapper:
+    mc, vc, ac, lc = cfg
     model = build_parallel_model(
-        cfg,
+        mc,
         device=torch.device("cuda"),
         device_mesh=mesh,
+        vision_config=vc,
+        adapter_config=ac,
+        vlm_config=lc,
         param_dtype=param_dtype,
         compile_model=compile_model,
     )
@@ -213,7 +220,7 @@ class TestFreezeStageUnderFsdp:
         apply_freeze_specs(
             wrapper,
             [FreezeSpec("mot", False)],
-            cfg.vlm.module_patterns,  # type: ignore[union-attr]
+            cfg[3].module_patterns,  # type: ignore[union-attr]
         )
         for p in wrapper.parameters():
             p.grad = None
@@ -269,16 +276,18 @@ class TestWarmStartUnderFsdp:
 
         # Build a JD model with the same backbone shape, unwrap the FSDP
         # state on rank 0 via state_dict, broadcast a CPU dict to all ranks.
-        jd_cfg = ModelConfig(
-            dim=64,
-            n_layers=2,
-            n_heads=4,
-            vocab_size=256,
-            max_seq_len=128,
-            ffn_hidden_dim=128,
-            vlm=JointDecoderConfig(
-                vision_encoder="random", feature_dim=96, num_tokens=8, max_text_len=32
+        jd_cfg = (
+            ModelConfig(
+                dim=64,
+                n_layers=2,
+                n_heads=4,
+                vocab_size=256,
+                max_seq_len=128,
+                ffn_hidden_dim=128,
             ),
+            VisionEncoderConfig(type="random", feature_dim=96, num_tokens=8),
+            AdapterConfig(),
+            JointDecoderConfig(max_text_len=32),
         )
         jd_wrapper = _build(jd_cfg, mesh, param_dtype=torch.float32)
         jd_state_full = inner_transformer(jd_wrapper).state_dict()
@@ -308,7 +317,7 @@ class TestWarmStartUnderFsdp:
 
         # Per-modality copies equal source dense weights (gather first).
         mot_t = inner_transformer(mot_wrapper)
-        for i in range(mot_cfg.n_layers):
+        for i in range(mot_cfg[0].n_layers):
             for m in mot_t.layers[str(i)].modalities:  # type: ignore[union-attr]
                 w = mot_t.layers[str(i)].attn.q_proj[m].weight  # type: ignore[union-attr]
                 w_full = w.full_tensor() if hasattr(w, "full_tensor") else w
@@ -390,7 +399,7 @@ class TestCheckpointRoundtrip:
         ckpt_cfg = CheckpointConfig(dir=str(path_str), interval=1)
         mgr = CheckpointManager(ckpt_cfg, wrapper, opt)
         freeze = canonical_freeze_meta(
-            effective_freeze(0, cfg.vlm.freeze, cfg.vlm.freeze_schedule)  # type: ignore[union-attr]
+            effective_freeze(0, cfg[3].freeze, cfg[3].freeze_schedule)  # type: ignore[union-attr]
         )
         mgr.save(step=1, extra={"vlm_freeze": freeze})
         dist.barrier()

--- a/tests/integration/test_vlm_cross_attn.py
+++ b/tests/integration/test_vlm_cross_attn.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 import pytest
 import torch
 
+from kempnerforge.config.adapter import AdapterConfig
 from kempnerforge.config.model import ModelConfig
+from kempnerforge.config.vision import VisionEncoderConfig
 from kempnerforge.config.vlm import (
     CrossAttentionConfig,
     FreezeSpec,
@@ -36,23 +38,18 @@ pytestmark = pytest.mark.skipif(
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
-def _tiny_ca_config(
+def _tiny_ca_configs(
     *,
     num_image_tokens: int = 8,
     feature_dim: int = 96,
     cadence: int = 2,
     freeze: list[FreezeSpec] | None = None,
-) -> ModelConfig:
-    return ModelConfig(
-        dim=64,
-        n_layers=4,
-        n_heads=4,
-        vocab_size=256,
-        max_seq_len=128,
-        vlm=CrossAttentionConfig(
-            vision_encoder="random",
-            feature_dim=feature_dim,
-            num_tokens=num_image_tokens,
+) -> tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, CrossAttentionConfig]:
+    return (
+        ModelConfig(dim=64, n_layers=4, n_heads=4, vocab_size=256, max_seq_len=128),
+        VisionEncoderConfig(type="random", feature_dim=feature_dim, num_tokens=num_image_tokens),
+        AdapterConfig(),
+        CrossAttentionConfig(
             max_text_len=32,
             cross_attention_every_n_layers=cadence,
             freeze=freeze if freeze is not None else [FreezeSpec("vision_encoder", True)],
@@ -60,8 +57,21 @@ def _tiny_ca_config(
     )
 
 
-def _build(cfg: ModelConfig, *, param_dtype: torch.dtype = torch.bfloat16) -> VLMWrapper:
-    model = build_parallel_model(cfg, device=DEVICE, device_mesh=None, param_dtype=param_dtype)
+def _build(
+    configs: tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, CrossAttentionConfig],
+    *,
+    param_dtype: torch.dtype = torch.bfloat16,
+) -> VLMWrapper:
+    mc, vc, ac, lc = configs
+    model = build_parallel_model(
+        mc,
+        device=DEVICE,
+        device_mesh=None,
+        vision_config=vc,
+        adapter_config=ac,
+        vlm_config=lc,
+        param_dtype=param_dtype,
+    )
     assert isinstance(model, VLMWrapper)
     return model
 
@@ -80,7 +90,7 @@ def _dummy_batch(
 class TestBuildAndForward:
     def test_build_and_forward_1gpu(self):
         """Tiny CA config builds on a single GPU; forward + backward run."""
-        cfg = _tiny_ca_config()
+        cfg = _tiny_ca_configs()
         wrapper = _build(cfg)
         assert isinstance(wrapper, VLMWrapper)
         # CA arch: residual stream is text-only.
@@ -90,7 +100,7 @@ class TestBuildAndForward:
 
         pixels, input_ids, labels = _dummy_batch(wrapper)
         logits, _ = wrapper(pixels, input_ids, labels)
-        assert logits.shape == (2, 16, cfg.vocab_size)
+        assert logits.shape == (2, 16, cfg[0].vocab_size)
         loss = logits.float().sum()
         loss.backward()
         # Adapter and CA layers receive gradients (encoder is frozen).
@@ -111,7 +121,7 @@ class TestBuildAndForward:
         """`FreezeSpec("cross_attention")` freezes only CA params and
         leaves the rest of the transformer trainable.
         """
-        cfg = _tiny_ca_config(freeze=[FreezeSpec("cross_attention", True)])
+        cfg = _tiny_ca_configs(freeze=[FreezeSpec("cross_attention", True)])
         wrapper = _build(cfg)
         trainable = {name for name, p in wrapper.named_parameters() if p.requires_grad}
         frozen = {name for name, p in wrapper.named_parameters() if not p.requires_grad}
@@ -132,7 +142,7 @@ class TestBuildAndForward:
         sees it. The test asserts (a) build with bf16 param_dtype works,
         (b) forward output is bf16, (c) no dtype-mismatch errors.
         """
-        cfg = _tiny_ca_config()
+        cfg = _tiny_ca_configs()
         wrapper = _build(cfg, param_dtype=torch.bfloat16)
         # Adapter params are bf16; encoder is in HF default (fp32).
         assert wrapper.adapter.proj1.weight.dtype == torch.bfloat16
@@ -145,7 +155,7 @@ class TestBuildAndForward:
         """torch.compile(wrapper) output matches eager output within
         a small tolerance. Catches compile-graph divergence in the
         CA-interleaved forward path."""
-        cfg = _tiny_ca_config()
+        cfg = _tiny_ca_configs()
         wrapper = _build(cfg, param_dtype=torch.float32)  # fp32 for tighter comparison
         wrapper.eval()
         pixels, input_ids, _ = _dummy_batch(wrapper, batch=1, text_len=8)
@@ -167,14 +177,14 @@ class TestFreezeStageHook:
         idempotent: running effective_freeze + apply_freeze_specs at the
         boundary matches the on-the-fly hook in scripts/train.py.
         """
-        cfg = _tiny_ca_config(
+        cfg = _tiny_ca_configs(
             freeze=[
                 FreezeSpec("vision_encoder", True),
                 FreezeSpec("adapter", False),
             ],
         )
         # Schedule: at step 3, freeze adapter. At step 7, unfreeze adapter.
-        cfg.vlm.freeze_schedule = [
+        cfg[3].freeze_schedule = [
             FreezeStage(start_step=3, specs=(FreezeSpec("adapter", True),)),
             FreezeStage(start_step=7, specs=(FreezeSpec("adapter", False),)),
         ]
@@ -187,14 +197,14 @@ class TestFreezeStageHook:
             assert p.requires_grad
 
         # At step 3: apply effective_freeze and confirm adapter is frozen.
-        specs = effective_freeze(3, cfg.vlm.freeze, cfg.vlm.freeze_schedule)
-        apply_freeze_specs(wrapper, specs, cfg.vlm.module_patterns)
+        specs = effective_freeze(3, cfg[3].freeze, cfg[3].freeze_schedule)
+        apply_freeze_specs(wrapper, specs, cfg[3].module_patterns)
         for p in adapter_params:
             assert not p.requires_grad
 
         # At step 7: unfreeze.
-        specs = effective_freeze(7, cfg.vlm.freeze, cfg.vlm.freeze_schedule)
-        apply_freeze_specs(wrapper, specs, cfg.vlm.module_patterns)
+        specs = effective_freeze(7, cfg[3].freeze, cfg[3].freeze_schedule)
+        apply_freeze_specs(wrapper, specs, cfg[3].module_patterns)
         for p in adapter_params:
             assert p.requires_grad
 
@@ -204,7 +214,7 @@ class TestFreezeStageHook:
         Frozen-adapter weights are bit-identical across optimizer steps
         even when weight_decay is non-zero.
         """
-        cfg = _tiny_ca_config(freeze=[FreezeSpec("adapter", True)])
+        cfg = _tiny_ca_configs(freeze=[FreezeSpec("adapter", True)])
         wrapper = _build(cfg, param_dtype=torch.float32)
 
         # Snapshot adapter weights before the optimizer step.
@@ -240,7 +250,7 @@ class TestFreezeStageHook:
         """A model's state_dict round-trips with bit-equal forward
         output. Catches missing buffer registration, persistent vs
         non-persistent buffer mistakes, etc."""
-        cfg = _tiny_ca_config()
+        cfg = _tiny_ca_configs()
         wrapper_a = _build(cfg, param_dtype=torch.float32)
         wrapper_a.eval()
         pixels, input_ids, _ = _dummy_batch(wrapper_a, batch=1, text_len=8)
@@ -263,18 +273,11 @@ class TestFreezeStageHook:
         """Sanity: a JD state_dict round-trips into a JD-built wrapper
         without missing/unexpected keys.
         """
-        cfg = ModelConfig(
-            dim=64,
-            n_layers=2,
-            n_heads=4,
-            vocab_size=256,
-            max_seq_len=128,
-            vlm=JointDecoderConfig(
-                vision_encoder="random",
-                feature_dim=96,
-                num_tokens=8,
-                max_text_len=32,
-            ),
+        cfg = (
+            ModelConfig(dim=64, n_layers=2, n_heads=4, vocab_size=256, max_seq_len=128),
+            VisionEncoderConfig(type="random", feature_dim=96, num_tokens=8),
+            AdapterConfig(),
+            JointDecoderConfig(max_text_len=32),
         )
         wrapper_a = _build(cfg)
         state = wrapper_a.state_dict()
@@ -289,20 +292,13 @@ class TestFreezeStageHook:
         (CA layers stay at their construction defaults, which for Wo
         is zero -> identity at init), and the resulting model is
         functional for forward."""
-        jd_cfg = ModelConfig(
-            dim=64,
-            n_layers=4,
-            n_heads=4,
-            vocab_size=256,
-            max_seq_len=128,
-            vlm=JointDecoderConfig(
-                vision_encoder="random",
-                feature_dim=96,
-                num_tokens=8,
-                max_text_len=32,
-            ),
+        jd_cfg = (
+            ModelConfig(dim=64, n_layers=4, n_heads=4, vocab_size=256, max_seq_len=128),
+            VisionEncoderConfig(type="random", feature_dim=96, num_tokens=8),
+            AdapterConfig(),
+            JointDecoderConfig(max_text_len=32),
         )
-        ca_cfg = _tiny_ca_config(num_image_tokens=8, feature_dim=96, cadence=2)
+        ca_cfg = _tiny_ca_configs(num_image_tokens=8, feature_dim=96, cadence=2)
 
         jd_wrapper = _build(jd_cfg)
         ca_wrapper = _build(ca_cfg)
@@ -329,25 +325,25 @@ class TestFreezeStageHook:
         (typo in TOML, e.g., "adaptor" instead of "adapter") must raise
         at training-loop start so the user can fix the typo before
         wasting compute. effective_freeze validates against
-        mc.vlm.module_patterns keys when the training loop calls it
+        vlm_cfg.module_patterns keys when the training loop calls it
         with valid_modules set.
         """
-        cfg = _tiny_ca_config()
+        cfg = _tiny_ca_configs()
         # FreezeStage with a typo'd module alias: "adaptor" not in
         # module_patterns ({transformer, vision_encoder, adapter,
         # cross_attention} for CrossAttentionConfig).
-        cfg.vlm.freeze_schedule = [
+        cfg[3].freeze_schedule = [
             FreezeStage(start_step=5, specs=(FreezeSpec("adaptor", True),)),
         ]
         # The validation fires when effective_freeze is called with
         # valid_modules=set(module_patterns.keys()), which scripts/train.py
         # does at every save and at resume.
-        valid_modules = set(cfg.vlm.module_patterns.keys())
+        valid_modules = set(cfg[3].module_patterns.keys())
         with pytest.raises(ValueError, match="adaptor"):
             effective_freeze(
                 step=10,
-                base=cfg.vlm.freeze,
-                schedule=cfg.vlm.freeze_schedule,
+                base=cfg[3].freeze,
+                schedule=cfg[3].freeze_schedule,
                 valid_modules=valid_modules,
             )
 
@@ -362,20 +358,21 @@ class TestFreezeStageHook:
         """
         from kempnerforge.model.vlm import inner_transformer
 
-        cfg = ModelConfig(
-            dim=64,
-            n_layers=4,
-            n_heads=4,
-            n_kv_heads=2,
-            vocab_size=256,
-            max_seq_len=128,
-            num_experts=4,
-            moe_top_k=2,
-            moe_frequency=2,
-            vlm=CrossAttentionConfig(
-                vision_encoder="random",
-                feature_dim=96,
-                num_tokens=8,
+        cfg = (
+            ModelConfig(
+                dim=64,
+                n_layers=4,
+                n_heads=4,
+                n_kv_heads=2,
+                vocab_size=256,
+                max_seq_len=128,
+                num_experts=4,
+                moe_top_k=2,
+                moe_frequency=2,
+            ),
+            VisionEncoderConfig(type="random", feature_dim=96, num_tokens=8),
+            AdapterConfig(),
+            CrossAttentionConfig(
                 max_text_len=32,
                 cross_attention_every_n_layers=2,
                 freeze=[FreezeSpec("vision_encoder", True)],
@@ -396,14 +393,14 @@ class TestFreezeStageHook:
         loss_fn = torch.nn.CrossEntropyLoss()
         torch.manual_seed(0)
         pixels = torch.randn(2, 3, 32, 32, device=DEVICE)
-        input_ids = torch.randint(0, cfg.vocab_size, (2, 16), device=DEVICE)
+        input_ids = torch.randint(0, cfg[0].vocab_size, (2, 16), device=DEVICE)
 
         inner = inner_transformer(wrapper)
         losses = []
         for step in range(5):
             inner.set_moe_step(step, max_steps=100)  # type: ignore[attr-defined]
             logits, _ = wrapper(pixels, input_ids, input_ids)
-            ce = loss_fn(logits.reshape(-1, cfg.vocab_size), input_ids.reshape(-1))
+            ce = loss_fn(logits.reshape(-1, cfg[0].vocab_size), input_ids.reshape(-1))
             aux = inner.get_moe_aux_loss()  # type: ignore[attr-defined]
             loss = ce + 0.01 * aux
             loss.backward()
@@ -430,7 +427,7 @@ class TestFreezeStageHook:
         functionally ignored" failure mode.
         """
         torch.manual_seed(0)
-        cfg = _tiny_ca_config(num_image_tokens=8, feature_dim=96, cadence=2)
+        cfg = _tiny_ca_configs(num_image_tokens=8, feature_dim=96, cadence=2)
         wrapper = _build(cfg, param_dtype=torch.float32)
         wrapper.train()
 
@@ -444,17 +441,17 @@ class TestFreezeStageHook:
         # could match if labels were random.
         input_ids_dataset = torch.zeros(n_pairs, text_len, dtype=torch.long, device=DEVICE)
         for i in range(n_pairs):
-            seed_val = int(pixels_dataset[i].sum().item() * 1000) % cfg.vocab_size
-            input_ids_dataset[i] = (
-                torch.arange(text_len, device=DEVICE) + seed_val
-            ) % cfg.vocab_size
+            seed_val = int(pixels_dataset[i].sum().item() * 1000) % cfg[0].vocab_size
+            input_ids_dataset[i] = (torch.arange(text_len, device=DEVICE) + seed_val) % cfg[
+                0
+            ].vocab_size
 
         optimizer = torch.optim.AdamW(wrapper.parameters(), lr=3e-3)
         loss_fn = torch.nn.CrossEntropyLoss(ignore_index=-100)
 
         def _train_step(pixels, input_ids, labels):
             logits, _ = wrapper(pixels, input_ids, labels)
-            loss = loss_fn(logits.reshape(-1, cfg.vocab_size), labels.reshape(-1))
+            loss = loss_fn(logits.reshape(-1, cfg[0].vocab_size), labels.reshape(-1))
             return loss
 
         # Initial loss: forward over the full mini-dataset.

--- a/tests/integration/test_vlm_mot.py
+++ b/tests/integration/test_vlm_mot.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 import pytest
 import torch
 
+from kempnerforge.config.adapter import AdapterConfig
 from kempnerforge.config.model import ModelConfig
+from kempnerforge.config.vision import VisionEncoderConfig
 from kempnerforge.config.vlm import (
     FreezeSpec,
     FreezeStage,
@@ -32,36 +34,50 @@ pytestmark = pytest.mark.skipif(
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
-def _tiny_mot_config(
+def _tiny_mot_configs(
     *,
     num_image_tokens: int = 8,
     feature_dim: int = 96,
     n_layers: int = 2,
     freeze: list[FreezeSpec] | None = None,
     moe: bool = False,
-) -> ModelConfig:
-    return ModelConfig(
-        dim=64,
-        n_layers=n_layers,
-        n_heads=4,
-        vocab_size=256,
-        max_seq_len=128,
-        ffn_hidden_dim=128,
-        num_experts=4 if moe else 0,
-        moe_top_k=2 if moe else 2,
-        moe_frequency=2 if moe else 1,
-        vlm=MoTConfig(
-            vision_encoder="random",
-            feature_dim=feature_dim,
-            num_tokens=num_image_tokens,
+) -> tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, MoTConfig]:
+    return (
+        ModelConfig(
+            dim=64,
+            n_layers=n_layers,
+            n_heads=4,
+            vocab_size=256,
+            max_seq_len=128,
+            ffn_hidden_dim=128,
+            num_experts=4 if moe else 0,
+            moe_top_k=2 if moe else 2,
+            moe_frequency=2 if moe else 1,
+        ),
+        VisionEncoderConfig(type="random", feature_dim=feature_dim, num_tokens=num_image_tokens),
+        AdapterConfig(),
+        MoTConfig(
             max_text_len=32,
             freeze=freeze if freeze is not None else [FreezeSpec("vision_encoder", True)],
         ),
     )
 
 
-def _build(cfg: ModelConfig, *, param_dtype: torch.dtype = torch.bfloat16) -> VLMWrapper:
-    model = build_parallel_model(cfg, device=DEVICE, device_mesh=None, param_dtype=param_dtype)
+def _build(
+    configs: tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, MoTConfig],
+    *,
+    param_dtype: torch.dtype = torch.bfloat16,
+) -> VLMWrapper:
+    mc, vc, ac, lc = configs
+    model = build_parallel_model(
+        mc,
+        device=DEVICE,
+        device_mesh=None,
+        vision_config=vc,
+        adapter_config=ac,
+        vlm_config=lc,
+        param_dtype=param_dtype,
+    )
     assert isinstance(model, VLMWrapper)
     return model
 
@@ -82,7 +98,7 @@ class TestBuildAndForward:
         """Tiny MoT config builds on a single GPU; forward + backward run."""
         from kempnerforge.model.mot import MoTBlock
 
-        cfg = _tiny_mot_config()
+        cfg = _tiny_mot_configs()
         wrapper = _build(cfg)
         assert isinstance(wrapper, VLMWrapper)
         # MoT extends the residual stream with num_image_tokens.
@@ -93,7 +109,7 @@ class TestBuildAndForward:
         pixels, input_ids, labels = _dummy_batch(wrapper)
         logits, _ = wrapper(pixels, input_ids, labels)
         # output_slice trims the 8 image positions; logits cover text_len positions.
-        assert logits.shape == (2, 16, cfg.vocab_size)
+        assert logits.shape == (2, 16, cfg[0].vocab_size)
         # Re-init per-modality o_proj / down_proj so backward exercises Q/K/V grads.
         with torch.no_grad():
             for layer in wrapper.transformer.layers.values():
@@ -121,7 +137,7 @@ class TestBuildAndForward:
         (transformer.layers.*) and leaves the adapter and final norms
         trainable.
         """
-        cfg = _tiny_mot_config(freeze=[FreezeSpec("mot", True)])
+        cfg = _tiny_mot_configs(freeze=[FreezeSpec("mot", True)])
         wrapper = _build(cfg)
         trainable = {name for name, p in wrapper.named_parameters() if p.requires_grad}
         frozen = {name for name, p in wrapper.named_parameters() if not p.requires_grad}
@@ -143,7 +159,7 @@ class TestBuildAndForward:
         block sees it. Asserts (a) build with bf16 param_dtype works,
         (b) forward output is bf16, (c) no dtype-mismatch errors.
         """
-        cfg = _tiny_mot_config()
+        cfg = _tiny_mot_configs()
         wrapper = _build(cfg, param_dtype=torch.bfloat16)
         assert wrapper.adapter.proj1.weight.dtype == torch.bfloat16
         pixels, input_ids, _ = _dummy_batch(wrapper)
@@ -154,7 +170,7 @@ class TestBuildAndForward:
         """torch.compile(wrapper) output matches eager output within a
         small tolerance. Catches compile-graph divergence on the MoT
         per-modality forward path."""
-        cfg = _tiny_mot_config()
+        cfg = _tiny_mot_configs()
         wrapper = _build(cfg, param_dtype=torch.float32)
         wrapper.eval()
         pixels, input_ids, _ = _dummy_batch(wrapper, batch=1, text_len=8)
@@ -170,7 +186,7 @@ class TestBuildAndForward:
 
     def test_save_load_forward_parity(self):
         """state_dict round-trips with bit-equal forward output."""
-        cfg = _tiny_mot_config()
+        cfg = _tiny_mot_configs()
         wrapper_a = _build(cfg, param_dtype=torch.float32)
         wrapper_a.eval()
         pixels, input_ids, _ = _dummy_batch(wrapper_a, batch=1, text_len=8)
@@ -196,7 +212,7 @@ class TestMoTPlusMoESmoke:
         from kempnerforge.model.moe import MoEMLP
         from kempnerforge.model.mot import MoTBlock
 
-        cfg = _tiny_mot_config(moe=True, n_layers=2)
+        cfg = _tiny_mot_configs(moe=True, n_layers=2)
         wrapper = _build(cfg)
         # Layer 1 (i=1, (i+1) % moe_frequency == 0) has MoE FFNs per modality.
         layer1 = wrapper.transformer.layers["1"]
@@ -210,11 +226,11 @@ class TestMoTPlusMoESmoke:
 
         pixels, input_ids, labels = _dummy_batch(wrapper)
         logits, _ = wrapper(pixels, input_ids, labels)
-        assert logits.shape == (2, 16, cfg.vocab_size)
+        assert logits.shape == (2, 16, cfg[0].vocab_size)
         assert torch.isfinite(logits).all()
 
     def test_mot_plus_moe_backward_1gpu(self):
-        cfg = _tiny_mot_config(moe=True, n_layers=2)
+        cfg = _tiny_mot_configs(moe=True, n_layers=2)
         wrapper = _build(cfg, param_dtype=torch.float32)
         with torch.no_grad():
             for layer in wrapper.transformer.layers.values():
@@ -251,19 +267,18 @@ class TestWarmStartFromJD:
         from kempnerforge.model.vlm import inner_transformer
 
         # Build a JD model with the same backbone shape and dump its state.
-        jd_cfg = ModelConfig(
-            dim=64,
-            n_layers=2,
-            n_heads=4,
-            vocab_size=256,
-            max_seq_len=128,
-            ffn_hidden_dim=128,
-            vlm=JointDecoderConfig(
-                vision_encoder="random",
-                feature_dim=96,
-                num_tokens=8,
-                max_text_len=32,
+        jd_cfg = (
+            ModelConfig(
+                dim=64,
+                n_layers=2,
+                n_heads=4,
+                vocab_size=256,
+                max_seq_len=128,
+                ffn_hidden_dim=128,
             ),
+            VisionEncoderConfig(type="random", feature_dim=96, num_tokens=8),
+            AdapterConfig(),
+            JointDecoderConfig(max_text_len=32),
         )
         jd_wrapper = _build(jd_cfg, param_dtype=torch.float32)
         jd_state = inner_transformer(jd_wrapper).state_dict()
@@ -271,7 +286,7 @@ class TestWarmStartFromJD:
         torch.save(jd_state, ckpt_path)
 
         # Build a MoT model and run the warm-start helper.
-        mot_cfg = _tiny_mot_config(num_image_tokens=8, n_layers=2)
+        mot_cfg = _tiny_mot_configs(num_image_tokens=8, n_layers=2)
         mot_wrapper = _build(mot_cfg, param_dtype=torch.float32)
         source = torch.load(ckpt_path, map_location="cpu", weights_only=True)
         mot_warm_start_from_text_stack(inner_transformer(mot_wrapper), source)
@@ -279,7 +294,7 @@ class TestWarmStartFromJD:
         # Per-modality copies equal the source dense weights. (Compare via
         # the on-disk CPU state to avoid cross-device tensor compares.)
         mot_t = inner_transformer(mot_wrapper)
-        for i in range(mot_cfg.n_layers):
+        for i in range(mot_cfg[0].n_layers):
             for m in mot_t.layers[str(i)].modalities:  # type: ignore[union-attr]
                 assert torch.equal(
                     mot_t.layers[str(i)].attn.q_proj[m].weight.cpu(),  # type: ignore[union-attr]
@@ -296,23 +311,25 @@ class TestWarmStartFromJD:
         from kempnerforge.model.mot import mot_warm_start_from_text_stack
         from kempnerforge.model.vlm import inner_transformer
 
-        jd_cfg = ModelConfig(
-            dim=64,
-            n_layers=2,
-            n_heads=4,
-            vocab_size=256,
-            max_seq_len=128,
-            ffn_hidden_dim=128,
-            vlm=JointDecoderConfig(
-                vision_encoder="random", feature_dim=96, num_tokens=8, max_text_len=32
+        jd_cfg = (
+            ModelConfig(
+                dim=64,
+                n_layers=2,
+                n_heads=4,
+                vocab_size=256,
+                max_seq_len=128,
+                ffn_hidden_dim=128,
             ),
+            VisionEncoderConfig(type="random", feature_dim=96, num_tokens=8),
+            AdapterConfig(),
+            JointDecoderConfig(max_text_len=32),
         )
         jd_wrapper = _build(jd_cfg, param_dtype=torch.float32)
         jd_state = inner_transformer(jd_wrapper).state_dict()
         ckpt_path = tmp_path / "jd_ckpt.pt"
         torch.save(jd_state, ckpt_path)
 
-        mot_cfg = _tiny_mot_config(num_image_tokens=8, n_layers=2)
+        mot_cfg = _tiny_mot_configs(num_image_tokens=8, n_layers=2)
         mot_wrapper = _build(mot_cfg, param_dtype=torch.float32)
         source = torch.load(ckpt_path, map_location="cpu", weights_only=True)
         mot_warm_start_from_text_stack(inner_transformer(mot_wrapper), source)
@@ -325,13 +342,13 @@ class TestWarmStartFromJD:
 class TestFreezeStageHook:
     def test_freeze_schedule_transitions(self):
         """Schedule that freezes 'mot' at step 3 and unfreezes at step 7."""
-        cfg = _tiny_mot_config(
+        cfg = _tiny_mot_configs(
             freeze=[
                 FreezeSpec("vision_encoder", True),
                 FreezeSpec("mot", False),
             ],
         )
-        cfg.vlm.freeze_schedule = [  # type: ignore[union-attr]
+        cfg[3].freeze_schedule = [  # type: ignore[union-attr]
             FreezeStage(start_step=3, specs=(FreezeSpec("mot", True),)),
             FreezeStage(start_step=7, specs=(FreezeSpec("mot", False),)),
         ]
@@ -346,13 +363,13 @@ class TestFreezeStageHook:
             assert p.requires_grad
 
         # Step 3: layers frozen.
-        specs = effective_freeze(3, cfg.vlm.freeze, cfg.vlm.freeze_schedule)  # type: ignore[union-attr]
-        apply_freeze_specs(wrapper, specs, cfg.vlm.module_patterns)  # type: ignore[union-attr]
+        specs = effective_freeze(3, cfg[3].freeze, cfg[3].freeze_schedule)  # type: ignore[union-attr]
+        apply_freeze_specs(wrapper, specs, cfg[3].module_patterns)  # type: ignore[union-attr]
         for p in layer_params:
             assert not p.requires_grad
 
         # Step 7: layers trainable again.
-        specs = effective_freeze(7, cfg.vlm.freeze, cfg.vlm.freeze_schedule)  # type: ignore[union-attr]
-        apply_freeze_specs(wrapper, specs, cfg.vlm.module_patterns)  # type: ignore[union-attr]
+        specs = effective_freeze(7, cfg[3].freeze, cfg[3].freeze_schedule)  # type: ignore[union-attr]
+        apply_freeze_specs(wrapper, specs, cfg[3].module_patterns)  # type: ignore[union-attr]
         for p in layer_params:
             assert p.requires_grad

--- a/tests/integration/test_vlm_train_step.py
+++ b/tests/integration/test_vlm_train_step.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 import pytest
 import torch
 
+from kempnerforge.config.adapter import AdapterConfig
 from kempnerforge.config.model import ModelConfig
 from kempnerforge.config.schema import OptimizerConfig
+from kempnerforge.config.vision import VisionEncoderConfig
 from kempnerforge.config.vlm import FreezeSpec, VLMConfig
 from kempnerforge.distributed.parallel import build_parallel_model
 from kempnerforge.model.vlm import VLMWrapper, inner_transformer
@@ -30,33 +32,36 @@ pytestmark = pytest.mark.skipif(
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
-def _tiny_vlm_config(
+def _tiny_vlm_configs(
     *,
     num_image_tokens: int = 8,
     feature_dim: int = 96,
     freeze: list[FreezeSpec] | None = None,
-) -> ModelConfig:
-    return ModelConfig(
-        dim=64,
-        n_layers=2,
-        n_heads=4,
-        vocab_size=256,
-        max_seq_len=128,
-        vlm=VLMConfig(
-            vision_encoder="random",
-            feature_dim=feature_dim,
-            num_tokens=num_image_tokens,
+) -> tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, VLMConfig]:
+    return (
+        ModelConfig(dim=64, n_layers=2, n_heads=4, vocab_size=256, max_seq_len=128),
+        VisionEncoderConfig(type="random", feature_dim=feature_dim, num_tokens=num_image_tokens),
+        AdapterConfig(),
+        VLMConfig(
             max_text_len=32,
             freeze=freeze if freeze is not None else [FreezeSpec("vision_encoder", True)],
         ),
     )
 
 
-def _build(cfg: ModelConfig, *, param_dtype: torch.dtype = torch.bfloat16) -> VLMWrapper:
+def _build(
+    configs: tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, VLMConfig],
+    *,
+    param_dtype: torch.dtype = torch.bfloat16,
+) -> VLMWrapper:
+    mc, vc, ac, lc = configs
     model = build_parallel_model(
-        cfg,
+        mc,
         device=DEVICE,
         device_mesh=None,
+        vision_config=vc,
+        adapter_config=ac,
+        vlm_config=lc,
         param_dtype=param_dtype,
     )
     assert isinstance(model, VLMWrapper)
@@ -84,13 +89,13 @@ def _dummy_batch(
 class TestBuild:
     def test_meta_device_build_no_oom(self):
         """Tiny VLM config builds on a single GPU."""
-        cfg = _tiny_vlm_config()
+        cfg = _tiny_vlm_configs()
         wrapper = _build(cfg)
         assert isinstance(wrapper, VLMWrapper)
         assert wrapper.num_image_tokens == 8
 
     def test_build_respects_freeze(self):
-        cfg = _tiny_vlm_config(freeze=[FreezeSpec("vision_encoder", True)])
+        cfg = _tiny_vlm_configs(freeze=[FreezeSpec("vision_encoder", True)])
         wrapper = _build(cfg)
         trainable = {name for name, p in wrapper.named_parameters() if p.requires_grad}
         frozen = {name for name, p in wrapper.named_parameters() if not p.requires_grad}
@@ -101,7 +106,7 @@ class TestBuild:
         assert any(n.startswith("transformer") for n in trainable)
 
     def test_encoder_in_eval_when_frozen(self):
-        wrapper = _build(_tiny_vlm_config())
+        wrapper = _build(_tiny_vlm_configs())
         assert wrapper.vision_encoder.training is False
         # Transformer and adapter remain in train mode (default for nn.Module).
         assert wrapper.transformer.training is True
@@ -112,7 +117,7 @@ class TestDtypePolicy:
     def test_frozen_encoder_not_cast_to_bf16(self):
         """Transformer and adapter are bf16, vision encoder stays in its
         HF dtype (fp32 for RandomVisionEncoder). D16."""
-        cfg = _tiny_vlm_config()
+        cfg = _tiny_vlm_configs()
         wrapper = _build(cfg, param_dtype=torch.bfloat16)
         # Transformer / adapter are bf16.
         for p in wrapper.transformer.parameters():
@@ -126,7 +131,7 @@ class TestDtypePolicy:
 
 class TestForward:
     def test_one_step_loss_finite(self):
-        cfg = _tiny_vlm_config()
+        cfg = _tiny_vlm_configs()
         wrapper = _build(cfg)
         optimizer = build_optimizer(wrapper, OptimizerConfig(lr=1e-3, fused=False))
 
@@ -139,18 +144,18 @@ class TestForward:
         assert torch.isfinite(loss).item()
 
     def test_logits_shape_matches_text_only(self):
-        cfg = _tiny_vlm_config(num_image_tokens=8)
+        cfg = _tiny_vlm_configs(num_image_tokens=8)
         wrapper = _build(cfg)
         pixels, input_ids, _ = _dummy_batch(wrapper, text_len=20)
         logits, _ = wrapper(pixels, input_ids, None)
         # output_slice drops image positions; (B, T, V) not (B, N+T, V).
-        assert logits.shape == (2, 20, cfg.vocab_size)
+        assert logits.shape == (2, 20, cfg[0].vocab_size)
 
     def test_vlm_all_pad_batch_no_nan(self):
         """Every label is -100: kempnerforge.training.loss.cross_entropy_loss
         short-circuits to 0.0 (no NaN), backward is skipped (no grad graph),
         and a subsequent real step still updates params."""
-        cfg = _tiny_vlm_config()
+        cfg = _tiny_vlm_configs()
         wrapper = _build(cfg)
         optimizer = build_optimizer(wrapper, OptimizerConfig(lr=1e-3, fused=False))
 
@@ -184,7 +189,7 @@ class TestOverfit:
     def test_adapter_changes_frozen_encoder_stays(self):
         """After 10 steps on a fixed batch, adapter + transformer params
         drift and the frozen encoder parameters are bit-equal."""
-        cfg = _tiny_vlm_config()
+        cfg = _tiny_vlm_configs()
         wrapper = _build(cfg)
         optimizer = build_optimizer(wrapper, OptimizerConfig(lr=1e-2, fused=False))
 
@@ -209,7 +214,7 @@ class TestOverfit:
 class TestInnerTransformer:
     def test_unwrap_reaches_moe_methods(self):
         """inner_transformer is usable under the real build path."""
-        wrapper = _build(_tiny_vlm_config())
+        wrapper = _build(_tiny_vlm_configs())
         inner = inner_transformer(wrapper)
         assert inner is wrapper.transformer
         # set_moe_step is a no-op on a dense model but must resolve.
@@ -221,7 +226,7 @@ class TestTokenAccounting:
         """scripts/train.py measures 'text_tokens_trained' as
         (labels != -100).sum(). Verify the math matches what the
         train-loop VLM branch would compute."""
-        cfg = _tiny_vlm_config(num_image_tokens=8)
+        cfg = _tiny_vlm_configs(num_image_tokens=8)
         wrapper = _build(cfg)
         pixels, input_ids, labels = _dummy_batch(wrapper, batch=3, text_len=16)
         # Manually mask half of labels as -100 (mimics prompt + pad masking).
@@ -233,7 +238,7 @@ class TestTokenAccounting:
         # 3 rows * 8 non-masked positions = 24
         assert n_tokens == 24
         # Logits cover text positions, not image positions.
-        assert logits.shape == (3, 16, cfg.vocab_size)
+        assert logits.shape == (3, 16, cfg[0].vocab_size)
 
 
 class TestValidation:
@@ -241,20 +246,18 @@ class TestValidation:
         """If max_seq_len < num_image_tokens + max_text_len, build_parallel_model
         raises even when num_tokens is resolved at build time (e.g.
         encoder exposes a different value than the config asserts)."""
-        # Trick: pass num_tokens=0 so the ModelConfig-time check is skipped,
+        # Trick: pass num_tokens=0 so the JobConfig-time check is skipped,
         # but the encoder default (num_tokens=16) will exceed max_seq_len.
-        cfg = ModelConfig(
-            dim=64,
-            n_layers=2,
-            n_heads=4,
-            vocab_size=256,
-            max_seq_len=20,  # 16 image + 32 text = 48 > 20
-            vlm=VLMConfig(
-                vision_encoder="random",
-                feature_dim=0,
-                num_tokens=0,
-                max_text_len=32,
-            ),
-        )
+        mc = ModelConfig(dim=64, n_layers=2, n_heads=4, vocab_size=256, max_seq_len=20)
+        vc = VisionEncoderConfig(type="random", feature_dim=0, num_tokens=0)
+        ac = AdapterConfig()
+        lc = VLMConfig(max_text_len=32)  # 16 image + 32 text = 48 > 20
         with pytest.raises(ValueError, match="insufficient"):
-            build_parallel_model(cfg, device=DEVICE, device_mesh=None)
+            build_parallel_model(
+                mc,
+                device=DEVICE,
+                device_mesh=None,
+                vision_config=vc,
+                adapter_config=ac,
+                vlm_config=lc,
+            )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,6 +9,7 @@ from kempnerforge.config.loader import _parse_cli_overrides
 from kempnerforge.config.registry import Registry
 from kempnerforge.config.schema import (
     ActivationCheckpointing,
+    AdapterConfig,
     AsyncCheckpointMode,
     CheckpointConfig,
     DataConfig,
@@ -20,6 +21,7 @@ from kempnerforge.config.schema import (
     SchedulerConfig,
     SchedulerType,
     TrainConfig,
+    VisionEncoderConfig,
     VLMConfig,
 )
 
@@ -366,10 +368,10 @@ class TestJobConfig:
 
     def test_validate_vlm_seq_len_too_short(self):
         config = JobConfig(
-            model=ModelConfig(
-                max_seq_len=1024,
-                vlm=VLMConfig(vision_encoder="random", num_tokens=64, max_text_len=512),
-            ),
+            model=ModelConfig(max_seq_len=1024),
+            vision_encoder=VisionEncoderConfig(type="random", num_tokens=64),
+            adapter=AdapterConfig(),
+            vlm=VLMConfig(max_text_len=512),
             train=TrainConfig(seq_len=100),
         )
         with pytest.raises(ValueError, match="train.seq_len.*insufficient for VLM"):
@@ -377,10 +379,10 @@ class TestJobConfig:
 
     def test_validate_vlm_pp_rejected(self):
         config = JobConfig(
-            model=ModelConfig(
-                max_seq_len=1024,
-                vlm=VLMConfig(vision_encoder="random", num_tokens=64, max_text_len=512),
-            ),
+            model=ModelConfig(max_seq_len=1024),
+            vision_encoder=VisionEncoderConfig(type="random", num_tokens=64),
+            adapter=AdapterConfig(),
+            vlm=VLMConfig(max_text_len=512),
             train=TrainConfig(seq_len=600),
             distributed=DistributedConfig(pp=2, dp_shard=1),
         )
@@ -389,10 +391,10 @@ class TestJobConfig:
 
     def test_validate_vlm_num_tokens_zero_defers(self):
         config = JobConfig(
-            model=ModelConfig(
-                max_seq_len=1024,
-                vlm=VLMConfig(vision_encoder="random", num_tokens=0, max_text_len=512),
-            ),
+            model=ModelConfig(max_seq_len=1024),
+            vision_encoder=VisionEncoderConfig(type="random", num_tokens=0),
+            adapter=AdapterConfig(),
+            vlm=VLMConfig(max_text_len=512),
             train=TrainConfig(seq_len=64),
         )
         config.validate(world_size=1)  # Should not raise — check deferred
@@ -403,12 +405,10 @@ class TestJobConfig:
         lives in TransformerBlocks; CrossAttentionBlocks remain dense.
         """
         config = JobConfig(
-            model=ModelConfig(
-                max_seq_len=1024,
-                vlm=VLMConfig(vision_encoder="random", num_tokens=64, max_text_len=512),
-                num_experts=4,
-                moe_top_k=2,
-            ),
+            model=ModelConfig(max_seq_len=1024, num_experts=4, moe_top_k=2),
+            vision_encoder=VisionEncoderConfig(type="random", num_tokens=64),
+            adapter=AdapterConfig(),
+            vlm=VLMConfig(max_text_len=512),
             train=TrainConfig(seq_len=600),
         )
         config.validate(world_size=1)  # Should not raise.
@@ -457,29 +457,31 @@ class TestTomlLoading:
             load_config(str(bad_toml), cli_args=[])
 
     def test_load_vlm_debug_toml(self):
-        """Regression: nested Optional[VLMConfig] in ModelConfig loads
-        correctly from [model.vlm] table, and list[FreezeSpec] inside
-        VLMConfig instantiates each freeze entry via __post_init__."""
+        """Regression: parallel [vision_encoder] / [adapter] / [vlm] tables
+        load correctly, and list[FreezeSpec] inside VLMConfig instantiates
+        each freeze entry via __post_init__."""
         config = load_config("configs/train/vlm_debug.toml", cli_args=[])
-        assert config.model.is_vlm is True
-        assert config.model.vlm is not None
-        assert config.model.vlm.vision_encoder == "random"
-        assert config.model.vlm.num_tokens == 64
-        assert len(config.model.vlm.freeze) == 1
-        assert config.model.vlm.freeze[0].module == "vision_encoder"
-        assert config.model.vlm.freeze[0].frozen is True
+        assert config.is_vlm is True
+        assert config.vision_encoder is not None
+        assert config.vlm is not None
+        assert config.vision_encoder.type == "random"
+        assert config.vision_encoder.num_tokens == 64
+        assert len(config.vlm.freeze) == 1
+        assert config.vlm.freeze[0].module == "vision_encoder"
+        assert config.vlm.freeze[0].frozen is True
         config.validate(world_size=1)
 
     def test_load_vlm_7b_siglip2_toml(self):
         config = load_config("configs/train/vlm_7b_siglip2.toml", cli_args=[])
-        assert config.model.is_vlm is True
-        assert config.model.vlm is not None
-        assert config.model.vlm.vision_encoder == "siglip2"
+        assert config.is_vlm is True
+        assert config.vision_encoder is not None
+        assert config.vlm is not None
+        assert config.vision_encoder.type == "siglip2"
         # num_tokens defaults to 0 = "infer from encoder at build time".
         # The encoder probes 196 (14x14 patches, no CLS) for this path; the
         # build-time max_seq_len cross-check in build_vlm_wrapper enforces
         # 196 + 2048 = 2244 <= max_seq_len=2304.
-        assert config.model.vlm.num_tokens == 0
+        assert config.vision_encoder.num_tokens == 0
         config.validate(world_size=4)
 
     def test_vlm_freeze_schedule_loads_variadic_tuple(self, tmp_path):
@@ -497,10 +499,12 @@ n_kv_heads = 4
 vocab_size = 256
 max_seq_len = 96
 
-[model.vlm]
-arch = "joint_decoder"
-vision_encoder = "random"
+[vision_encoder]
+type = "random"
 num_tokens = 16
+
+[vlm]
+arch = "joint_decoder"
 max_text_len = 64
 freeze = [{module = "vision_encoder", frozen = true}]
 freeze_schedule = [
@@ -510,8 +514,8 @@ freeze_schedule = [
 """
         )
         config = load_config(str(toml), cli_args=[])
-        assert config.model.vlm is not None
-        sched = config.model.vlm.freeze_schedule
+        assert config.vlm is not None
+        sched = config.vlm.freeze_schedule
         assert len(sched) == 2
         assert sched[0].start_step == 5
         assert sched[0].specs[0].module == "adapter"
@@ -533,10 +537,12 @@ freeze_schedule = [
         toml = tmp_path / "vlm_reserved.toml"
         toml.write_text(
             f"""
-[model.vlm]
-arch = "{reserved_arch}"
-vision_encoder = "random"
+[vision_encoder]
+type = "random"
 num_tokens = 16
+
+[vlm]
+arch = "{reserved_arch}"
 max_text_len = 32
 """
         )
@@ -547,10 +553,12 @@ max_text_len = 32
         toml = tmp_path / "vlm_unknown.toml"
         toml.write_text(
             """
-[model.vlm]
-arch = "bogus_arch"
-vision_encoder = "random"
+[vision_encoder]
+type = "random"
 num_tokens = 16
+
+[vlm]
+arch = "bogus_arch"
 max_text_len = 32
 """
         )
@@ -563,10 +571,12 @@ max_text_len = 32
         toml = tmp_path / "vlm_typo.toml"
         toml.write_text(
             """
-[model.vlm]
-arch = "joint_decoder"
-vision_encoder = "random"
+[vision_encoder]
+type = "random"
 num_tokens = 16
+
+[vlm]
+arch = "joint_decoder"
 max_text_len = 32
 not_a_real_field = 99
 """

--- a/tests/unit/test_distributed.py
+++ b/tests/unit/test_distributed.py
@@ -324,40 +324,54 @@ class TestApplyFsdpVLMGuards:
 
 
 class TestBuildParallelModelVLM:
-    def _vlm_model_config(self, max_seq_len: int = 64, max_text_len: int = 32, num_tokens: int = 8):
+    def _vlm_configs(self, max_seq_len: int = 64, max_text_len: int = 32, num_tokens: int = 8):
+        from kempnerforge.config.adapter import AdapterConfig
+        from kempnerforge.config.vision import VisionEncoderConfig
         from kempnerforge.config.vlm import VLMConfig
 
-        return ModelConfig(
-            dim=64,
-            n_layers=2,
-            n_heads=4,
-            n_kv_heads=4,
-            vocab_size=256,
-            max_seq_len=max_seq_len,
-            vlm=VLMConfig(
-                vision_encoder="random",
-                feature_dim=96,
-                num_tokens=num_tokens,
-                max_text_len=max_text_len,
+        return (
+            ModelConfig(
+                dim=64,
+                n_layers=2,
+                n_heads=4,
+                n_kv_heads=4,
+                vocab_size=256,
+                max_seq_len=max_seq_len,
             ),
+            VisionEncoderConfig(type="random", feature_dim=96, num_tokens=num_tokens),
+            AdapterConfig(),
+            VLMConfig(max_text_len=max_text_len),
         )
 
     def test_dispatches_to_vlm_branch(self):
-        """``is_vlm=True`` routes through ``_build_vlm`` and returns a
-        ``VLMWrapper`` (not a bare Transformer)."""
+        """Passing a non-None ``vlm_config`` routes through ``_build_vlm`` and
+        returns a ``VLMWrapper`` (not a bare Transformer)."""
         from kempnerforge.distributed.parallel import build_parallel_model
         from kempnerforge.model.vlm import VLMWrapper
 
-        cfg = self._vlm_model_config()
-        model = build_parallel_model(cfg, torch.device("cpu"), device_mesh=None)
+        mc, vc, ac, lc = self._vlm_configs()
+        model = build_parallel_model(
+            mc,
+            torch.device("cpu"),
+            device_mesh=None,
+            vision_config=vc,
+            adapter_config=ac,
+            vlm_config=lc,
+        )
         assert isinstance(model, VLMWrapper)
 
     def test_param_dtype_applied_to_transformer_and_adapter(self):
         from kempnerforge.distributed.parallel import build_parallel_model
 
-        cfg = self._vlm_model_config()
+        mc, vc, ac, lc = self._vlm_configs()
         model = build_parallel_model(
-            cfg, torch.device("cpu"), device_mesh=None, param_dtype=torch.bfloat16
+            mc,
+            torch.device("cpu"),
+            device_mesh=None,
+            vision_config=vc,
+            adapter_config=ac,
+            vlm_config=lc,
+            param_dtype=torch.bfloat16,
         )
         # Transformer + adapter cast to bf16; encoder stays in HF dtype (fp32 here).
         assert model.transformer.token_embedding.embedding.weight.dtype == torch.bfloat16
@@ -365,68 +379,89 @@ class TestBuildParallelModelVLM:
 
     def test_max_seq_len_too_short_raises(self):
         """Cross-check: ``num_image_tokens + max_text_len > max_seq_len`` raises."""
+        from kempnerforge.config.adapter import AdapterConfig
+        from kempnerforge.config.vision import VisionEncoderConfig
         from kempnerforge.config.vlm import VLMConfig
         from kempnerforge.distributed.parallel import build_parallel_model
 
-        # Bypass the ModelConfig __post_init__ check by setting num_tokens=0
+        # Bypass the JobConfig __post_init__ check by setting num_tokens=0
         # (deferred), then forcing the encoder to produce a real number of
         # tokens that overflows max_seq_len at build time.
-        cfg = ModelConfig(
+        mc = ModelConfig(
             dim=64,
             n_layers=2,
             n_heads=4,
             n_kv_heads=4,
             vocab_size=256,
             max_seq_len=32,
-            vlm=VLMConfig(
-                vision_encoder="random",
-                feature_dim=96,
-                num_tokens=0,  # defer; RandomVisionEncoder default = 16
-                max_text_len=24,  # 16 + 24 = 40 > 32
-            ),
         )
+        vc = VisionEncoderConfig(type="random", feature_dim=96, num_tokens=0)
+        ac = AdapterConfig()
+        lc = VLMConfig(max_text_len=24)  # 16 + 24 = 40 > 32
         with pytest.raises(ValueError, match="max_seq_len.*insufficient"):
-            build_parallel_model(cfg, torch.device("cpu"), device_mesh=None)
+            build_parallel_model(
+                mc,
+                torch.device("cpu"),
+                device_mesh=None,
+                vision_config=vc,
+                adapter_config=ac,
+                vlm_config=lc,
+            )
 
     def test_frozen_encoder_set_to_eval(self):
         """When all freeze specs target the vision encoder with frozen=True,
         the encoder is switched to eval() and its params have requires_grad=False."""
         from kempnerforge.distributed.parallel import build_parallel_model
 
-        cfg = self._vlm_model_config()
-        model = build_parallel_model(cfg, torch.device("cpu"), device_mesh=None)
+        mc, vc, ac, lc = self._vlm_configs()
+        model = build_parallel_model(
+            mc,
+            torch.device("cpu"),
+            device_mesh=None,
+            vision_config=vc,
+            adapter_config=ac,
+            vlm_config=lc,
+        )
         assert model.vision_encoder.training is False
         assert all(not p.requires_grad for p in model.vision_encoder.parameters())
 
     def test_partially_unfrozen_encoder_stays_in_train_mode(self):
+        from kempnerforge.config.adapter import AdapterConfig
+        from kempnerforge.config.vision import VisionEncoderConfig
         from kempnerforge.config.vlm import FreezeSpec, VLMConfig
         from kempnerforge.distributed.parallel import build_parallel_model
 
-        cfg = ModelConfig(
+        mc = ModelConfig(
             dim=64,
             n_layers=2,
             n_heads=4,
             n_kv_heads=4,
             vocab_size=256,
             max_seq_len=64,
-            vlm=VLMConfig(
-                vision_encoder="random",
-                feature_dim=96,
-                num_tokens=8,
-                max_text_len=32,
-                # Mixed specs: alias+True plus a sub-pattern with frozen=False
-                # means _is_encoder_frozen returns False -> stays in train().
-                freeze=[
-                    FreezeSpec("vision_encoder", True),
-                    FreezeSpec("vision_encoder._anchor", False),
-                ],
-            ),
         )
-        model = build_parallel_model(cfg, torch.device("cpu"), device_mesh=None)
+        vc = VisionEncoderConfig(type="random", feature_dim=96, num_tokens=8)
+        ac = AdapterConfig()
+        # Mixed specs: alias+True plus a sub-pattern with frozen=False
+        # means _is_encoder_frozen returns False -> stays in train().
+        lc = VLMConfig(
+            max_text_len=32,
+            freeze=[
+                FreezeSpec("vision_encoder", True),
+                FreezeSpec("vision_encoder._anchor", False),
+            ],
+        )
+        model = build_parallel_model(
+            mc,
+            torch.device("cpu"),
+            device_mesh=None,
+            vision_config=vc,
+            adapter_config=ac,
+            vlm_config=lc,
+        )
         assert model.vision_encoder.training is True
 
     def test_dispatch_falls_through_for_non_vlm(self):
-        """Sanity: non-VLM ModelConfig does not enter the VLM branch."""
+        """Sanity: omitting vlm_config builds a plain Transformer."""
         from kempnerforge.distributed.parallel import build_parallel_model
 
         cfg = ModelConfig(dim=64, n_layers=2, n_heads=4, n_kv_heads=4, vocab_size=256)

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -620,7 +620,7 @@ class TestModalityIdsCrossArgs:
 # ---------------------------------------------------------------------------
 
 
-def _mot_config(
+def _mot_setup(
     dim: int = 128,
     n_layers: int = 2,
     n_heads: int = 4,
@@ -629,11 +629,11 @@ def _mot_config(
     max_text_len: int = 16,
     mot_image_n_heads: int = 0,
     mot_image_n_kv_heads: int = 0,
-) -> ModelConfig:
-    """Tiny MoT-backed ModelConfig for integration tests."""
+):
+    """Tiny MoT-backed (model_config, vlm_config, num_image_tokens, max_text_len)."""
     from kempnerforge.config.vlm import MoTConfig
 
-    return ModelConfig(
+    mc = ModelConfig(
         dim=dim,
         n_layers=n_layers,
         n_heads=n_heads,
@@ -641,14 +641,18 @@ def _mot_config(
         vocab_size=256,
         max_seq_len=num_tokens + max_text_len,
         ffn_hidden_dim=128,
-        vlm=MoTConfig(
-            vision_encoder="random",
-            num_tokens=num_tokens,
-            max_text_len=max_text_len,
-            mot_image_n_heads=mot_image_n_heads,
-            mot_image_n_kv_heads=mot_image_n_kv_heads,
-        ),
     )
+    lc = MoTConfig(
+        max_text_len=max_text_len,
+        mot_image_n_heads=mot_image_n_heads,
+        mot_image_n_kv_heads=mot_image_n_kv_heads,
+    )
+    return mc, lc, num_tokens, max_text_len
+
+
+def _mot_transformer(**kwargs) -> Transformer:
+    mc, lc, n_image, _ = _mot_setup(**kwargs)
+    return Transformer(mc, vlm_config=lc, num_image_tokens=n_image)
 
 
 class TestMoT:
@@ -657,8 +661,7 @@ class TestMoT:
     def test_layers_are_mot_blocks_when_mot(self):
         from kempnerforge.model.mot import MoTBlock
 
-        cfg = _mot_config()
-        model = Transformer(cfg).to(DEVICE)
+        model = _mot_transformer().to(DEVICE)
         assert all(isinstance(layer, MoTBlock) for layer in model.layers.values())
         assert model._mot_modalities == ("image", "text")
         assert model._mot_n_image == 8
@@ -676,27 +679,25 @@ class TestMoT:
     def test_unequal_image_n_heads_raises(self):
         """v1 enforces equal head counts across modalities."""
         with pytest.raises(ValueError, match="equal head counts"):
-            cfg = _mot_config(mot_image_n_heads=2)
-            Transformer(cfg)
+            _mot_transformer(mot_image_n_heads=2)
 
     def test_unequal_image_n_kv_heads_raises(self):
         with pytest.raises(ValueError, match="equal head counts"):
-            cfg = _mot_config(mot_image_n_kv_heads=2)
-            Transformer(cfg)
+            _mot_transformer(mot_image_n_kv_heads=2)
 
     def test_modality_ids_required_when_mot_active(self):
-        cfg = _mot_config()
-        model = Transformer(cfg).to(DEVICE).eval()
-        tokens = torch.randint(0, 256, (1, cfg.vlm.max_text_len), device=DEVICE)  # type: ignore[union-attr]
-        prefix = torch.randn(1, cfg.vlm.num_tokens, cfg.dim, device=DEVICE)  # type: ignore[union-attr]
+        mc, lc, n_image, max_text_len = _mot_setup()
+        model = Transformer(mc, vlm_config=lc, num_image_tokens=n_image).to(DEVICE).eval()
+        tokens = torch.randint(0, 256, (1, max_text_len), device=DEVICE)
+        prefix = torch.randn(1, n_image, mc.dim, device=DEVICE)
         with pytest.raises(ValueError, match="MoT model requires modality.modality_ids"):
             model(tokens, modality=ModalityContext(prefix_embeds=prefix))
 
     def test_modality_ids_shape_mismatch_raises(self):
-        cfg = _mot_config()
-        model = Transformer(cfg).to(DEVICE).eval()
-        tokens = torch.randint(0, 256, (1, cfg.vlm.max_text_len), device=DEVICE)  # type: ignore[union-attr]
-        prefix = torch.randn(1, cfg.vlm.num_tokens, cfg.dim, device=DEVICE)  # type: ignore[union-attr]
+        mc, lc, n_image, max_text_len = _mot_setup()
+        model = Transformer(mc, vlm_config=lc, num_image_tokens=n_image).to(DEVICE).eval()
+        tokens = torch.randint(0, 256, (1, max_text_len), device=DEVICE)
+        prefix = torch.randn(1, n_image, mc.dim, device=DEVICE)
         bad_ids = torch.zeros(1, 5, dtype=torch.long, device=DEVICE)
         with pytest.raises(ValueError, match="modality.modality_ids shape"):
             model(
@@ -705,13 +706,11 @@ class TestMoT:
             )
 
     def test_forward_output_shape(self):
-        cfg = _mot_config()
-        model = Transformer(cfg).to(DEVICE).eval()
-        n_image = cfg.vlm.num_tokens  # type: ignore[union-attr]
-        n_text = cfg.vlm.max_text_len  # type: ignore[union-attr]
+        mc, lc, n_image, n_text = _mot_setup()
+        model = Transformer(mc, vlm_config=lc, num_image_tokens=n_image).to(DEVICE).eval()
         total = n_image + n_text
         tokens = torch.randint(0, 256, (1, n_text), device=DEVICE)
-        prefix = torch.randn(1, n_image, cfg.dim, device=DEVICE)
+        prefix = torch.randn(1, n_image, mc.dim, device=DEVICE)
         ids = torch.zeros(1, total, dtype=torch.long, device=DEVICE)
         ids[:, n_image:] = 1
         with torch.no_grad():
@@ -719,17 +718,15 @@ class TestMoT:
                 tokens,
                 modality=ModalityContext(prefix_embeds=prefix, modality_ids=ids),
             )
-        assert out.shape == (1, total, cfg.vocab_size)
+        assert out.shape == (1, total, mc.vocab_size)
         assert torch.isfinite(out).all()
 
     def test_forward_output_slice_works(self):
         """output_slice composes with the MoT path: trim image tokens off the head input."""
-        cfg = _mot_config()
-        model = Transformer(cfg).to(DEVICE).eval()
-        n_image = cfg.vlm.num_tokens  # type: ignore[union-attr]
-        n_text = cfg.vlm.max_text_len  # type: ignore[union-attr]
+        mc, lc, n_image, n_text = _mot_setup()
+        model = Transformer(mc, vlm_config=lc, num_image_tokens=n_image).to(DEVICE).eval()
         tokens = torch.randint(0, 256, (1, n_text), device=DEVICE)
-        prefix = torch.randn(1, n_image, cfg.dim, device=DEVICE)
+        prefix = torch.randn(1, n_image, mc.dim, device=DEVICE)
         ids = torch.zeros(1, n_image + n_text, dtype=torch.long, device=DEVICE)
         ids[:, n_image:] = 1
         with torch.no_grad():
@@ -741,11 +738,10 @@ class TestMoT:
                     output_slice=slice(n_image, None),
                 ),
             )
-        assert out.shape == (1, n_text, cfg.vocab_size)
+        assert out.shape == (1, n_text, mc.vocab_size)
 
     def test_state_dict_contains_per_modality_keys(self):
-        cfg = _mot_config()
-        model = Transformer(cfg).to(DEVICE)
+        model = _mot_transformer().to(DEVICE)
         keys = set(model.state_dict().keys())
         assert "layers.0.attn.q_proj.image.weight" in keys
         assert "layers.0.attn.q_proj.text.weight" in keys
@@ -763,17 +759,15 @@ class TestMoT:
         """Backward flows through per-modality projections after a non-zero
         o_proj re-init (zero-init residual blocks gradient to upstream
         Q/K/V via the residual chain rule)."""
-        cfg = _mot_config()
-        model = Transformer(cfg).to(DEVICE)
+        mc, lc, n_image, n_text = _mot_setup()
+        model = Transformer(mc, vlm_config=lc, num_image_tokens=n_image).to(DEVICE)
         with torch.no_grad():
             for layer in model.layers.values():
                 for m in layer.modalities:
                     torch.nn.init.normal_(layer.attn.o_proj[m].weight, std=0.01)
                     torch.nn.init.normal_(layer.mlp[m].down_proj.weight, std=0.01)
-        n_image = cfg.vlm.num_tokens  # type: ignore[union-attr]
-        n_text = cfg.vlm.max_text_len  # type: ignore[union-attr]
         tokens = torch.randint(0, 256, (1, n_text), device=DEVICE)
-        prefix = torch.randn(1, n_image, cfg.dim, device=DEVICE)
+        prefix = torch.randn(1, n_image, mc.dim, device=DEVICE)
         ids = torch.zeros(1, n_image + n_text, dtype=torch.long, device=DEVICE)
         ids[:, n_image:] = 1
         out = model(
@@ -791,36 +785,36 @@ class TestMoT:
 # ---------------------------------------------------------------------------
 
 
-def _ca_config(n_layers: int, cadence: int) -> ModelConfig:
-    """Tiny CrossAttentionConfig-backed ModelConfig for interleaving tests."""
+def _ca_setup(n_layers: int, cadence: int):
+    """Tiny CrossAttentionConfig setup -> (model_config, vlm_config, num_image_tokens)."""
     from kempnerforge.config.vlm import CrossAttentionConfig
 
-    return ModelConfig(
+    mc = ModelConfig(
         dim=64,
         n_layers=n_layers,
         n_heads=4,
         vocab_size=256,
         max_seq_len=128,
-        vlm=CrossAttentionConfig(
-            vision_encoder="random",
-            feature_dim=64,
-            num_tokens=8,
-            cross_attention_every_n_layers=cadence,
-            max_text_len=64,
-        ),
     )
+    lc = CrossAttentionConfig(cross_attention_every_n_layers=cadence, max_text_len=64)
+    return mc, lc, 8
+
+
+def _ca_transformer(n_layers: int, cadence: int) -> Transformer:
+    mc, lc, n_image = _ca_setup(n_layers, cadence)
+    return Transformer(mc, vlm_config=lc, num_image_tokens=n_image)
 
 
 class TestCrossAttentionInterleaving:
     def test_n28_cadence4_yields_7_ca_blocks(self):
         """Paper baseline: 28 layers, cadence 4 -> 7 CA blocks."""
-        model = Transformer(_ca_config(n_layers=28, cadence=4))
+        model = _ca_transformer(n_layers=28, cadence=4)
         assert len(model.cross_attention_layers) == 7
         assert model._ca_cadence == 4
 
     def test_n32_cadence4_yields_8_ca_blocks(self):
         """Default 7B backbone: 32 layers, cadence 4 -> 8 CA blocks."""
-        model = Transformer(_ca_config(n_layers=32, cadence=4))
+        model = _ca_transformer(n_layers=32, cadence=4)
         assert len(model.cross_attention_layers) == 8
 
     def test_n28_cadence4_attaches_at_paper_positions(self):
@@ -830,10 +824,10 @@ class TestCrossAttentionInterleaving:
         from kempnerforge.config.vlm import CrossAttentionConfig
         from kempnerforge.model.cross_attention import CrossAttentionBlock
 
-        config = _ca_config(n_layers=28, cadence=4)
-        assert isinstance(config.vlm, CrossAttentionConfig)
+        mc, lc, n_image = _ca_setup(n_layers=28, cadence=4)
+        assert isinstance(lc, CrossAttentionConfig)
 
-        model = Transformer(config).to(DEVICE).eval()
+        model = Transformer(mc, vlm_config=lc, num_image_tokens=n_image).to(DEVICE).eval()
         # Replace CA blocks with counters via monkeypatching forward.
         invocations: list[int] = []
         original = CrossAttentionBlock.forward
@@ -891,10 +885,8 @@ class TestCrossAttentionInterleaving:
         4 CA blocks): strict=True raises with a missing-keys error
         mentioning cross_attention_layers.
         """
-        cfg_4 = _ca_config(n_layers=8, cadence=4)  # K=2
-        cfg_2 = _ca_config(n_layers=8, cadence=2)  # K=4
-        model_4 = Transformer(cfg_4)
-        model_2 = Transformer(cfg_2)
+        model_4 = _ca_transformer(n_layers=8, cadence=4)  # K=2
+        model_2 = _ca_transformer(n_layers=8, cadence=2)  # K=4
         state_4 = model_4.state_dict()
         with pytest.raises(RuntimeError, match="cross_attention_layers"):
             model_2.load_state_dict(state_4, strict=True)
@@ -906,8 +898,7 @@ class TestCrossAttentionInterleaving:
         [t..end] must produce equal logits on positions [0..t-1].
         """
         torch.manual_seed(0)
-        config = _ca_config(n_layers=8, cadence=4)
-        model = Transformer(config).to(DEVICE).eval()
+        model = _ca_transformer(n_layers=8, cadence=4).to(DEVICE).eval()
         img = torch.randn(1, 8, 64, device=DEVICE)
         seq_len = 12
 
@@ -928,15 +919,15 @@ class TestCrossAttentionInterleaving:
         and same backbone weights.
         """
         torch.manual_seed(0)
-        config_ca = _ca_config(n_layers=4, cadence=2)
+        mc_ca, lc_ca, n_image = _ca_setup(n_layers=4, cadence=2)
         text_config = ModelConfig(
-            dim=config_ca.dim,
-            n_layers=config_ca.n_layers,
-            n_heads=config_ca.n_heads,
-            vocab_size=config_ca.vocab_size,
-            max_seq_len=config_ca.max_seq_len,
+            dim=mc_ca.dim,
+            n_layers=mc_ca.n_layers,
+            n_heads=mc_ca.n_heads,
+            vocab_size=mc_ca.vocab_size,
+            max_seq_len=mc_ca.max_seq_len,
         )
-        ca_model = Transformer(config_ca).to(DEVICE).eval()
+        ca_model = Transformer(mc_ca, vlm_config=lc_ca, num_image_tokens=n_image).to(DEVICE).eval()
         text_model = Transformer(text_config).to(DEVICE).eval()
         # Copy CA model's text-stack weights into text_model so backbone matches.
         text_state = {
@@ -953,8 +944,7 @@ class TestCrossAttentionInterleaving:
     def test_image_features_required_when_ca_layers_present(self):
         """Forward without image_features raises a clear error when
         CA layers are configured."""
-        config = _ca_config(n_layers=4, cadence=2)
-        model = Transformer(config).to(DEVICE).eval()
+        model = _ca_transformer(n_layers=4, cadence=2).to(DEVICE).eval()
         tokens = torch.randint(0, 256, (1, 8), device=DEVICE)
         with pytest.raises(ValueError, match="image_features is None"):
             model(tokens)
@@ -963,8 +953,9 @@ class TestCrossAttentionInterleaving:
         """Cross-arg invariant: image_features is training-only."""
         from kempnerforge.model.attention import KVCache
 
-        config = _ca_config(n_layers=4, cadence=2)
-        model = Transformer(config).to(DEVICE)
+        mc, lc, n_image = _ca_setup(n_layers=4, cadence=2)
+        config = mc
+        model = Transformer(mc, vlm_config=lc, num_image_tokens=n_image).to(DEVICE)
         kv = [
             KVCache(
                 batch_size=1,

--- a/tests/unit/test_vision_config.py
+++ b/tests/unit/test_vision_config.py
@@ -1,0 +1,63 @@
+"""Unit tests for VisionEncoderConfig (config/vision.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+import kempnerforge.model.vision  # noqa: F401  -- register encoder types
+from kempnerforge.config.registry import registry
+from kempnerforge.config.vision import VisionEncoderConfig
+
+
+class TestVisionEncoderConfig:
+    def test_defaults(self):
+        cfg = VisionEncoderConfig()
+        assert cfg.type == "random"
+        assert cfg.path == ""
+        assert cfg.feature_dim == 0
+        assert cfg.num_tokens == 0
+
+    def test_explicit_fields(self):
+        cfg = VisionEncoderConfig(
+            type="siglip2",
+            path="google/siglip2-base-patch16-224",
+            feature_dim=768,
+            num_tokens=196,
+        )
+        assert cfg.type == "siglip2"
+        assert cfg.path == "google/siglip2-base-patch16-224"
+        assert cfg.feature_dim == 768
+        assert cfg.num_tokens == 196
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(ValueError, match="Unknown vision_encoder.type"):
+            VisionEncoderConfig(type="not_a_real_encoder")
+
+    def test_negative_feature_dim_raises(self):
+        with pytest.raises(ValueError, match="feature_dim must be non-negative"):
+            VisionEncoderConfig(feature_dim=-1)
+
+    def test_negative_num_tokens_raises(self):
+        with pytest.raises(ValueError, match="num_tokens must be non-negative"):
+            VisionEncoderConfig(num_tokens=-1)
+
+    def test_zero_feature_dim_is_inference_sentinel(self):
+        """``feature_dim=0`` means 'infer from the encoder at build time';
+        it is not a validation error."""
+        cfg = VisionEncoderConfig(feature_dim=0)
+        assert cfg.feature_dim == 0
+
+    def test_zero_num_tokens_is_inference_sentinel(self):
+        """``num_tokens=0`` means 'infer at build time'; the cross-check
+        against ``model.max_seq_len`` then runs in ``build_vlm_wrapper``
+        using the encoder's resolved value."""
+        cfg = VisionEncoderConfig(num_tokens=0)
+        assert cfg.num_tokens == 0
+
+    def test_registered_types_include_known_encoders(self):
+        """Sanity: the registry knows about the three encoders the
+        codebase ships, so the type-validation error message is useful."""
+        names = registry.list_vision_encoders()
+        assert "random" in names
+        assert "siglip2" in names
+        assert "clip" in names

--- a/tests/unit/test_vlm.py
+++ b/tests/unit/test_vlm.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import pytest
 import torch
 
+from kempnerforge.config.adapter import AdapterConfig
 from kempnerforge.config.model import ModelConfig
+from kempnerforge.config.vision import VisionEncoderConfig
 from kempnerforge.config.vlm import (
     CrossAttentionConfig,
     FreezeSpec,
@@ -38,24 +40,20 @@ DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 # ---------------------------------------------------------------------------
 
 
-def _tiny_vlm_config(num_image_tokens: int = 8, feature_dim: int = 96) -> ModelConfig:
-    return ModelConfig(
-        dim=64,
-        n_layers=2,
-        n_heads=4,
-        vocab_size=256,
-        max_seq_len=64,
-        vlm=VLMConfig(
-            vision_encoder="random",
-            feature_dim=feature_dim,
-            num_tokens=num_image_tokens,
-            max_text_len=32,
-        ),
+def _tiny_configs(
+    num_image_tokens: int = 8, feature_dim: int = 96
+) -> tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, VLMConfig]:
+    return (
+        ModelConfig(dim=64, n_layers=2, n_heads=4, vocab_size=256, max_seq_len=64),
+        VisionEncoderConfig(type="random", feature_dim=feature_dim, num_tokens=num_image_tokens),
+        AdapterConfig(),
+        VLMConfig(max_text_len=32),
     )
 
 
 def _build_tiny_wrapper(num_image_tokens: int = 8, feature_dim: int = 96) -> VLMWrapper:
-    return build_vlm_wrapper(_tiny_vlm_config(num_image_tokens, feature_dim))
+    mc, vc, ac, lc = _tiny_configs(num_image_tokens, feature_dim)
+    return build_vlm_wrapper(mc, vc, ac, lc)
 
 
 class TestVLMWrapper:
@@ -105,15 +103,15 @@ class TestVLMWrapper:
         trainable = [p for p in wrapper.transformer.parameters() if p.requires_grad]
         assert any(p.grad is not None for p in trainable)
 
-    def test_dispatch_on_is_vlm_only(self):
+    def test_dispatch_on_vlm_only(self):
         """build_vlm_wrapper should not require model_type changes; the
         inner transformer is registered under the standard 'transformer'
-        model_type, and VLM dispatch happens through model_config.is_vlm.
+        model_type, and VLM dispatch happens through the presence of a
+        VLMConfig.
         """
-        cfg = _tiny_vlm_config()
-        assert cfg.is_vlm is True
-        assert cfg.model_type == "transformer"
-        wrapper = build_vlm_wrapper(cfg)
+        mc, vc, ac, lc = _tiny_configs()
+        assert mc.model_type == "transformer"
+        wrapper = build_vlm_wrapper(mc, vc, ac, lc)
         assert isinstance(wrapper.transformer, Transformer)
 
     def test_transformer_reachable(self):
@@ -171,40 +169,25 @@ class TestInnerTransformer:
 
 
 class TestBuildVLMWrapperErrors:
-    def test_missing_vlm_raises(self):
-        cfg = ModelConfig(dim=64, n_layers=2, n_heads=4, vocab_size=256)
-        assert cfg.vlm is None
-        with pytest.raises(ValueError, match="model_config.vlm"):
-            build_vlm_wrapper(cfg)
-
     def test_max_seq_len_insufficient_for_inferred_encoder_num_tokens(self):
-        """When ``vlm.num_tokens=0`` (the "infer from encoder at build time"
-        sentinel), the config-time cross-check in ``ModelConfig.__post_init__``
-        is skipped. The build-time check in ``build_vlm_wrapper`` must catch
-        the case where the encoder's resolved ``num_tokens`` + ``max_text_len``
-        exceeds ``max_seq_len``. Regression guard for the §1.1 validation gap.
+        """When ``vision_encoder.num_tokens=0`` (the "infer from encoder at
+        build time" sentinel), the config-time cross-check in
+        ``JobConfig.__post_init__`` is skipped. The build-time check in
+        ``build_vlm_wrapper`` must catch the case where the encoder's
+        resolved ``num_tokens`` + ``max_text_len`` exceeds ``max_seq_len``.
+        Regression guard for the validation gap.
         """
-        # RandomVisionEncoder's default num_tokens is 16 (see vision.py:53),
-        # so vlm.num_tokens=0 -> encoder resolves to 16 at build time.
+        # RandomVisionEncoder's default num_tokens is 16 (see vision.py),
+        # so num_tokens=0 -> encoder resolves to 16 at build time.
         # max_text_len=32 -> JD residual = 16 + 32 = 48. max_seq_len=32 < 48.
-        cfg = ModelConfig(
-            dim=64,
-            n_layers=2,
-            n_heads=4,
-            vocab_size=256,
-            max_seq_len=32,
-            vlm=VLMConfig(
-                vision_encoder="random",
-                num_tokens=0,  # sentinel — skips config-time check
-                max_text_len=32,
-            ),
-        )
-        # ModelConfig construction succeeded (no num_tokens-based check fired).
-        assert cfg.vlm is not None and cfg.vlm.num_tokens == 0
+        mc = ModelConfig(dim=64, n_layers=2, n_heads=4, vocab_size=256, max_seq_len=32)
+        vc = VisionEncoderConfig(type="random", num_tokens=0)  # sentinel
+        ac = AdapterConfig()
+        lc = VLMConfig(max_text_len=32)
         with pytest.raises(ValueError) as exc_info:
-            build_vlm_wrapper(cfg)
+            build_vlm_wrapper(mc, vc, ac, lc)
         # Error message must name max_seq_len, encoder.num_tokens, and
-        # vlm.max_text_len so the user can find the offending knobs.
+        # max_text_len so the user can find the offending knobs.
         msg = str(exc_info.value)
         assert "max_seq_len" in msg
         assert "encoder.num_tokens" in msg
@@ -220,21 +203,11 @@ class TestBuildVLMWrapperErrors:
         """
         # max_seq_len=32, max_text_len=32 -> JD would fail (residual would
         # be 16+32=48), but CA's residual is text-only (0+32=32).
-        cfg = ModelConfig(
-            dim=64,
-            n_layers=2,
-            n_heads=4,
-            vocab_size=256,
-            max_seq_len=32,
-            vlm=CrossAttentionConfig(
-                vision_encoder="random",
-                num_tokens=0,
-                max_text_len=32,
-            ),
-        )
-        # Should not raise — CA's residual_stream_image_tokens() returns 0
-        # regardless of the encoder's num_tokens.
-        wrapper = build_vlm_wrapper(cfg)
+        mc = ModelConfig(dim=64, n_layers=2, n_heads=4, vocab_size=256, max_seq_len=32)
+        vc = VisionEncoderConfig(type="random", num_tokens=0)
+        ac = AdapterConfig()
+        lc = CrossAttentionConfig(max_text_len=32)
+        wrapper = build_vlm_wrapper(mc, vc, ac, lc)
         assert isinstance(wrapper, VLMWrapper)
         # CA's residual is text-only, so wrapper.num_image_tokens is 0.
         assert wrapper.num_image_tokens == 0
@@ -274,44 +247,43 @@ class TestIsEncoderFrozen:
 # ---------------------------------------------------------------------------
 
 
-def _ca_vlm_config(
+def _ca_configs(
     num_image_tokens: int = 8, feature_dim: int = 96, cadence: int = 2
-) -> ModelConfig:
-    return ModelConfig(
-        dim=64,
-        n_layers=4,
-        n_heads=4,
-        vocab_size=256,
-        max_seq_len=64,
-        vlm=CrossAttentionConfig(
-            vision_encoder="random",
-            feature_dim=feature_dim,
-            num_tokens=num_image_tokens,
-            max_text_len=32,
-            cross_attention_every_n_layers=cadence,
-        ),
+) -> tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, CrossAttentionConfig]:
+    return (
+        ModelConfig(dim=64, n_layers=4, n_heads=4, vocab_size=256, max_seq_len=64),
+        VisionEncoderConfig(type="random", feature_dim=feature_dim, num_tokens=num_image_tokens),
+        AdapterConfig(),
+        CrossAttentionConfig(max_text_len=32, cross_attention_every_n_layers=cadence),
     )
 
 
-def _mot_vlm_config(num_image_tokens: int = 8, feature_dim: int = 96) -> ModelConfig:
-    return ModelConfig(
-        dim=64,
-        n_layers=2,
-        n_heads=4,
-        vocab_size=256,
-        max_seq_len=64,
-        ffn_hidden_dim=128,
-        vlm=MoTConfig(
-            vision_encoder="random",
-            feature_dim=feature_dim,
-            num_tokens=num_image_tokens,
-            max_text_len=32,
+def _build_ca_tiny_wrapper(*args, **kwargs) -> VLMWrapper:
+    mc, vc, ac, lc = _ca_configs(*args, **kwargs)
+    return build_vlm_wrapper(mc, vc, ac, lc)
+
+
+def _mot_configs(
+    num_image_tokens: int = 8, feature_dim: int = 96
+) -> tuple[ModelConfig, VisionEncoderConfig, AdapterConfig, MoTConfig]:
+    return (
+        ModelConfig(
+            dim=64,
+            n_layers=2,
+            n_heads=4,
+            vocab_size=256,
+            max_seq_len=64,
+            ffn_hidden_dim=128,
         ),
+        VisionEncoderConfig(type="random", feature_dim=feature_dim, num_tokens=num_image_tokens),
+        AdapterConfig(),
+        MoTConfig(max_text_len=32),
     )
 
 
 def _build_mot_tiny_wrapper(num_image_tokens: int = 8, feature_dim: int = 96) -> VLMWrapper:
-    return build_vlm_wrapper(_mot_vlm_config(num_image_tokens, feature_dim))
+    mc, vc, ac, lc = _mot_configs(num_image_tokens, feature_dim)
+    return build_vlm_wrapper(mc, vc, ac, lc)
 
 
 class TestModalityStrategies:
@@ -362,7 +334,7 @@ class TestModalityStrategies:
         assert ctx.modality_ids.device == input_ids.device
 
     def test_cross_attention_strategy_fills_image_features(self):
-        wrapper = build_vlm_wrapper(_ca_vlm_config(num_image_tokens=8))
+        wrapper = _build_ca_tiny_wrapper(num_image_tokens=8)
         strategy = CrossAttentionStrategy()
         pixel_values = torch.randn(1, 3, 64, 64)
         input_ids = torch.randint(0, 256, (1, 16))
@@ -377,7 +349,7 @@ class TestModalityStrategies:
 
     def test_strategy_num_image_tokens_arch_specific(self):
         jd_wrapper = _build_tiny_wrapper(num_image_tokens=12)
-        ca_wrapper = build_vlm_wrapper(_ca_vlm_config(num_image_tokens=12))
+        ca_wrapper = _build_ca_tiny_wrapper(num_image_tokens=12)
         # JD: extends the residual stream by num_image_tokens.
         assert jd_wrapper.num_image_tokens == 12
         # CA: residual stream is text-only, so no extension.
@@ -386,17 +358,17 @@ class TestModalityStrategies:
 
 class TestVLMWrapperDispatch:
     def test_build_modality_strategy_joint_decoder(self):
-        cfg = JointDecoderConfig(vision_encoder="random")
+        cfg = JointDecoderConfig()
         strategy = build_modality_strategy(cfg)
         assert isinstance(strategy, JointDecoderStrategy)
 
     def test_build_modality_strategy_cross_attention(self):
-        cfg = CrossAttentionConfig(vision_encoder="random")
+        cfg = CrossAttentionConfig()
         strategy = build_modality_strategy(cfg)
         assert isinstance(strategy, CrossAttentionStrategy)
 
     def test_build_modality_strategy_mot(self):
-        cfg = MoTConfig(vision_encoder="random")
+        cfg = MoTConfig()
         strategy = build_modality_strategy(cfg)
         assert isinstance(strategy, MoTStrategy)
 
@@ -426,7 +398,7 @@ class TestVLMWrapperDispatch:
         assert isinstance(wrapper.strategy, JointDecoderStrategy)
 
     def test_ca_wrapper_uses_ca_strategy(self):
-        wrapper = build_vlm_wrapper(_ca_vlm_config())
+        wrapper = _build_ca_tiny_wrapper()
         assert isinstance(wrapper.strategy, CrossAttentionStrategy)
 
     def test_mot_wrapper_uses_mot_strategy(self):
@@ -471,7 +443,7 @@ class TestVLMWrapperDispatch:
     def test_ca_forward_logits_text_only_shape(self):
         """CA forward also returns logits with shape (B, T, V): the
         residual stream is text-only, so no extra image positions."""
-        wrapper = build_vlm_wrapper(_ca_vlm_config(num_image_tokens=8)).to(DEVICE).eval()
+        wrapper = _build_ca_tiny_wrapper(num_image_tokens=8).to(DEVICE).eval()
         pixel_values = torch.randn(1, 3, 64, 64, device=DEVICE)
         input_ids = torch.randint(0, 256, (1, 16), device=DEVICE)
         with torch.no_grad():

--- a/tests/unit/test_vlm_config.py
+++ b/tests/unit/test_vlm_config.py
@@ -1,10 +1,16 @@
-"""Unit tests for VLMConfig and its integration with ModelConfig."""
+"""Unit tests for VLMConfig (arch-only after the schema flip).
+
+Vision-encoder fields (``type``/``path``/``feature_dim``/``num_tokens``)
+moved to ``VisionEncoderConfig`` and live in ``tests/unit/test_vision_config.py``.
+Adapter fields (``type``/``hidden_dim``/``activation``) moved to
+``AdapterConfig`` and live in ``tests/unit/test_adapter.py``.
+``JobConfig`` cross-section validation lives in ``tests/unit/test_config.py``.
+"""
 
 from __future__ import annotations
 
 import pytest
 
-from kempnerforge.config.model import ModelConfig
 from kempnerforge.config.registry import registry
 from kempnerforge.config.vlm import (
     DEFAULT_MODULE_PATTERNS,
@@ -20,28 +26,15 @@ from kempnerforge.config.vlm import (
 class TestVLMConfigValidation:
     def test_unknown_arch(self):
         with pytest.raises(ValueError, match="Unknown vlm.arch"):
-            VLMConfig(arch="bogus", vision_encoder="random")
-
-    def test_requires_vision_encoder(self):
-        with pytest.raises(ValueError, match="vision_encoder must be set"):
-            VLMConfig(arch="joint_decoder")
-
-    def test_unknown_adapter_activation(self):
-        with pytest.raises(ValueError, match="adapter_activation"):
-            VLMConfig(vision_encoder="random", adapter_activation="tanh")
-
-    def test_negative_feature_dim(self):
-        with pytest.raises(ValueError, match="non-negative"):
-            VLMConfig(vision_encoder="random", feature_dim=-1)
+            VLMConfig(arch="bogus")
 
     def test_zero_max_text_len(self):
         with pytest.raises(ValueError, match="max_text_len"):
-            VLMConfig(vision_encoder="random", max_text_len=0)
+            VLMConfig(max_text_len=0)
 
     def test_freeze_schedule_monotonic(self):
         with pytest.raises(ValueError, match="strictly monotonic"):
             VLMConfig(
-                vision_encoder="random",
                 freeze_schedule=[
                     FreezeStage(start_step=100, specs=(FreezeSpec("transformer"),)),
                     FreezeStage(start_step=50, specs=(FreezeSpec("transformer"),)),
@@ -50,7 +43,6 @@ class TestVLMConfigValidation:
 
     def test_freeze_schedule_valid_monotonic(self):
         cfg = VLMConfig(
-            vision_encoder="random",
             freeze_schedule=[
                 FreezeStage(start_step=50, specs=(FreezeSpec("transformer"),)),
                 FreezeStage(start_step=100, specs=(FreezeSpec("vision_encoder"),)),
@@ -58,12 +50,8 @@ class TestVLMConfigValidation:
         )
         assert [s.start_step for s in cfg.freeze_schedule] == [50, 100]
 
-    def test_negative_adapter_hidden_dim(self):
-        with pytest.raises(ValueError, match="adapter_hidden_dim must be non-negative"):
-            VLMConfig(vision_encoder="random", adapter_hidden_dim=-1)
-
     def test_default_is_valid(self):
-        cfg = VLMConfig(vision_encoder="random")
+        cfg = VLMConfig()
         assert cfg.arch == "joint_decoder"
         assert cfg.freeze == [FreezeSpec("vision_encoder", True)]
         # module_patterns is a copy, not shared with the module-level default
@@ -75,12 +63,12 @@ class TestVLMConfigSubclasses:
     """Subclassed VLMConfig: discriminated union via registry."""
 
     def test_joint_decoder_config_construction(self):
-        cfg = JointDecoderConfig(vision_encoder="random")
+        cfg = JointDecoderConfig()
         assert cfg.arch == "joint_decoder"
         assert isinstance(cfg, VLMConfig)
 
     def test_cross_attention_config_construction(self):
-        cfg = CrossAttentionConfig(vision_encoder="random")
+        cfg = CrossAttentionConfig()
         assert cfg.arch == "cross_attention"
         assert cfg.cross_attention_every_n_layers == 4
         assert cfg.cross_attention_n_heads == 0
@@ -97,33 +85,29 @@ class TestVLMConfigSubclasses:
 
     def test_cross_attention_invalid_cadence(self):
         with pytest.raises(ValueError, match="cross_attention_every_n_layers"):
-            CrossAttentionConfig(vision_encoder="random", cross_attention_every_n_layers=0)
+            CrossAttentionConfig(cross_attention_every_n_layers=0)
 
     def test_cross_attention_negative_heads(self):
         with pytest.raises(ValueError, match="non-negative"):
-            CrossAttentionConfig(vision_encoder="random", cross_attention_n_heads=-1)
+            CrossAttentionConfig(cross_attention_n_heads=-1)
 
     def test_for_arch_joint_decoder(self):
-        cfg = VLMConfig.for_arch("joint_decoder", vision_encoder="random")
+        cfg = VLMConfig.for_arch("joint_decoder")
         assert isinstance(cfg, JointDecoderConfig)
         assert cfg.arch == "joint_decoder"
 
     def test_for_arch_cross_attention(self):
-        cfg = VLMConfig.for_arch(
-            "cross_attention",
-            vision_encoder="random",
-            cross_attention_every_n_layers=2,
-        )
+        cfg = VLMConfig.for_arch("cross_attention", cross_attention_every_n_layers=2)
         assert isinstance(cfg, CrossAttentionConfig)
         assert cfg.cross_attention_every_n_layers == 2
 
     def test_for_arch_unknown_raises_value_error(self):
         with pytest.raises(ValueError, match="Unknown vlm.arch"):
-            VLMConfig.for_arch("bogus", vision_encoder="random")
+            VLMConfig.for_arch("bogus")
 
     def test_for_arch_error_lists_registered_arches(self):
         try:
-            VLMConfig.for_arch("bogus", vision_encoder="random")
+            VLMConfig.for_arch("bogus")
         except ValueError as e:
             msg = str(e)
             assert "joint_decoder" in msg
@@ -141,26 +125,25 @@ class TestCrossAttentionResolvedHeads:
     """
 
     def test_both_zero_resolve_to_model_n_heads_mha(self):
-        cfg = CrossAttentionConfig(vision_encoder="random")
+        cfg = CrossAttentionConfig()
         n, kv = cfg.resolved_heads(model_n_heads=32)
         assert n == 32
         assert kv == 32
 
     def test_n_heads_zero_n_kv_heads_explicit_gqa(self):
-        cfg = CrossAttentionConfig(vision_encoder="random", cross_attention_n_kv_heads=4)
+        cfg = CrossAttentionConfig(cross_attention_n_kv_heads=4)
         n, kv = cfg.resolved_heads(model_n_heads=32)
         assert n == 32
         assert kv == 4
 
     def test_n_heads_explicit_n_kv_heads_zero_mha(self):
-        cfg = CrossAttentionConfig(vision_encoder="random", cross_attention_n_heads=8)
+        cfg = CrossAttentionConfig(cross_attention_n_heads=8)
         n, kv = cfg.resolved_heads(model_n_heads=32)
         assert n == 8
         assert kv == 8
 
     def test_both_explicit(self):
         cfg = CrossAttentionConfig(
-            vision_encoder="random",
             cross_attention_n_heads=16,
             cross_attention_n_kv_heads=4,
         )
@@ -169,7 +152,7 @@ class TestCrossAttentionResolvedHeads:
         assert kv == 4
 
     def test_zero_model_n_heads_raises(self):
-        cfg = CrossAttentionConfig(vision_encoder="random")
+        cfg = CrossAttentionConfig()
         with pytest.raises(ValueError, match="model_n_heads must be positive"):
             cfg.resolved_heads(model_n_heads=0)
 
@@ -214,7 +197,7 @@ class TestMoTConfig:
     """`MoTConfig` (registered subclass for arch='mot')."""
 
     def test_construction_defaults(self):
-        cfg = MoTConfig(vision_encoder="random")
+        cfg = MoTConfig()
         assert cfg.arch == "mot"
         assert isinstance(cfg, VLMConfig)
         assert cfg.mot_modalities == ("image", "text")
@@ -223,7 +206,7 @@ class TestMoTConfig:
         assert cfg.mot_warm_start_from_text is False
 
     def test_module_patterns_has_mot_alias(self):
-        cfg = MoTConfig(vision_encoder="random")
+        cfg = MoTConfig()
         assert "mot" in cfg.module_patterns
         assert cfg.module_patterns["mot"] == [
             "transformer.layers",
@@ -234,93 +217,84 @@ class TestMoTConfig:
         assert "vision_encoder" in cfg.module_patterns
 
     def test_for_arch_mot_returns_subclass(self):
-        cfg = VLMConfig.for_arch("mot", vision_encoder="random")
+        cfg = VLMConfig.for_arch("mot")
         assert isinstance(cfg, MoTConfig)
         assert cfg.arch == "mot"
 
     def test_for_arch_mot_with_overrides(self):
         cfg = VLMConfig.for_arch(
             "mot",
-            vision_encoder="random",
-            num_tokens=64,
             mot_warm_start_from_text=True,
             mot_warm_start_path="/tmp/jd_ckpt.pt",
         )
         assert isinstance(cfg, MoTConfig)
-        assert cfg.num_tokens == 64
         assert cfg.mot_warm_start_from_text is True
 
-    def test_residual_stream_image_tokens_matches_num_tokens(self):
-        cfg = MoTConfig(vision_encoder="random", num_tokens=128)
-        assert cfg.residual_stream_image_tokens() == 128
+    def test_residual_stream_image_tokens_passes_through(self):
+        cfg = MoTConfig()
+        assert cfg.residual_stream_image_tokens(128) == 128
 
     def test_resolved_image_heads_zero_inherits_model(self):
-        cfg = MoTConfig(vision_encoder="random")
+        cfg = MoTConfig()
         n, kv = cfg.resolved_image_heads(model_n_heads=32)
         assert n == 32 and kv == 32  # MHA default (no model_n_kv_heads passed)
 
     def test_resolved_image_heads_inherits_model_gqa(self):
         """When the text backbone is GQA, image kv_heads inherits the text
         kv_heads default (so v1's equal-head-count check still passes)."""
-        cfg = MoTConfig(vision_encoder="random")
+        cfg = MoTConfig()
         n, kv = cfg.resolved_image_heads(model_n_heads=32, model_n_kv_heads=8)
         assert n == 32 and kv == 8  # inherits text-side GQA
 
     def test_resolved_image_heads_explicit_n_kv_heads(self):
-        cfg = MoTConfig(vision_encoder="random", mot_image_n_kv_heads=4)
+        cfg = MoTConfig(mot_image_n_kv_heads=4)
         n, kv = cfg.resolved_image_heads(model_n_heads=32)
         assert n == 32 and kv == 4  # GQA on image path
 
     def test_resolved_image_heads_explicit_n_heads(self):
-        cfg = MoTConfig(vision_encoder="random", mot_image_n_heads=8)
+        cfg = MoTConfig(mot_image_n_heads=8)
         n, kv = cfg.resolved_image_heads(model_n_heads=32)
         assert n == 8 and kv == 8
 
     def test_resolved_image_heads_zero_model_raises(self):
-        cfg = MoTConfig(vision_encoder="random")
+        cfg = MoTConfig()
         with pytest.raises(ValueError, match="model_n_heads must be positive"):
             cfg.resolved_image_heads(model_n_heads=0)
 
     def test_mot_modalities_must_include_text(self):
         with pytest.raises(ValueError, match="must include 'text'"):
-            MoTConfig(vision_encoder="random", mot_modalities=("image", "audio"))
+            MoTConfig(mot_modalities=("image", "audio"))
 
     def test_mot_modalities_must_include_image(self):
         with pytest.raises(ValueError, match="must include 'image'"):
-            MoTConfig(vision_encoder="random", mot_modalities=("text", "audio"))
+            MoTConfig(mot_modalities=("text", "audio"))
 
     def test_mot_modalities_too_short_raises(self):
         with pytest.raises(ValueError, match="at least 2 entries"):
-            MoTConfig(vision_encoder="random", mot_modalities=("text",))
+            MoTConfig(mot_modalities=("text",))
 
     def test_mot_modalities_duplicates_raise(self):
         with pytest.raises(ValueError, match="duplicates"):
-            MoTConfig(vision_encoder="random", mot_modalities=("image", "text", "text"))
+            MoTConfig(mot_modalities=("image", "text", "text"))
 
     def test_negative_image_heads_raises(self):
         with pytest.raises(ValueError, match="non-negative"):
-            MoTConfig(vision_encoder="random", mot_image_n_heads=-1)
+            MoTConfig(mot_image_n_heads=-1)
 
     def test_negative_image_kv_heads_raises(self):
         with pytest.raises(ValueError, match="non-negative"):
-            MoTConfig(vision_encoder="random", mot_image_n_kv_heads=-1)
-
-    def test_inherits_base_validation(self):
-        """Base-class validations still fire on MoT subclass."""
-        with pytest.raises(ValueError, match="vision_encoder must be set"):
-            MoTConfig()
+            MoTConfig(mot_image_n_kv_heads=-1)
 
     def test_warm_start_path_default_empty(self):
-        cfg = MoTConfig(vision_encoder="random")
+        cfg = MoTConfig()
         assert cfg.mot_warm_start_path == ""
 
     def test_warm_start_from_text_requires_path(self):
         with pytest.raises(ValueError, match="mot_warm_start_path"):
-            MoTConfig(vision_encoder="random", mot_warm_start_from_text=True)
+            MoTConfig(mot_warm_start_from_text=True)
 
     def test_warm_start_from_text_with_path(self):
         cfg = MoTConfig(
-            vision_encoder="random",
             mot_warm_start_from_text=True,
             mot_warm_start_path="/tmp/jd_ckpt.pt",
         )
@@ -330,57 +304,8 @@ class TestMoTConfig:
     def test_warm_start_path_set_without_flag_is_valid(self):
         """Path can be set without the flag; the flag is the gate."""
         cfg = MoTConfig(
-            vision_encoder="random",
             mot_warm_start_from_text=False,
             mot_warm_start_path="/tmp/jd_ckpt.pt",
         )
         assert cfg.mot_warm_start_from_text is False
         assert cfg.mot_warm_start_path == "/tmp/jd_ckpt.pt"
-
-
-class TestModelConfigWithVLM:
-    def test_is_vlm_false_by_default(self):
-        mc = ModelConfig()
-        assert mc.is_vlm is False
-        assert mc.vlm is None
-
-    def test_is_vlm_true_when_set(self):
-        mc = ModelConfig(
-            max_seq_len=1024,
-            vlm=VLMConfig(vision_encoder="random", num_tokens=64, max_text_len=512),
-        )
-        assert mc.is_vlm is True
-
-    def test_max_seq_len_cross_check_raises(self):
-        with pytest.raises(ValueError, match="max_seq_len.*insufficient"):
-            ModelConfig(
-                max_seq_len=128,
-                vlm=VLMConfig(
-                    vision_encoder="random",
-                    num_tokens=64,
-                    max_text_len=512,
-                ),
-            )
-
-    def test_max_seq_len_ok_when_large_enough(self):
-        mc = ModelConfig(
-            max_seq_len=600,
-            vlm=VLMConfig(
-                vision_encoder="random",
-                num_tokens=64,
-                max_text_len=512,
-            ),
-        )
-        assert mc.max_seq_len == 600
-
-    def test_num_tokens_zero_defers_check(self):
-        """num_tokens=0 means 'infer at build time'; config-time check is skipped."""
-        mc = ModelConfig(
-            max_seq_len=64,
-            vlm=VLMConfig(
-                vision_encoder="random",
-                num_tokens=0,
-                max_text_len=512,
-            ),
-        )
-        assert mc.is_vlm is True


### PR DESCRIPTION
## Summary
- Lift component fields out of `VLMConfig`: vision-encoder fields move
  to the new `VisionEncoderConfig`; adapter fields stay on the
  existing `AdapterConfig`; arch knobs stay on `VLMConfig`.
- `JobConfig` gains parallel top-level fields `vision_encoder`,
  `adapter`, `vlm` and owns cross-section validation (`max_seq_len`,
  `train.seq_len`, the VLM + PP rejection).
- `ModelConfig` drops the `vlm` field and `is_vlm` property; `is_vlm`
  moves to `JobConfig`. `build_vlm_wrapper`, `_build_vlm`,
  `build_parallel_model` take the configs as explicit kwargs.

## Changes
- New: `kempnerforge/config/vision.py` (`VisionEncoderConfig` with
  `type`, `path`, `feature_dim`, `num_tokens`; `__post_init__`
  validates `type` against the registered encoders).
- `VLMConfig` keeps `arch`, `max_text_len`, `freeze`, `freeze_schedule`,
  `module_patterns`. Subclass-specific fields unchanged.
- `Transformer.__init__` takes `vlm_config` and `num_image_tokens` as
  kwargs instead of reading `ModelConfig.vlm`. Text-only callers pass
  nothing and get the existing behavior.
- 10 VLM configs rewritten to the new schema. `[adapter]` section
  omitted when defaults apply (all 10 omit it).
- 12 test files migrate. `tests/unit/test_vision_config.py` is new
  (8 tests). `test_vlm_config.py` keeps only arch knobs.

Closes #90

## Test plan
- [x] `uv run pytest tests/unit/` (1227 pass, 2 skipped on this machine)
- [x] `uv run pytest tests/integration/` on a single H200 (68 pass)
- [x] `uv run pytest tests/e2e/ --e2e` on a single H200 (10 pass, 19
      multi-GPU tests skipped)
- [x] `uv run ruff check` + `uv run ruff format --check` (clean)
- [x] `uv run pyright kempnerforge/` (0 errors)
- [x] `tests/distributed/test_vlm_*_fsdp.py` via `torchrun` on a 2+ GPU
      node (deferred to CI; migration is mechanical and matches the
      single-GPU pattern that is green here).