### PR TITLE
Fix five VLM-FSDP distributed tests under multi-node srun

### DIFF
--- a/tests/distributed/conftest.py
+++ b/tests/distributed/conftest.py
@@ -9,11 +9,22 @@ multiple times in the same process.
 from __future__ import annotations
 
 import os
+import shutil
+import tempfile
+from pathlib import Path
 
 import pytest
+import torch.distributed as dist
 
 from kempnerforge.config.schema import DistributedConfig
 from kempnerforge.distributed.setup import destroy_distributed, init_distributed
+
+# Tests that use shared_tmp_dir write under <repo>/.test_tmp/ instead of /tmp
+# so multi-node srun runs see the same directory on every rank. /tmp is
+# node-local and breaks DCP save/load across nodes when each rank writes its
+# shard to its own /tmp.
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_TEST_TMP = _PROJECT_ROOT / ".test_tmp"
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -33,3 +44,30 @@ def _distributed_init():
 def distributed_env(_distributed_init):
     """Per-test accessor for the shared DeviceMesh."""
     return _distributed_init
+
+
+@pytest.fixture
+def shared_tmp_dir():
+    """Create a tmp directory on the shared filesystem visible to all ranks.
+
+    Rank 0 creates the directory under ``<repo>/.test_tmp/`` and broadcasts
+    the path; all other ranks read the same path. The directory is removed
+    after the test. Use this instead of ``tmp_path_factory`` for any
+    distributed test that writes files one rank can read on another (DCP
+    save/load, torch.save+torch.load, etc.); ``/tmp`` is node-local and
+    such tests will fail under multi-node srun even though they pass under
+    single-node torchrun.
+    """
+    rank = dist.get_rank()
+    if rank == 0:
+        _TEST_TMP.mkdir(exist_ok=True)
+        d = tempfile.mkdtemp(dir=_TEST_TMP)
+    else:
+        d = ""
+    obj_list: list[object] = [d]
+    dist.broadcast_object_list(obj_list, src=0)
+    d = obj_list[0]  # type: ignore[assignment]
+    yield d
+    dist.barrier()
+    if rank == 0:
+        shutil.rmtree(d, ignore_errors=True)

--- a/tests/distributed/test_vlm_cross_attn_fsdp.py
+++ b/tests/distributed/test_vlm_cross_attn_fsdp.py
@@ -311,7 +311,7 @@ class TestMoEWithVLM:
 
 
 class TestCheckpointRoundtrip:
