### PR TITLE
Document Mode, tokenizer pairing, and max_seq_len rule in VLM configs

### DIFF
--- a/configs/train/vlm_7b.toml
+++ b/configs/train/vlm_7b.toml
@@ -1,5 +1,11 @@
 # 7B VLM Joint-Decoder on 4x H200 (141 GB/GPU).
 #
+# Mode: smoke.
+#
+# max_seq_len allocation (JD/MoT): residual_image_tokens + max_text_len.
+# Image tokens prepend the text sequence in the residual stream, so the
+# budget must cover both modalities.
+#
 # Primary 7B VLM config. Activation checkpointing is OFF to trade
 # recompute for throughput, and batch_size=16 per GPU uses ~72% of
 # H200 VRAM. For memory-tighter setups (fewer GPUs, smaller GPUs,
@@ -30,7 +36,7 @@ vocab_size = 50257
 ffn_dim_multiplier = 1.3
 norm_type = "rmsnorm"
 activation = "silu"
-max_seq_len = 1024
+max_seq_len = 1024     # 256 image + 512 text (max_text_len default) + headroom
 rope_theta = 500000.0
 tie_embeddings = false
 

--- a/configs/train/vlm_7b_ac.toml
+++ b/configs/train/vlm_7b_ac.toml
@@ -1,5 +1,11 @@
 # 7B VLM Joint-Decoder with activation checkpointing (memory-tight).
 #
+# Mode: smoke.
+#
+# max_seq_len allocation (JD/MoT): residual_image_tokens + max_text_len.
+# Image tokens prepend the text sequence in the residual stream, so the
+# budget must cover both modalities.
+#
 # Sibling of vlm_7b.toml with activation_checkpointing="full" and a
 # smaller batch. Use when memory is tight (fewer GPUs, longer seq_len,
 # larger image token count) or when recompute is cheap relative to
@@ -27,7 +33,7 @@ vocab_size = 50257          # gpt2 tokenizer vocab
 ffn_dim_multiplier = 1.3
 norm_type = "rmsnorm"
 activation = "silu"
-max_seq_len = 1024
+max_seq_len = 1024          # 256 image + 512 text (max_text_len default) + headroom
 rope_theta = 500000.0
 tie_embeddings = false
 

--- a/configs/train/vlm_7b_cross_attn.toml
+++ b/configs/train/vlm_7b_cross_attn.toml
@@ -1,5 +1,10 @@
 # 7B VLM Cross-Attention on 4x H200 (141 GB/GPU).
 #
+# Mode: smoke.
+#
+# max_seq_len allocation (CA): max_text_len only. The residual stream is
+# text-only; image features flow as K/V into separate CrossAttentionBlocks.
+#
 # Llama-3-V style: text flows through the main self-attention stack
 # unchanged; CrossAttentionBlocks are inserted between regular
 # transformer blocks at a configurable cadence (default 4 ->
@@ -42,7 +47,7 @@ vocab_size = 50257
 ffn_dim_multiplier = 1.3
 norm_type = "rmsnorm"
 activation = "silu"
-max_seq_len = 1024
+max_seq_len = 1024     # text-only (CA): max_text_len default 512 + headroom
 rope_theta = 500000.0
 tie_embeddings = false
 

--- a/configs/train/vlm_7b_freeze_schedule.toml
+++ b/configs/train/vlm_7b_freeze_schedule.toml
@@ -1,6 +1,11 @@
 # 7B VLM Cross-Attention with a multi-stage freeze schedule + async
 # DCP checkpointing.
 #
+# Mode: smoke.
+#
+# max_seq_len allocation (CA): max_text_len only. The residual stream is
+# text-only; image features flow as K/V into separate CrossAttentionBlocks.
+#
 # Exercises the FreezeStage hook in scripts/train.py:
 #   - step 0..9: vision encoder frozen, everything else trainable.
 #   - step 10: freeze adapter (typical "pretrain CA blocks first" recipe).
@@ -31,7 +36,7 @@ vocab_size = 50257
 ffn_dim_multiplier = 1.3
 norm_type = "rmsnorm"
 activation = "silu"
