### PR TITLE
Warn when HF-backed vision encoder is paired with override knobs

### DIFF
--- a/kempnerforge/config/job.py
+++ b/kempnerforge/config/job.py
@@ -18,6 +18,13 @@ from kempnerforge.config.training import TrainConfig
 from kempnerforge.config.vision import VisionEncoderConfig
 from kempnerforge.config.vlm import VLMConfig
 
+# Vision-encoder types whose builders load a HuggingFace model and probe
+# feature_dim / num_tokens from the model's config. Setting these knobs
+# explicitly in the TOML overrides the probe and is almost always a
+# user mistake. The "random" stub is excluded because it has no model
+# to probe and the user-supplied values are the actual values.
+_HF_VISION_ENCODER_TYPES = frozenset({"siglip2", "clip"})
+
 
 @dataclass
 class JobConfig:
@@ -63,6 +70,30 @@ class JobConfig:
                 # Materialize the default adapter so downstream callers always
                 # see a non-None AdapterConfig once [vlm] is present.
                 self.adapter = AdapterConfig()
+            # HF-backed encoder override warning. SigLIP2 / CLIP encoders
+            # probe their own feature_dim and num_tokens from the loaded
+            # HF model. Setting these to non-zero values in the TOML
+            # overrides the probe at build time and silently desyncs from
+            # the actual model, so warn the user. The override is still
+            # legal (the builder applies it post-probe) so this is a
+            # warning, not an error.
+            if self.vision_encoder.type in _HF_VISION_ENCODER_TYPES and (
+                self.vision_encoder.feature_dim > 0 or self.vision_encoder.num_tokens > 0
+            ):
+                import logging
+
+                overrides = []
+                if self.vision_encoder.feature_dim > 0:
+                    overrides.append(f"feature_dim={self.vision_encoder.feature_dim}")
+                if self.vision_encoder.num_tokens > 0:
+                    overrides.append(f"num_tokens={self.vision_encoder.num_tokens}")
+                logging.getLogger(__name__).warning(
+                    "vision_encoder.type=%r is HF-backed and probes its own dims; "
+                    "setting %s overrides the probe and may desync from the loaded "
+                    "model. Leave both at 0 to use the probed values.",
+                    self.vision_encoder.type,
+                    " and ".join(overrides),
+                )
             # max_seq_len cross-check. Effective residual-stream length is
             # residual_stream_image_tokens(num_tokens) + max_text_len.
             #   - Joint-Decoder / MoT: residual is num_tokens + max_text_len.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -414,6 +414,76 @@ class TestJobConfig:
         config.validate(world_size=1)  # Should not raise.
 
 
+class TestHfEncoderOverrideWarning:
+    """HF-backed encoders probe feature_dim / num_tokens from the loaded
+    model. Non-zero TOML values override the probe at build time and
+    silently desync from the actual model, so ``JobConfig.__post_init__``
+    logs a warning.
+
+    ``kempnerforge.metrics.logger._configure_root`` sets
+    ``propagate = False`` on the ``kempnerforge`` logger, which blocks
+    pytest's caplog (attached at the python root). We temporarily
+    re-enable propagation in setup/teardown so caplog can observe the
+    records from ``kempnerforge.config.job``.
+    """
+
+    def setup_method(self):
+        import logging
+
+        self._kf_logger = logging.getLogger("kempnerforge")
+        self._old_propagate = self._kf_logger.propagate
+        self._kf_logger.propagate = True
+
+    def teardown_method(self):
+        self._kf_logger.propagate = self._old_propagate
+
+    def _vlm_config_with(self, *, type: str, feature_dim: int = 0, num_tokens: int = 0):
+        return JobConfig(
+            model=ModelConfig(max_seq_len=2304),
+            vision_encoder=VisionEncoderConfig(
+                type=type, feature_dim=feature_dim, num_tokens=num_tokens
+            ),
+            adapter=AdapterConfig(),
+            vlm=VLMConfig(max_text_len=2048),
+        )
+
+    def test_warns_when_siglip2_paired_with_num_tokens(self, caplog):
+        with caplog.at_level("WARNING", logger="kempnerforge.config.job"):
+            self._vlm_config_with(type="siglip2", num_tokens=196)
+        assert any(
+            "siglip2" in r.getMessage() and "num_tokens=196" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_warns_when_clip_paired_with_feature_dim(self, caplog):
+        with caplog.at_level("WARNING", logger="kempnerforge.config.job"):
+            self._vlm_config_with(type="clip", feature_dim=768)
+        assert any(
+            "clip" in r.getMessage() and "feature_dim=768" in r.getMessage() for r in caplog.records
+        )
+
+    def test_warns_with_both_overrides(self, caplog):
+        with caplog.at_level("WARNING", logger="kempnerforge.config.job"):
+            self._vlm_config_with(type="siglip2", feature_dim=768, num_tokens=196)
+        matches = [r.getMessage() for r in caplog.records if "siglip2" in r.getMessage()]
+        assert len(matches) == 1
+        assert "feature_dim=768" in matches[0]
+        assert "num_tokens=196" in matches[0]
+
+    def test_no_warning_for_hf_with_zero_overrides(self, caplog):
+        """The documented path: HF type + both knobs at 0. No warning."""
+        with caplog.at_level("WARNING", logger="kempnerforge.config.job"):
+            self._vlm_config_with(type="siglip2")
+        assert not any("siglip2" in r.getMessage() for r in caplog.records)
+
+    def test_no_warning_for_random_with_overrides(self, caplog):
+        """The 'random' stub has no model to probe; user-supplied values
+        ARE the actual values. No warning regardless of non-zero values."""
+        with caplog.at_level("WARNING", logger="kempnerforge.config.job"):
+            self._vlm_config_with(type="random", feature_dim=384, num_tokens=64)
+        assert not any("random" in r.getMessage() for r in caplog.records)
+
+
 # ---------------------------------------------------------------------------
 # TOML Loading
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `JobConfig.__post_init__` logs a `WARNING` via
  `logging.getLogger("kempnerforge.config.job")` when
  `vision_encoder.type in {"siglip2", "clip"}` and
  `vision_encoder.feature_dim > 0` or
  `vision_encoder.num_tokens > 0`.
- The HF-backed type set lives at module scope in `config/job.py` as
  `_HF_VISION_ENCODER_TYPES = frozenset({"siglip2", "clip"})`. Adding a
  third HF encoder is one string append.
- The override is still legal (the builder applies the user value
  post-probe). This is a warning, not an error.

Closes #94

## Changes
- `kempnerforge/config/job.py`: `_HF_VISION_ENCODER_TYPES` constant +
  warning in `__post_init__`.
- `tests/unit/test_config.py`: new `TestHfEncoderOverrideWarning`
  class with 5 tests covering siglip2 + num_tokens, clip +
  feature_dim, both at once, HF + zero overrides (silent), random +
  non-zero (silent). Test class flips
  `kempnerforge` logger propagation in `setup_method` because
  `metrics/logger.py:_configure_root` sets `propagate = False` which
  blocks `caplog` from observing records.

## Test plan
- [x] `uv run pytest tests/unit/test_config.py` (111 pass, 1 skipped).
- [x] `uv run pytest tests/unit/` (1232 pass, 2 skipped; was 1227 + 5
      new).
- [x] `uv run ruff check kempnerforge/ tests/ scripts/` (clean).
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/`
      (clean).
- [x] `uv run pyright kempnerforge/` (0 errors).
- [x] No source-side behavior change for the documented HF path
      (both knobs at 0), so integration/e2e/distributed paths
      unaffected.