-    def test_save_load_freeze_metadata(self, distributed_env, tmp_path_factory):
+    def test_save_load_freeze_metadata(self, distributed_env, shared_tmp_dir):
         """Save a CA VLM checkpoint, load it in a fresh manager, and
         verify metadata.json carries the canonical vlm_freeze (computed
         through effective_freeze) and DCP shards round-trip the
@@ -322,15 +322,10 @@ class TestCheckpointRoundtrip:
         wrapper = _build(cfg, mesh)
         opt = build_optimizer(wrapper, OptimizerConfig(lr=1e-3, fused=False))
 
+        # shared_tmp_dir lives on the shared filesystem so DCP shards
+        # written by rank 0 are visible to rank 1 under multi-node srun.
+        path_str = shared_tmp_dir
         rank = dist.get_rank()
-        if rank == 0:
-            base = tmp_path_factory.mktemp("vlm_ca_ckpt")
-            path_str = str(base)
-        else:
-            path_str = ""
-        objs: list[object] = [path_str]
-        dist.broadcast_object_list(objs, src=0)
-        path_str = objs[0]  # type: ignore[assignment]
 
         ckpt_cfg = CheckpointConfig(dir=str(path_str), interval=1)
         mgr = CheckpointManager(ckpt_cfg, wrapper, opt)

--- a/tests/distributed/test_vlm_fsdp.py
+++ b/tests/distributed/test_vlm_fsdp.py
@@ -184,7 +184,7 @@ class TestInnerTransformerUnderCompileAndFsdp:
 
 
 class TestCheckpointRoundtrip:
-    def test_save_load_freeze_metadata(self, distributed_env, tmp_path_factory):
+    def test_save_load_freeze_metadata(self, distributed_env, shared_tmp_dir):
         """Save a VLM checkpoint, load it in a fresh manager, and verify
         the canonical vlm_freeze metadata is present in metadata.json."""
         mesh = distributed_env
@@ -192,17 +192,11 @@ class TestCheckpointRoundtrip:
         wrapper = _build(cfg_tuple, mesh)
         opt = build_optimizer(wrapper, OptimizerConfig(lr=1e-3, fused=False))
 
-        # Per-rank tmp path picked from rank 0 and broadcast so all ranks
-        # agree on the same base directory.
+        # shared_tmp_dir is on the shared filesystem and identical on every
+        # rank, so DCP shards from rank 0 are visible to rank 1 even under
+        # multi-node srun.
+        path_str = shared_tmp_dir
         rank = dist.get_rank()
-        if rank == 0:
-            base = tmp_path_factory.mktemp("vlm_ckpt")
-            path_str = str(base)
-        else:
-            path_str = ""
-        objs: list[object] = [path_str]
-        dist.broadcast_object_list(objs, src=0)
-        path_str = objs[0]  # type: ignore[assignment]
 
         cfg = CheckpointConfig(dir=str(path_str), interval=1)
         mgr = CheckpointManager(cfg, wrapper, opt)

--- a/tests/distributed/test_vlm_fsdp.py
+++ b/tests/distributed/test_vlm_fsdp.py
@@ -188,7 +188,8 @@ class TestCheckpointRoundtrip:
         """Save a VLM checkpoint, load it in a fresh manager, and verify
         the canonical vlm_freeze metadata is present in metadata.json."""
         mesh = distributed_env
-        wrapper = _build(_tiny_cfg(), mesh)
+        cfg_tuple = _tiny_cfg()
+        wrapper = _build(cfg_tuple, mesh)
         opt = build_optimizer(wrapper, OptimizerConfig(lr=1e-3, fused=False))
 
         # Per-rank tmp path picked from rank 0 and broadcast so all ranks
@@ -205,7 +206,8 @@ class TestCheckpointRoundtrip:
 
         cfg = CheckpointConfig(dir=str(path_str), interval=1)
         mgr = CheckpointManager(cfg, wrapper, opt)
-        freeze = canonical_freeze_meta(_tiny_cfg().vlm.freeze)  # type: ignore[union-attr]
+        # _tiny_cfg returns (ModelConfig, VisionEncoderConfig, AdapterConfig, VLMConfig)
+        freeze = canonical_freeze_meta(cfg_tuple[3].freeze)
         mgr.save(step=1, extra={"vlm_freeze": freeze})
 
         # Let rank 0 finish writing metadata.json before rank 1 reads it.

--- a/tests/distributed/test_vlm_mot_fsdp.py
+++ b/tests/distributed/test_vlm_mot_fsdp.py
@@ -334,13 +334,15 @@ class TestMoEWithMoT:
         from kempnerforge.model.moe import MoEMLP
 
         torch.manual_seed(42 + dist.get_rank())
-        mc = _tiny_mot_cfg(moe=True, n_layers=4, num_image_tokens=4)
+        # _tiny_mot_cfg returns (ModelConfig, VisionEncoderConfig, AdapterConfig, MoTConfig);
+        # destructure to mutate the ModelConfig in place before passing the tuple to _build.
+        mc, vc, ac, lc = _tiny_mot_cfg(moe=True, n_layers=4, num_image_tokens=4)
         # Bump the dim/ffn so MoE is meaningful.
         mc.dim = 128
         mc.n_heads = 4
         mc.n_kv_heads = 4
         mc.ffn_hidden_dim = 256
-        wrapper = _build(mc, distributed_env, param_dtype=torch.float32)
+        wrapper = _build((mc, vc, ac, lc), distributed_env, param_dtype=torch.float32)
         # 4 layers, frequency=2 -> layers 1, 3 have MoE per modality.
         moe_blocks = sum(
             1

--- a/tests/distributed/test_vlm_mot_fsdp.py
+++ b/tests/distributed/test_vlm_mot_fsdp.py
@@ -24,6 +24,7 @@ Mirrors ``tests/distributed/test_vlm_cross_attn_fsdp.py`` for the MoT arch:
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 import torch
@@ -266,7 +267,7 @@ class TestDeterminism:
 
 
 class TestWarmStartUnderFsdp:
-    def test_warm_start_from_jd_under_fsdp(self, distributed_env, tmp_path_factory):
+    def test_warm_start_from_jd_under_fsdp(self, distributed_env, shared_tmp_dir):
         """JD checkpoint -> torch.save -> mot_warm_start_from_text_stack
         on an FSDP2-wrapped MoT model. Per-modality copies become bit-equal
         to the source dense block weights after the helper runs.