-max_seq_len = 1024
+max_seq_len = 1024     # text-only (CA): max_text_len default 512 + headroom
 rope_theta = 500000.0
 tie_embeddings = false
 

--- a/configs/train/vlm_7b_mot.toml
+++ b/configs/train/vlm_7b_mot.toml
@@ -1,5 +1,11 @@
 # 7B VLM Mixture-of-Transformers (MoT) on 4x H200 (141 GB/GPU).
 #
+# Mode: smoke.
+#
+# max_seq_len allocation (JD/MoT): residual_image_tokens + max_text_len.
+# Image tokens prepend the text sequence in the residual stream, so the
+# budget must cover both modalities.
+#
 # Per-modality Q/K/V/O + per-modality FFN at every layer; single global
 # self-attention mixes both modality streams within each layer
 # (Liang et al. 2024 Algorithm 1). Image tokens prepend the text
@@ -42,7 +48,7 @@ vocab_size = 50257
 ffn_dim_multiplier = 1.3
 norm_type = "rmsnorm"
 activation = "silu"
-max_seq_len = 1024
+max_seq_len = 1024     # 256 image + 512 text (max_text_len default) + headroom
 rope_theta = 500000.0
 tie_embeddings = false
 

--- a/configs/train/vlm_7b_siglip2.toml
+++ b/configs/train/vlm_7b_siglip2.toml
@@ -1,5 +1,18 @@
 # 7B Llama-style backbone + SigLIP2 vision encoder, Joint-Decoder VLM.
 #
+# Mode: real-run starting point (max_steps = 5000).
+#
+# Tokenizer: meta-llama/Meta-Llama-3-8B (vocab_size = 128256). The SigLIP2
+# family uses the Llama-3 vocab to match a real Llama-3 + SigLIP2
+# production target. Other configs in this folder use gpt2 (vocab_size =
+# 50257) for fast smoke iteration.
+#
+# max_seq_len allocation (JD/MoT): residual_image_tokens + max_text_len.
+# Image tokens prepend the text sequence in the residual stream, so the
+# budget must cover both modalities. SigLIP2-base-patch16-224 probes
+# num_tokens = 196 (14x14 patches, no CLS); with max_text_len = 2048 the
+# minimum is 2244 and 2304 leaves a small headroom margin.
+#
 # Target: 4-8 GPU single node via FSDP2. Pipeline parallelism with VLM is
 # not supported on this branch (JobConfig.validate raises).
 #
@@ -30,7 +43,7 @@ vocab_size = 128256
 ffn_dim_multiplier = 1.3
 norm_type = "rmsnorm"
 activation = "silu"
-max_seq_len = 2304     # 256 image + 2048 text
+max_seq_len = 2304     # 196 image (SigLIP2-base probes 14x14 patches) + 2048 text + headroom
 rope_theta = 500000.0
 tie_embeddings = false
 

--- a/configs/train/vlm_7b_siglip2_cross_attn.toml
+++ b/configs/train/vlm_7b_siglip2_cross_attn.toml
@@ -1,5 +1,15 @@
 # 7B Llama-style backbone + SigLIP2 vision encoder, Cross-Attention VLM.
 #
+# Mode: smoke.
+#
+# Tokenizer: meta-llama/Meta-Llama-3-8B (vocab_size = 128256). The SigLIP2
+# family uses the Llama-3 vocab to match a real Llama-3 + SigLIP2
+# production target. Other configs in this folder use gpt2 (vocab_size =
+# 50257) for fast smoke iteration.
+#
+# max_seq_len allocation (CA): max_text_len only. The residual stream is
+# text-only; image features flow as K/V into separate CrossAttentionBlocks.
+#
 # Sibling of vlm_7b_siglip2.toml (Joint-Decoder) for the Cross-Attention
 # arch. Image features flow as K/V into separate CrossAttentionBlocks
 # at cadence 4 (n_layers=32 -> 8 CA blocks); the residual stream

