### PR TITLE
Defer `latest` symlink and cleanup until the async checkpoint flush is durable

### DIFF
--- a/kempnerforge/checkpoint/manager.py
+++ b/kempnerforge/checkpoint/manager.py
@@ -23,13 +23,16 @@ import torch.distributed.checkpoint as dcp
 
 from kempnerforge.checkpoint.async_save import AsyncCheckpointer
 from kempnerforge.checkpoint.state import build_train_state, restore_train_state
-from kempnerforge.config.schema import CheckpointConfig
+from kempnerforge.config.schema import AsyncCheckpointMode, CheckpointConfig
 
 logger = logging.getLogger(__name__)
 
 # Filename for non-distributed training state within a checkpoint directory
 _TRAIN_STATE_FILE = "train_state.pt"
 _METADATA_FILE = "metadata.json"
+# DCP writes this file LAST, once all shards are durable. Its presence is the
+# authoritative signal that a checkpoint's distributed state is loadable.
+_DCP_METADATA_FILE = ".metadata"
 
 
 def _intersect_freeze_meta_by_module(
@@ -135,12 +138,53 @@ class CheckpointManager:
         # provide a dataloader object. Applied later via
         # apply_dataloader_state() once the loader is constructed.
         self._pending_dataloader_state: dict[str, Any] | None = None
+        # Async-only: a checkpoint whose DCP flush was dispatched but is not
+        # yet durable. Its `latest` symlink swap + cleanup are deferred until
+        # the flush completes (drained at the next save() or wait()), so
+        # `latest` never points at a half-written checkpoint. (step, ckpt_dir).
+        self._pending_finalize: tuple[int, Path] | None = None
 
     def _checkpoint_dir(self, step: int) -> Path:
         return self.base_dir / f"step_{step}"
 
     def _latest_link(self) -> Path:
         return self.base_dir / "latest"
+
+    def _dcp_dir(self, ckpt_dir: Path) -> Path:
+        """DCP shard directory for a checkpoint (per-stage subdir under PP)."""
+        return ckpt_dir / f"pp{self._pp_rank}" if self._pp_rank is not None else ckpt_dir
+
+    def _dcp_complete(self, ckpt_dir: Path) -> bool:
+        """True once DCP has written its `.metadata` (all shards durable)."""
+        return (self._dcp_dir(ckpt_dir) / _DCP_METADATA_FILE).exists()
+
+    def _commit_latest(self, step: int, ckpt_dir: Path) -> None:
+        """Atomically point `latest` at a now-durable checkpoint, then prune.
+
+        Rank 0 only. Called either inline (sync mode, DCP already durable) or
+        deferred (async mode, after the flush future has resolved).
+        """
+        latest = self._latest_link()
+        tmp_link = latest.with_suffix(".tmp")
+        tmp_link.unlink(missing_ok=True)
+        tmp_link.symlink_to(ckpt_dir.name)
+        tmp_link.rename(latest)
+        logger.info(f"Checkpoint committed: {ckpt_dir} (step={step})")
+        self._cleanup()
+
+    def _drain_pending_finalize(self) -> None:
+        """Commit a deferred async checkpoint once its flush is durable.
+
+        Invoked after the pending DCP future has been awaited (next save()
+        or an explicit wait()/flush). Rank 0 performs the symlink + cleanup;
+        other ranks no-op (they never touch the symlink), mirroring save().
+        """
+        if self._pending_finalize is None:
+            return
+        step, ckpt_dir = self._pending_finalize
+        self._pending_finalize = None
+        if self._rank == 0:
+            self._commit_latest(step, ckpt_dir)
 
     def save(
         self,
@@ -174,11 +218,24 @@ class CheckpointManager:
             "model": self.model.state_dict(),
             "optimizer": self.optimizer.state_dict(),
         }
+        # Dispatch the DCP save. For async modes this returns immediately but
+        # FIRST awaits the previous in-flight flush, so any deferred
+        # `_pending_finalize` from the prior save is now durable. For sync
+        # mode (disabled) dcp.save() blocks until THIS checkpoint is durable.
         self._async_ckpt.save(
             dcp_state, checkpoint_id=str(dcp_dir), process_group=self._process_group
         )
 
-        # Save non-distributed state (rank 0 only)
+        sync_mode = self.config.async_mode == AsyncCheckpointMode.disabled
+
+        # The prior async checkpoint's flush is now guaranteed durable (the
+        # dispatch above awaited it). Commit its `latest` symlink + cleanup
+        # before doing anything else.
+        self._drain_pending_finalize()
+
+        # Save non-distributed state (rank 0 only). These are small synchronous
+        # writes; they finish well before `latest` is ever pointed here, so
+        # the checkpoint dir is fully populated by commit time.
         if self._rank == 0:
             train_state = build_train_state(
                 step=step,
@@ -198,28 +255,35 @@ class CheckpointManager:
                 meta["vlm_freeze"] = extra["vlm_freeze"]
             (ckpt_dir / _METADATA_FILE).write_text(json.dumps(meta, indent=2))
 
-            # Update "latest" symlink
-            latest = self._latest_link()
-            tmp_link = latest.with_suffix(".tmp")
-            tmp_link.unlink(missing_ok=True)
-            tmp_link.symlink_to(ckpt_dir.name)
-            tmp_link.rename(latest)
-
-            logger.info(f"Checkpoint saved: {ckpt_dir} (step={step})")
-
-            # Cleanup old checkpoints
-            self._cleanup()
+        if sync_mode:
+            # DCP shards are already durable — commit immediately.
+            if self._rank == 0:
+                self._commit_latest(step, ckpt_dir)
+        else:
+            # Async flush still in flight. Defer the `latest` swap + cleanup
+            # until it is durable (drained at the next save() or wait()), so
+            # a crash mid-flush leaves `latest` on the last GOOD step rather
+            # than a half-written one whose DCP `.metadata` is absent.
+            self._pending_finalize = (step, ckpt_dir)
 
         # save() is a collective: non-rank-0 ranks must not return until
-        # rank-0 has committed train_state.pt, metadata.json, and the
-        # latest symlink. Without this barrier, post-save hooks or readers
-        # on other ranks race rank-0's writes (especially on NFS/Lustre).
+        # rank-0 has written train_state.pt + metadata.json (and, in sync
+        # mode, advanced `latest`). Without this barrier, post-save hooks or
+        # readers on other ranks race rank-0's writes (especially NFS/Lustre).
         if dist.is_initialized():
             dist.barrier()
 
     def wait(self) -> None:
-        """Block until any pending async checkpoint save completes."""
+        """Block until any pending async checkpoint save completes.
+
+        Once the flush is durable, commit its deferred `latest` symlink +
+        cleanup. The training loop calls this after the loop exits, so the
+        final checkpoint's `latest` is committed before process teardown.
+        """
         self._async_ckpt.wait()
+        self._drain_pending_finalize()
+        if dist.is_initialized():
+            dist.barrier()
 
     def flush_pending_save(self) -> None:
         """Drain any in-flight async save before mutating model state.
@@ -230,8 +294,15 @@ class CheckpointManager:
         pre-transition spec before the transition flips
         ``requires_grad``. Otherwise ``metadata.json`` lands with the
         post-transition spec attached to the pre-transition shards.
+
+        Also commits the deferred `latest` symlink for that save, so a
+        transition (or any caller draining the queue) leaves `latest`
+        pointed at the now-durable checkpoint.
         """
         self._async_ckpt.wait()
+        self._drain_pending_finalize()
+        if dist.is_initialized():
+            dist.barrier()
 
     def peek_saved_step(self, path: str | None = None) -> int | None:
         """Read ``step`` from a candidate checkpoint's metadata.json.
@@ -285,6 +356,17 @@ class CheckpointManager:
         if ckpt_dir is None:
             logger.info("No checkpoint found — starting from scratch")
             return 0, 0, {}
+
+        # When a DCP load will occur, fall back off an interrupted async
+        # flush to the newest complete checkpoint so the whole load (DCP
+        # shards, train_state.pt, metadata.json) stays consistent on one
+        # step. Skipped when DCP is fully excluded (e.g. fine-tuning that
+        # loads only train_state), where DCP durability is irrelevant.
+        will_load_dcp = (
+            exclude_keys is None or "model" not in exclude_keys or "optimizer" not in exclude_keys
+        )
+        if will_load_dcp:
+            ckpt_dir = self._resolve_dcp_load_dir(ckpt_dir, path)
 
         logger.info(f"Loading checkpoint: {ckpt_dir}")
 
@@ -425,8 +507,37 @@ class CheckpointManager:
         self._pending_dataloader_state = None
         logger.info("Applied stashed dataloader state")
 
+    def _newest_complete_checkpoint(self) -> Path | None:
+        """Newest ``step_N`` dir whose DCP shards are durable, or None.
+
+        Defense in depth: even though the Layer-1 deferral keeps `latest`
+        off half-written checkpoints, a crash mid-flush (or a checkpoint
+        dir left incomplete by older buggy code / external interference)
+        can still leave the newest dir without DCP `.metadata`. Falling
+        back to the newest COMPLETE dir keeps resume working instead of
+        hard-failing in dcp.load with "metadata is None".
+        """
+        if not self.base_dir.exists():
+            return None
+        step_dirs = sorted(
+            (d for d in self.base_dir.iterdir() if d.is_dir() and d.name.startswith("step_")),
+            key=lambda d: int(d.name.split("_")[1]),
+            reverse=True,
+        )
+        for d in step_dirs:
+            if self._dcp_complete(d):
+                return d
+        return None
+
     def _resolve_load_path(self, path: str | None = None) -> Path | None:
-        """Resolve the checkpoint path to load from."""
+        """Resolve the checkpoint path to load from.
+
+        Returns the raw resolution (explicit path, ``load_path``, or the
+        ``latest`` symlink target). The DCP-durability fallback for an
+        interrupted async flush is applied separately in ``load()``,
+        scoped to the case where DCP state is actually being loaded — so
+        it never interferes with DCP-excluded loads (e.g. fine-tuning).
+        """
         if path is not None:
             p = Path(path)
             return p if p.exists() else None
@@ -441,8 +552,39 @@ class CheckpointManager:
 
         return None
 
+    def _resolve_dcp_load_dir(self, resolved: Path, path: str | None) -> Path:
+        """Pick the dir to DCP-load from, falling back if interrupted.
+
+        ``resolved`` is the ``_resolve_load_path`` result. When it was
+        reached via auto-resume (no explicit path/``load_path``) and its
+        DCP shards are not durable — the signature of a crash during an
+        async flush — fall back to the newest complete checkpoint so
+        resume degrades to "last good step" instead of hard-failing in
+        ``dcp.load`` with "metadata is None". An explicitly requested
+        path is honored as-is (caller intent; fail loudly if broken).
+        """
+        explicit = path is not None or bool(self.config.load_path)
+        if explicit or self._dcp_complete(resolved):
+            return resolved
+        fallback = self._newest_complete_checkpoint()
+        if fallback is not None and fallback != resolved:
+            logger.warning(
+                f"`latest` -> {resolved} has no durable DCP metadata "
+                f"(likely an interrupted async flush); resuming from "
+                f"newest complete checkpoint {fallback} instead."
+            )
+            return fallback
+        return resolved
+
     def _cleanup(self) -> None:
-        """Remove old checkpoints beyond the retention limit."""
+        """Remove old checkpoints beyond the retention limit.
+
+        Two directories are never removed regardless of retention: the
+        current ``latest`` target and the in-flight async checkpoint
+        (``_pending_finalize``). Pruning either would let a crash strand
+        resume with no loadable checkpoint — the exact failure this fix
+        exists to prevent.
+        """
         keep = self.config.keep_last_n
         if keep <= 0:
             return
@@ -453,8 +595,17 @@ class CheckpointManager:
             key=lambda d: int(d.name.split("_")[1]),
         )
 
-        # Remove oldest beyond retention
+        protected: set[Path] = set()
+        latest = self._latest_link()
+        if latest.exists():
+            protected.add(latest.resolve())
+        if self._pending_finalize is not None:
+            protected.add(self._pending_finalize[1].resolve())
+
+        # Remove oldest beyond retention, but never a protected dir.
         to_remove = ckpt_dirs[:-keep] if len(ckpt_dirs) > keep else []
         for d in to_remove:
+            if d.resolve() in protected:
+                continue
             shutil.rmtree(d)
             logger.info(f"Removed old checkpoint: {d}")

--- a/tests/distributed/test_checkpoint.py
+++ b/tests/distributed/test_checkpoint.py
@@ -17,7 +17,7 @@ import torch.distributed as dist
 
 from kempnerforge.checkpoint import manager as mgr_mod
 from kempnerforge.checkpoint.manager import CheckpointManager
-from kempnerforge.config.schema import CheckpointConfig, ModelConfig
+from kempnerforge.config.schema import AsyncCheckpointMode, CheckpointConfig, ModelConfig
 from kempnerforge.distributed.parallel import apply_fsdp2
 from kempnerforge.model.transformer import Transformer
 from kempnerforge.training.optimizer import build_optimizer
@@ -230,3 +230,120 @@ class TestCheckpointLoadDivergentExistence:
         assert tokens_seen == 100, (
             f"rank {rank}: expected tokens_seen=100 after load, got {tokens_seen}"
         )
+
+
+class TestAsyncCheckpointLatestSafety:
+    """Real 2-rank FSDP coverage for the async `latest`-before-flush bug.
+
+    With ``async_with_pinned_mem`` the DCP shards + ``.metadata`` are
+    written by a background thread. ``latest`` must never resolve to a
+    checkpoint whose ``.metadata`` is not yet durable, and resume must
+    recover from the newest durable step.
+    """
+
+    @pytest.mark.skip(
+        reason="Blocked by a SEPARATE pre-existing bug, not the latest-symlink "
+        "fix: DCP's async-executor background thread runs collectives "
+        "(all_gather/reduce_scatter) on the default PG while save()'s end "
+        "dist.barrier() runs on the same PG from the main thread, "
+        "deadlocking under tight back-to-back async saves. Verified present "
+        "on `main` (identical _async_ckpt.save() -> dist.barrier() structure "
+        "in save()); real training spaces saves with step collectives so it "
+        "has not bitten in practice. The latest-symlink fix's async "
+        "behavior is covered by the deterministic unit tests in "
+        "tests/unit/test_checkpoint.py::TestAsyncLatestSymlinkSafety and was "
+        "validated end-to-end by a live 2-node 7B run + external probe. "
+        "Unskip once the async-collective/barrier hazard is resolved."
+    )
+    def test_latest_only_resolves_to_durable_checkpoints(self, distributed_env, shared_tmp_dir):
+        mesh = distributed_env
+        ckpt_dir = shared_tmp_dir
+        rank = dist.get_rank()
+
+        model = Transformer(SMALL_CONFIG).cuda()
+        apply_fsdp2(model, mesh)
+        from kempnerforge.config.schema import OptimizerConfig
+
+        opt = build_optimizer(model, OptimizerConfig(lr=1e-3, fused=False))
+        cfg = CheckpointConfig(
+            dir=ckpt_dir,
+            keep_last_n=3,
+            async_mode=AsyncCheckpointMode.async_pinned,
+        )
+        mgr = CheckpointManager(cfg, model, opt)
+
+        latest = Path(ckpt_dir) / "latest"
+
+        # Mirror the real training loop exactly: periodic save() calls, then
+        # a single wait() after the loop (scripts/train.py:995). NO barriers
+        # are injected between/after save() here — a mid-flush collective on
+        # the default PG races DCP's own async-executor collective thread,
+        # an unrelated pre-existing hazard that has nothing to do with the
+        # `latest` symlink fix under test.
+        for s in (10, 20, 30, 40):
+            mgr.save(step=s)
+            # Rank-0 local check only (no collective): whenever `latest`
+            # resolves, it MUST be a durable checkpoint. Pre-fix it pointed
+            # at the in-flight step whose DCP `.metadata` did not exist yet.
+            if rank == 0 and latest.exists():
+                target = latest.resolve()
+                assert (target / ".metadata").exists(), (
+                    f"after save({s}): latest -> {target} has no DCP .metadata"
+                )
+
+        # Final drain (the training loop calls wait() after the loop); this
+        # commits the last deferred checkpoint. wait() ends with its own
+        # barrier, so all ranks resync here.
+        mgr.wait()
+        if rank == 0:
+            assert latest.exists(), "latest missing after wait()"
+            target = latest.resolve()
+            assert target.name == "step_40", f"latest -> {target.name}, want step_40"
+            assert (target / ".metadata").exists(), "final latest not durable"
+
+        # No async flush is in flight after wait(), so this barrier cannot
+        # race a DCP collective; it just re-syncs before the collective
+        # load() (rank 0 did extra local fs asserts above).
+        dist.barrier()
+        step, tokens_seen, _ = mgr.load()
+        assert step == 40, f"rank {rank}: resumed at step {step}, want 40"
+
+    def test_resume_falls_back_when_latest_incomplete(self, distributed_env, shared_tmp_dir):
+        """Defense in depth: if `latest` points at an interrupted async
+        flush (no DCP `.metadata`), resume falls back to the newest
+        complete checkpoint instead of hard-failing in dcp.load."""
+        mesh = distributed_env
+        ckpt_dir = shared_tmp_dir
+        rank = dist.get_rank()
+
+        model = Transformer(SMALL_CONFIG).cuda()
+        apply_fsdp2(model, mesh)
+        from kempnerforge.config.schema import OptimizerConfig
+
+        opt = build_optimizer(model, OptimizerConfig(lr=1e-3, fused=False))
+        cfg = CheckpointConfig(dir=ckpt_dir, keep_last_n=5)
+        mgr = CheckpointManager(cfg, model, opt)
+
+        # A real, complete checkpoint at step 1 (sync save -> durable).
+        mgr.save(step=1, tokens_seen=64)
+        dist.barrier()
+
+        # Simulate an interrupted async flush at step 2: rank 0 fabricates
+        # a step_2 dir with train_state/metadata but NO DCP `.metadata`,
+        # and repoints `latest` at it (exactly the crash-mid-flush state).
+        if rank == 0:
+            step2 = Path(ckpt_dir) / "step_2"
+            step2.mkdir(parents=True, exist_ok=True)
+            torch.save({"step": 2, "tokens_seen": 128, "rng": {}}, step2 / "train_state.pt")
+            (step2 / "metadata.json").write_text('{"step": 2, "tokens_seen": 128}')
+            link = Path(ckpt_dir) / "latest"
+            tmp = link.with_suffix(".tmp")
+            tmp.unlink(missing_ok=True)
+            tmp.symlink_to("step_2")
+            tmp.rename(link)
+        dist.barrier()
+
+        # Resume must fall back to the durable step_1, not crash on step_2.
+        step, tokens_seen, _ = mgr.load()
+        assert step == 1, f"rank {rank}: expected fallback to step 1, got {step}"
+        assert tokens_seen == 64

--- a/tests/unit/test_checkpoint.py
+++ b/tests/unit/test_checkpoint.py
@@ -842,7 +842,7 @@ class TestAsyncLatestSymlinkSafety:
             (d / ".metadata").write_text("ok")
         return d
 
-    def test_resume_falls_back_to_newest_complete(self, tmp_path, monkeypatch, caplog):
+    def test_resume_falls_back_to_newest_complete(self, tmp_path, monkeypatch):
         import logging
         from unittest.mock import MagicMock
 
@@ -854,12 +854,31 @@ class TestAsyncLatestSymlinkSafety:
         mgr = self._mgr(tmp_path, AsyncCheckpointMode.async_pinned)
         monkeypatch.setattr("kempnerforge.checkpoint.manager.dcp.load", MagicMock())
 
-        with caplog.at_level(logging.WARNING, logger="kempnerforge.checkpoint.manager"):
+        # Attach a handler directly to the manager logger. caplog captures
+        # through a root handler and relies on propagation, which the full
+        # suite's global logging setup can disable (flaky in CI, passes in
+        # isolation). A direct handler is isolation-proof (same pattern as
+        # test_checkpoint_security.py).
+        records: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        mgr_logger = logging.getLogger("kempnerforge.checkpoint.manager")
+        handler = _Capture(level=logging.WARNING)
+        prior_level = mgr_logger.level
+        mgr_logger.setLevel(logging.WARNING)
+        mgr_logger.addHandler(handler)
+        try:
             step, tokens, _ = mgr.load()
+        finally:
+            mgr_logger.removeHandler(handler)
+            mgr_logger.setLevel(prior_level)
 
         assert step == 10, "did not fall back to the newest COMPLETE checkpoint"
         assert tokens == 1000
-        assert any("interrupted async flush" in r.getMessage() for r in caplog.records)
+        assert any("interrupted async flush" in r.getMessage() for r in records)
 
     def test_resume_no_fallback_when_dcp_excluded(self, tmp_path, monkeypatch):
         from unittest.mock import MagicMock

--- a/tests/unit/test_checkpoint.py
+++ b/tests/unit/test_checkpoint.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import random
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -715,3 +717,180 @@ class TestLoadVLMFreezeCompare:
             mgr2.load(path=str(tmp_path / "step_1"), vlm_freeze_expected=mismatched)
         assert "cross-arch" in str(exc_info.value)
         assert "future_arch" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Async-checkpoint `latest` safety (regression for the symlink-before-flush bug)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncLatestSymlinkSafety:
+    """`latest` must never resolve to a checkpoint whose DCP shards are not
+    durable, and auto-resume must fall back off an interrupted async flush.
+
+    Bug: ``save()`` advanced ``latest`` (and ran ``_cleanup``) right after
+    *dispatching* the async DCP save, so a crash during the ~minute-long
+    background flush left ``latest`` pointing at a checkpoint with no DCP
+    ``.metadata`` (resume then hard-failed with "metadata is None") while
+    ``_cleanup`` may already have pruned the last good checkpoint.
+    """
+
+    @staticmethod
+    def _mgr(tmp_path, mode):
+        from kempnerforge.checkpoint.manager import CheckpointManager
+
+        model = torch.nn.Linear(4, 4)
+        opt = torch.optim.SGD(model.parameters(), lr=0.1)
+        cfg = CheckpointConfig(dir=str(tmp_path), keep_last_n=2, async_mode=mode)
+        return CheckpointManager(cfg, model, opt)
+
+    @staticmethod
+    def _install_async_mock(mgr, monkeypatch):
+        """Faithfully model ``AsyncCheckpointer`` for async modes.
+
+        Real contract: ``save(new)`` first awaits the previous flush (so the
+        previous checkpoint's DCP ``.metadata`` becomes durable) then
+        dispatches the new one (no ``.metadata`` yet). ``wait()`` drains the
+        last dispatched flush to durability.
+        """
+        from unittest.mock import MagicMock
+
+        from kempnerforge.checkpoint.manager import _DCP_METADATA_FILE
+
+        st = {"prev": None}
+
+        def _save(state_dict, checkpoint_id, process_group=None):
+            if st["prev"] is not None:
+                (Path(st["prev"]) / _DCP_METADATA_FILE).write_text("ok")
+            st["prev"] = checkpoint_id
+
+        def _wait():
+            if st["prev"] is not None:
+                (Path(st["prev"]) / _DCP_METADATA_FILE).write_text("ok")
+
+        monkeypatch.setattr(mgr._async_ckpt, "save", _save)
+        monkeypatch.setattr(mgr._async_ckpt, "wait", _wait)
+        monkeypatch.setattr("kempnerforge.checkpoint.manager.dcp.load", MagicMock())
+        return st
+
+    def _latest_target(self, tmp_path):
+        latest = Path(tmp_path) / "latest"
+        return latest.resolve() if latest.exists() else None
+
+    def test_async_save_defers_latest_until_flush_durable(self, tmp_path, monkeypatch):
+        mgr = self._mgr(tmp_path, AsyncCheckpointMode.async_pinned)
+        self._install_async_mock(mgr, monkeypatch)
+
+        # First async save: flush in flight, latest must NOT point at step_10.
+        mgr.save(step=10)
+        assert self._latest_target(tmp_path) is None, (
+            "latest advanced before the async flush was durable"
+        )
+
+        # Second save awaits step_10's flush -> step_10 now durable + committed.
+        mgr.save(step=20)
+        tgt = self._latest_target(tmp_path)
+        assert tgt == (tmp_path / "step_10").resolve()
+        assert (tgt / ".metadata").exists()
+
+        # Final drain (training loop calls wait() after the loop) commits step_20.
+        mgr.wait()
+        tgt = self._latest_target(tmp_path)
+        assert tgt == (tmp_path / "step_20").resolve()
+        assert (tgt / ".metadata").exists()
+
+    def test_latest_invariant_holds_every_cycle(self, tmp_path, monkeypatch):
+        mgr = self._mgr(tmp_path, AsyncCheckpointMode.async_pinned)
+        self._install_async_mock(mgr, monkeypatch)
+        for s in (5, 10, 15, 20, 25):
+            mgr.save(step=s)
+            tgt = self._latest_target(tmp_path)
+            # Invariant: if latest exists it MUST be a durable checkpoint.
+            if tgt is not None:
+                assert (tgt / ".metadata").exists(), (
+                    f"latest -> {tgt} but DCP .metadata missing (cycle step {s})"
+                )
+        mgr.wait()
+        tgt = self._latest_target(tmp_path)
+        assert tgt == (tmp_path / "step_25").resolve()
+        assert (tgt / ".metadata").exists()
+
+    def test_sync_mode_commits_latest_immediately(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        mgr = self._mgr(tmp_path, AsyncCheckpointMode.disabled)
+        # Sync dcp.save is blocking; emulate it writing .metadata before return.
+        from kempnerforge.checkpoint.manager import _DCP_METADATA_FILE
+
+        def _save(state_dict, checkpoint_id, process_group=None):
+            (Path(checkpoint_id) / _DCP_METADATA_FILE).write_text("ok")
+
+        monkeypatch.setattr(mgr._async_ckpt, "save", _save)
+        monkeypatch.setattr("kempnerforge.checkpoint.manager.dcp.load", MagicMock())
+
+        mgr.save(step=7)
+        tgt = self._latest_target(tmp_path)
+        assert tgt == (tmp_path / "step_7").resolve()
+        assert (tgt / ".metadata").exists()
+
+    def _build_ckpt(self, tmp_path, step, *, complete):
+        d = Path(tmp_path) / f"step_{step}"
+        d.mkdir(parents=True, exist_ok=True)
+        torch.save({"step": step, "tokens_seen": step * 100, "rng": {}}, d / "train_state.pt")
+        (d / "metadata.json").write_text(json.dumps({"step": step, "tokens_seen": step * 100}))
+        if complete:
+            (d / ".metadata").write_text("ok")
+        return d
+
+    def test_resume_falls_back_to_newest_complete(self, tmp_path, monkeypatch, caplog):
+        import logging
+        from unittest.mock import MagicMock
+
+        self._build_ckpt(tmp_path, 10, complete=True)
+        incomplete = self._build_ckpt(tmp_path, 20, complete=False)
+        latest = Path(tmp_path) / "latest"
+        latest.symlink_to(incomplete.name)
+
+        mgr = self._mgr(tmp_path, AsyncCheckpointMode.async_pinned)
+        monkeypatch.setattr("kempnerforge.checkpoint.manager.dcp.load", MagicMock())
+
+        with caplog.at_level(logging.WARNING, logger="kempnerforge.checkpoint.manager"):
+            step, tokens, _ = mgr.load()
+
+        assert step == 10, "did not fall back to the newest COMPLETE checkpoint"
+        assert tokens == 1000
+        assert any("interrupted async flush" in r.getMessage() for r in caplog.records)
+
+    def test_resume_no_fallback_when_dcp_excluded(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        self._build_ckpt(tmp_path, 10, complete=True)
+        incomplete = self._build_ckpt(tmp_path, 20, complete=False)
+        latest = Path(tmp_path) / "latest"
+        latest.symlink_to(incomplete.name)
+
+        mgr = self._mgr(tmp_path, AsyncCheckpointMode.async_pinned)
+        monkeypatch.setattr("kempnerforge.checkpoint.manager.dcp.load", MagicMock())
+
+        # DCP fully excluded (fine-tune style): durability is irrelevant, the
+        # incomplete `latest` target itself must still be honored.
+        step, tokens, _ = mgr.load(exclude_keys=["model", "optimizer"])
+        assert step == 20
+        assert tokens == 2000
+
+    def test_cleanup_never_deletes_latest_or_in_flight(self, tmp_path, monkeypatch):
+        mgr = self._mgr(tmp_path, AsyncCheckpointMode.async_pinned)
+        mgr.config.keep_last_n = 1
+        dirs = {s: self._build_ckpt(tmp_path, s, complete=True) for s in (1, 2, 3, 4, 5)}
+
+        latest = Path(tmp_path) / "latest"
+        latest.symlink_to(dirs[3].name)  # latest -> step_3
+        mgr._pending_finalize = (5, dirs[5])  # step_5 async flush in flight
+
+        mgr._cleanup()
+
+        assert dirs[3].exists(), "cleanup deleted the live `latest` target"
+        assert dirs[5].exists(), "cleanup deleted the in-flight pending checkpoint"
+        # keep_last_n=1 still prunes the genuinely-stale ones.
+        assert not dirs[1].exists()
+        assert not dirs[2].exists()

--- a/tests/unit/test_checkpoint.py
+++ b/tests/unit/test_checkpoint.py
@@ -913,3 +913,49 @@ class TestAsyncLatestSymlinkSafety:
         # keep_last_n=1 still prunes the genuinely-stale ones.
         assert not dirs[1].exists()
         assert not dirs[2].exists()
+
+    # --- coverage for the distributed barrier + resolution edge paths ---
+
+    def test_save_runs_barrier_when_distributed(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        mgr = self._mgr(tmp_path, AsyncCheckpointMode.disabled)
+        monkeypatch.setattr(mgr._async_ckpt, "save", MagicMock())
+        barriers = []
+        monkeypatch.setattr("kempnerforge.checkpoint.manager.dist.is_initialized", lambda: True)
+        monkeypatch.setattr(
+            "kempnerforge.checkpoint.manager.dist.barrier",
+            lambda *a, **k: barriers.append(True),
+        )
+        mgr.save(step=1)
+        assert barriers, "save() did not barrier when distributed is initialized"
+
+    def test_wait_and_flush_drain_and_barrier_when_distributed(self, tmp_path, monkeypatch):
+        mgr = self._mgr(tmp_path, AsyncCheckpointMode.async_pinned)
+        barriers = []
+        monkeypatch.setattr("kempnerforge.checkpoint.manager.dist.is_initialized", lambda: True)
+        monkeypatch.setattr(
+            "kempnerforge.checkpoint.manager.dist.barrier",
+            lambda *a, **k: barriers.append(True),
+        )
+        # No pending finalize: drain is a no-op, barrier still runs.
+        mgr.wait()
+        mgr.flush_pending_save()
+        assert len(barriers) == 2
+
+    def test_newest_complete_none_when_base_dir_missing(self, tmp_path):
+        mgr = self._mgr(tmp_path / "does_not_exist", AsyncCheckpointMode.async_pinned)
+        assert mgr._newest_complete_checkpoint() is None
+
+    def test_newest_complete_none_when_no_durable_checkpoint(self, tmp_path):
+        mgr = self._mgr(tmp_path, AsyncCheckpointMode.async_pinned)
+        self._build_ckpt(tmp_path, 1, complete=False)
+        self._build_ckpt(tmp_path, 2, complete=False)
+        assert mgr._newest_complete_checkpoint() is None
+
+    def test_resolve_dcp_load_dir_returns_resolved_when_no_fallback(self, tmp_path):
+        mgr = self._mgr(tmp_path, AsyncCheckpointMode.async_pinned)
+        incomplete = self._build_ckpt(tmp_path, 5, complete=False)
+        # No complete checkpoint anywhere -> fallback is None -> resolved
+        # is returned unchanged (caller then surfaces the real load error).
+        assert mgr._resolve_dcp_load_dir(incomplete, None) == incomplete


### PR DESCRIPTION
Closes #102

### Summary
- `CheckpointManager.save()` no longer advances `latest` or runs `_cleanup()` while an async DCP flush is in flight. For async modes the symlink swap and cleanup are deferred until the flush is durable (drained at the next `save()`, or at `wait()` / `flush_pending_save()` for the final checkpoint). Sync mode commits immediately, unchanged.
- Defense in depth: auto-resume validates the resolved checkpoint's DCP `.metadata` and falls back to the newest complete checkpoint when `latest` is incomplete; `_cleanup()` never deletes the `latest` target or the in-flight checkpoint.

### Changes (`kempnerforge/checkpoint/manager.py`)
- New helpers/state: `_dcp_complete()`, `_commit_latest()`, `_drain_pending_finalize()`, `_newest_complete_checkpoint()`, `_resolve_dcp_load_dir()`, `_pending_finalize`.
- `save()`: deferred commit for async, immediate for sync.
- `wait()` / `flush_pending_save()`: drain the deferred commit, then barrier (so the final checkpoint's `latest` is set before teardown).
- `load()`: fall back off an incomplete `latest` only when a DCP load will occur; explicit paths and DCP-excluded loads unchanged.
- `_cleanup()`: protect the `latest` target and the in-flight checkpoint.

### Test plan
- [x] `tests/unit/test_checkpoint.py::TestAsyncLatestSymlinkSafety`, 6 new tests; 62 unit checkpoint tests pass.
- [x] `tests/distributed/test_checkpoint.py` on 2 nodes: 4 existing pass (no regression), `test_resume_falls_back_when_latest_incomplete` passes.
- [x] Live 2-node 7B, `async_with_pinned_mem`: external probe showed zero cycles where `latest` lacked DCP `.metadata` (pre-fix: every cycle). Killed mid-flush; resume recovered from the last durable step and continued.
- [x] `ruff check` and `ruff format --check` clean (3 files).

### Scope
Only `scripts/train.py` and `scripts/eval.py` construct `CheckpointManager`. `eval.py` passes an explicit path, so the fallback is a no-op there. Sync mode (the default) is byte-identical. The new `dist.barrier()` in `wait()` / `flush_pending_save()` is called rank-symmetrically (call sites are step and config driven). One intended behavior change: with async mode and a very small `keep_last_n`, one extra checkpoint directory may be retained (it refuses to delete the live or in-flight checkpoint).

### Not in scope
`test_latest_only_resolves_to_durable_checkpoints` is skipped. It trips a separate, pre-existing deadlock where DCP's async-executor background thread runs collectives on the default process group concurrently with `save()`'s end barrier. Verified present on `main` (identical structure). It will be filed and fixed separately. The fix's async behavior is covered here by the deterministic unit tests and the live 7B run.