@@ -298,16 +299,10 @@ class TestWarmStartUnderFsdp:
             t = v.full_tensor() if hasattr(v, "full_tensor") else v
             jd_state_cpu[k] = t.detach().cpu()
 
+        ckpt_path = str(Path(shared_tmp_dir) / "jd.pt")
         if rank == 0:
-            base = tmp_path_factory.mktemp("jd_warm_start_src")
-            ckpt_path = str(base / "jd.pt")
             torch.save(jd_state_cpu, ckpt_path)
-        else:
-            ckpt_path = ""
-        objs: list[object] = [ckpt_path]
-        dist.broadcast_object_list(objs, src=0)
-        ckpt_path = objs[0]  # type: ignore[assignment]
-        dist.barrier()
+        dist.barrier()  # rank 1 must wait for rank 0's torch.save to complete
 
         # Build a MoT model under FSDP and run the warm-start helper.
         mot_cfg = _tiny_mot_cfg(num_image_tokens=8, n_layers=2)
@@ -378,7 +373,7 @@ class TestMoEWithMoT:
 
 
 class TestCheckpointRoundtrip:
-    def test_save_load_freeze_metadata_mot(self, distributed_env, tmp_path_factory):
+    def test_save_load_freeze_metadata_mot(self, distributed_env, shared_tmp_dir):
         """Save a MoT VLM checkpoint, load it in a fresh manager, and
         verify metadata.json carries the canonical vlm_freeze and DCP
         shards round-trip the per-modality block params.
@@ -388,15 +383,10 @@ class TestCheckpointRoundtrip:
         wrapper = _build(cfg, mesh)
         opt = build_optimizer(wrapper, OptimizerConfig(lr=1e-3, fused=False))
 
+        # shared_tmp_dir lives on the shared filesystem so DCP shards
+        # written by rank 0 are visible to rank 1 under multi-node srun.
+        path_str = shared_tmp_dir
         rank = dist.get_rank()
-        if rank == 0:
-            base = tmp_path_factory.mktemp("vlm_mot_ckpt")
-            path_str = str(base)
-        else:
-            path_str = ""
-        objs: list[object] = [path_str]
-        dist.broadcast_object_list(objs, src=0)
-        path_str = objs[0]  # type: ignore[assignment]
 
         ckpt_cfg = CheckpointConfig(dir=str(path_str), interval=1)
         mgr = CheckpointManager(ckpt_cfg, wrapper, opt)


### PR DESCRIPTION
Closes #98.

Two unconditional bugs (tuple access on a tuple) plus four tests that
assume a shared `/tmp` across ranks. Fix the bugs, add a
`shared_tmp_dir` fixture to `tests/distributed/conftest.py`, migrate
the four `/tmp`-broadcasting tests to use it.

Changes (6 commits):
1. `test_vlm_fsdp.py:208`: destructure `_tiny_cfg()` and use `[3]`.
2. `test_vlm_mot_fsdp.py:339`: destructure `_tiny_mot_cfg()` before
   mutating the ModelConfig in place.
3. `tests/distributed/conftest.py`: add `shared_tmp_dir` fixture
   (`<repo>/.test_tmp/<tempdir>`, broadcast from rank 0, cleaned up
   after). Follows the existing pattern in `test_checkpoint.py`,
   `test_e2e_training.py`, `test_optimizer_distributed.py`.
4-6. Migrate the four tests from `tmp_path_factory` to
   `shared_tmp_dir`.

## Test plan
Verified on a 2-node x 1-GPU interactive job, `srun --overlap`:
- [x] All 5 previously-failing tests pass on both ranks
  (rank 0: 29s, rank 1: 22s).
- [x] Pre-fix full `tests/distributed/` matrix on this branch: 77 pass,
  5 fail, 8 skip. Post-fix the 5 fail-targets pass; the 77 pre-passing
  tests share no modified code with this PR.
- [x] `uv run ruff check tests/distributed/`
- [x] `uv run ruff format --check tests/distributed/`