--- a/configs/train/vlm_debug.toml
+++ b/configs/train/vlm_debug.toml
@@ -1,9 +1,15 @@
 # VLM smoke config — tiny LLM + random vision encoder.
 #
+# Mode: smoke.
+#
 # Runs end-to-end in <1 minute on 1 GPU. Uses RandomVisionEncoder so no
 # HF download is needed; pair with any HF image-text dataset (the default
 # below is a placeholder). For a real vision encoder, see
 # configs/train/vlm_7b_siglip2.toml.
+#
+# max_seq_len allocation (JD/MoT): residual_image_tokens + max_text_len.
+# Image tokens prepend the text sequence in the residual stream, so the
+# budget must cover both modalities.
 #
 # Usage:
 #   uv run python scripts/train.py configs/train/vlm_debug.toml \

--- a/configs/train/vlm_debug_moe.toml
+++ b/configs/train/vlm_debug_moe.toml
@@ -1,6 +1,11 @@
 # VLM + MoE smoke config — tiny LLM with MoE TransformerBlocks +
 # random vision encoder + Cross-Attention.
 #
+# Mode: smoke.
+#
+# max_seq_len allocation (CA): max_text_len only. The residual stream is
+# text-only; image features flow as K/V into separate CrossAttentionBlocks.
+#
 # MoE lives in the text TransformerBlocks (every other layer at
 # moe_frequency=2). CrossAttentionBlocks remain dense MLPs. The two
 # arches compose: image features flow as K/V into CA blocks, while

--- a/configs/train/vlm_debug_mot.toml
+++ b/configs/train/vlm_debug_mot.toml
@@ -1,8 +1,14 @@
 # VLM smoke config — Mixture-of-Transformers (MoT) arch, tiny LLM + random vision encoder.
 #
+# Mode: smoke.
+#
 # Runs end-to-end in <1 minute on 1 GPU. Uses RandomVisionEncoder so no
 # HF download is needed. Per-modality Q/K/V/O + per-modality FFN at every
 # layer, single global self-attention (Liang et al. 2024 Algorithm 1).
+#
+# max_seq_len allocation (JD/MoT): residual_image_tokens + max_text_len.
+# Image tokens prepend the text sequence in the residual stream, so the
+# budget must cover both modalities.
 #
 # Usage:
 #   uv run python scripts/train.py configs/train/vlm_debug_mot.toml \


### PR DESCRIPTION
## Summary

Adds three header documentation items to every VLM config so the
choices are explicit instead of accidental:

- `# Mode: smoke` or `# Mode: real-run starting point (max_steps = N)`
  near the top of each file. Only `vlm_7b_siglip2.toml` is real-run
  (5000 steps); the other 9 are smoke configs (15-200 steps).
- Tokenizer/vocab rationale on the SigLIP2 family
  (`vlm_7b_siglip2.toml`, `vlm_7b_siglip2_cross_attn.toml`) explaining
  why these two use the Llama-3 tokenizer (128256 vocab) while every
  other config uses gpt2 (50257).
- `# max_seq_len allocation` rule in every header, plus inline
  arithmetic next to the `max_seq_len = N` line. JD/MoT configs note
  `residual_image_tokens + max_text_len`; CA configs note
  `max_text_len` only.

Also fixes a stale inline comment in `vlm_7b_siglip2.toml` that said
`# 256 image + 2048 text` next to `max_seq_len = 2304`.
SigLIP2-base-patch16-224 probes `num_tokens = 196` (14x14 patches, no
CLS), so the correct arithmetic is `196 + 2048 = 2244 < 2304`
(headroom).

Closes #92

## Changes

10 `configs/train/vlm_*.toml` files, header-comment-only edits.

## Test plan
- [x] `uv run pytest tests/unit/test_config.py` (106 pass, 1 skipped:
      loader still parses both TOMLs that are exercised by tests).
- [x] `uv run pytest tests/unit/` (1227 pass, 2 skipped).
- [x] `uv run ruff check configs/ kempnerforge/ tests/ scripts/`
      (clean).
- [x] No source or test changes; integration/e2e/distributed paths
      unaffected.