### PR TITLE
Run the checkpoint `save()` barrier on a dedicated gloo group

### DIFF
--- a/kempnerforge/checkpoint/manager.py
+++ b/kempnerforge/checkpoint/manager.py
@@ -15,7 +15,7 @@ import os
 import shutil
 import stat
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import torch
 import torch.distributed as dist
@@ -143,6 +143,23 @@ class CheckpointManager:
         # the flush completes (drained at the next save() or wait()), so
         # `latest` never points at a half-written checkpoint. (step, ckpt_dir).
         self._pending_finalize: tuple[int, Path] | None = None
+        # Dedicated gloo group for the manager's own synchronization
+        # (the end-of-save barrier). dcp.async_save() runs its collective
+        # planning (all_gather/reduce_scatter) on a background thread using
+        # the default process group; issuing the save() barrier on that
+        # SAME group from the main thread interleaves two collectives on
+        # one communicator with nondeterministic per-rank ordering, which
+        # deadlocks under tightly spaced async saves. A separate gloo
+        # group is independent, so the CPU-only barrier cannot race the
+        # in-flight DCP collective. Created on all ranks (every rank
+        # constructs CheckpointManager identically). Typed + cast because
+        # the torch stubs declare new_group as ProcessGroup | int | None
+        # but barrier(group=...) wants ProcessGroup | None.
+        self._sync_group: dist.ProcessGroup | None = (
+            cast("dist.ProcessGroup", dist.new_group(backend="gloo"))
+            if dist.is_initialized()
+            else None
+        )
 
     def _checkpoint_dir(self, step: int) -> Path:
         return self.base_dir / f"step_{step}"
@@ -185,6 +202,16 @@ class CheckpointManager:
         self._pending_finalize = None
         if self._rank == 0:
             self._commit_latest(step, ckpt_dir)
+
+    def _sync_barrier(self) -> None:
+        """Barrier on the manager's dedicated gloo group.
+
+        Used to fence non-rank-0 ranks behind rank-0's metadata writes
+        without sharing the default process group that DCP's async-save
+        background thread is concurrently issuing collectives on.
+        """
+        if dist.is_initialized():
+            dist.barrier(group=self._sync_group)
 
     def save(
         self,
@@ -270,8 +297,10 @@ class CheckpointManager:
         # rank-0 has written train_state.pt + metadata.json (and, in sync
         # mode, advanced `latest`). Without this barrier, post-save hooks or
         # readers on other ranks race rank-0's writes (especially NFS/Lustre).
-        if dist.is_initialized():
-            dist.barrier()
+        # Uses the dedicated gloo group: the async DCP flush dispatched just
+        # above runs collectives on the default process group from a
+        # background thread, and sharing that group here deadlocks.
+        self._sync_barrier()
 
     def wait(self) -> None:
         """Block until any pending async checkpoint save completes.

--- a/tests/distributed/test_checkpoint.py
+++ b/tests/distributed/test_checkpoint.py
@@ -242,18 +242,15 @@ class TestAsyncCheckpointLatestSafety:
     """
 
     @pytest.mark.skip(
-        reason="Blocked by a SEPARATE pre-existing bug, not the latest-symlink "
-        "fix: DCP's async-executor background thread runs collectives "
-        "(all_gather/reduce_scatter) on the default PG while save()'s end "
-        "dist.barrier() runs on the same PG from the main thread, "
-        "deadlocking under tight back-to-back async saves. Verified present "
-        "on `main` (identical _async_ckpt.save() -> dist.barrier() structure "
-        "in save()); real training spaces saves with step collectives so it "
-        "has not bitten in practice. The latest-symlink fix's async "
-        "behavior is covered by the deterministic unit tests in "
-        "tests/unit/test_checkpoint.py::TestAsyncLatestSymlinkSafety and was "
-        "validated end-to-end by a live 2-node 7B run + external probe. "
-        "Unskip once the async-collective/barrier hazard is resolved."
+        reason="Test contains internal dist.barrier() calls between async saves "
+        "that race DCP's async-executor background collective on the "
+        "default PG. The save()-end barrier deadlock is fixed by this PR "
+        "(via _sync_barrier on a dedicated gloo group), but unskipping "
+        "additionally requires rewriting this test's intra-loop barriers "
+        "to drain the async future first or use a private gloo group. "
+        "Out of scope here; the async-save behavior is covered by "
+        "TestAsyncSaveBarrierNoDeadlock and by the deterministic unit "
+        "tests in TestAsyncLatestSymlinkSafety."
     )
     def test_latest_only_resolves_to_durable_checkpoints(self, distributed_env, shared_tmp_dir):
         mesh = distributed_env
@@ -347,3 +344,45 @@ class TestAsyncCheckpointLatestSafety:
         step, tokens_seen, _ = mgr.load()
         assert step == 1, f"rank {rank}: expected fallback to step 1, got {step}"
         assert tokens_seen == 64
+
+
+class TestAsyncSaveBarrierNoDeadlock:
+    """save()'s end barrier must not deadlock against DCP's async-save
+    background collective.
+
+    ``dcp.async_save()`` runs its collective planning (all_gather /
+    reduce_scatter) on a background thread using the default process
+    group. Pre-fix, save()'s end barrier ran on that same group from the
+    main thread; two collectives interleaving on one communicator with
+    nondeterministic per-rank ordering deadlock under tightly spaced
+    async saves (no training collectives in between to separate them).
+    The fix moves the barrier onto a dedicated gloo group.
+    """
+
+    def test_back_to_back_async_saves_do_not_deadlock(self, distributed_env, shared_tmp_dir):
+        mesh = distributed_env
+        ckpt_dir = shared_tmp_dir
+        from kempnerforge.config.schema import OptimizerConfig
+
+        model = Transformer(SMALL_CONFIG).cuda()
+        apply_fsdp2(model, mesh)
+        opt = build_optimizer(model, OptimizerConfig(lr=1e-3, fused=False))
+        cfg = CheckpointConfig(
+            dir=ckpt_dir,
+            keep_last_n=3,
+            async_mode=AsyncCheckpointMode.async_pinned,
+        )
+        mgr = CheckpointManager(cfg, model, opt)
+
+        # Tight loop, no training collectives between saves: the exact
+        # pattern that deadlocks pre-fix. Reaching the asserts at all means
+        # the gloo barrier did not race the in-flight DCP collective.
+        for s in (10, 20, 30, 40):
+            mgr.save(step=s)
+        mgr.wait()
+
+        if dist.get_rank() == 0:
+            latest = Path(ckpt_dir) / "latest"
+            assert latest.exists()
+            assert latest.resolve().name == "step_40"
+        dist.barrier()

--- a/tests/unit/test_checkpoint.py
+++ b/tests/unit/test_checkpoint.py
@@ -959,3 +959,67 @@ class TestAsyncLatestSymlinkSafety:
         # No complete checkpoint anywhere -> fallback is None -> resolved
         # is returned unchanged (caller then surfaces the real load error).
         assert mgr._resolve_dcp_load_dir(incomplete, None) == incomplete
+
+
+# ---------------------------------------------------------------------------
+# Dedicated sync-barrier group (async-save / barrier deadlock fix)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncBarrierGroup:
+    """save()'s end barrier must run on a dedicated gloo group, not the
+    default process group that DCP's async-save background thread uses.
+
+    Sharing that group across the main thread (barrier) and DCP's executor
+    thread (all_gather / reduce_scatter) interleaves two collectives on one
+    communicator and deadlocks under tight async saves.
+    """
+
+    def _mgr(self, tmp_path):
+        from kempnerforge.checkpoint.manager import CheckpointManager
+
+        model = torch.nn.Linear(4, 4)
+        opt = torch.optim.SGD(model.parameters(), lr=0.1)
+        return CheckpointManager(CheckpointConfig(dir=str(tmp_path)), model, opt)
+
+    def test_sync_group_none_when_not_distributed(self, tmp_path):
+        mgr = self._mgr(tmp_path)
+        assert mgr._sync_group is None
+
+    def test_sync_barrier_noop_when_not_distributed(self, tmp_path):
+        # Must not raise when distributed is not initialized.
+        self._mgr(tmp_path)._sync_barrier()
+
+    def test_init_creates_dedicated_gloo_group(self, tmp_path, monkeypatch):
+        import kempnerforge.checkpoint.manager as mgr_mod
+
+        calls = {}
+
+        def fake_new_group(backend=None):
+            calls["backend"] = backend
+            return "SENTINEL_GLOO_GROUP"
+
+        monkeypatch.setattr(mgr_mod.dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(mgr_mod.dist, "new_group", fake_new_group)
+        monkeypatch.setattr(mgr_mod.dist, "get_rank", lambda: 0)
+
+        mgr = self._mgr(tmp_path)
+        assert calls["backend"] == "gloo"
+        assert mgr._sync_group == "SENTINEL_GLOO_GROUP"
+
+    def test_sync_barrier_uses_dedicated_group_not_default(self, tmp_path, monkeypatch):
+        import kempnerforge.checkpoint.manager as mgr_mod
+
+        barrier_calls = []
+
+        monkeypatch.setattr(mgr_mod.dist, "is_initialized", lambda: True)
+        monkeypatch.setattr(mgr_mod.dist, "new_group", lambda backend=None: "GLOO_PG")
+        monkeypatch.setattr(mgr_mod.dist, "get_rank", lambda: 0)
+        monkeypatch.setattr(mgr_mod.dist, "barrier", lambda group=None: barrier_calls.append(group))
+
+        mgr = self._mgr(tmp_path)
+        mgr._sync_barrier()
+
+        # The barrier must target the dedicated gloo group, never the
+        # default group (group=None) that DCP's async thread uses.
+        assert barrier_calls == ["GLOO_PG"]


### PR DESCRIPTION
Closes #104

### Summary
`CheckpointManager` creates a dedicated gloo process group in `__init__` and runs its end-of-save barrier on it via `_sync_barrier()`, instead of the default process group that `dcp.async_save()`'s background thread issues collectives on. A separate gloo communicator is independent, so the barrier cannot interleave with the in-flight DCP collective on a shared group.

### Changes (`kempnerforge/checkpoint/manager.py`)
- `__init__` (line 158): `self._sync_group: dist.ProcessGroup | None = cast("dist.ProcessGroup", dist.new_group(backend="gloo")) if dist.is_initialized() else None`. The cast is needed because the torch stubs declare `new_group` as `ProcessGroup | int | None` while `barrier(group=...)` wants `ProcessGroup | None`.
- `_sync_barrier()` (line 206): `dist.barrier(group=self._sync_group)`, guarded by `dist.is_initialized()`.
- `save()` (line 303): the end-of-save barrier now calls `self._sync_barrier()` instead of `dist.barrier()` on the default group.

### Test plan
- [x] `tests/unit/test_checkpoint.py::TestSyncBarrierGroup` (4 tests): `test_sync_group_none_when_not_distributed`, `test_sync_barrier_noop_when_not_distributed`, `test_init_creates_dedicated_gloo_group`, `test_sync_barrier_uses_dedicated_group_not_default`. All pass.
- [x] `tests/distributed/test_checkpoint.py::TestAsyncSaveBarrierNoDeadlock::test_back_to_back_async_saves_do_not_deadlock` on the 2-node interactive job: tight back-to-back async saves complete (6 passed, 1 skipped, both ranks). This is the exact pattern that hangs without the fix.
- [x] Full checkpoint + security unit suite: 71 pass. `ruff check`, `ruff format --check`, and `uv run pyright kempnerforge/` (0 errors) all clean.
- [x] End-to-end live validation on 2 nodes after rebase: `debug_moe.toml` with `async_with_pinned_mem`, external symlink probe at 100 ms. Phase 1 (initial training, max step 6045, 301 ckpt cycles): 0 BUG WINDOWs across 301 probe transitions. Killed mid-flush; `latest` left on a durable step. Phase 2 (resume + continue, steps 6025 to 14795, 438 ckpt cycles): `Resumed from step 6020, 24,657,920 tokens seen`; training continued cleanly, 0 BUG WINDOWs across 438 transitions, loss decreasing, MoE balanced.

### Scope
`CheckpointManager` is constructed only at `scripts/train.py:201` and `scripts/eval.py:88`, both unguarded and after `init_distributed()` (`scripts/train.py:83`, `scripts/eval.py:64`), so `dist.new_group()` (a collective) is called symmetrically on all ranks. Non-distributed callers get `_sync_group=None` and a no-op barrier. DCP keeps using the default group; only the manager's own end-of-save barrier moves to gloo. The barriers in `wait()` / `flush_pending_save()` added by #103 (`manager.py:315` and `:334`) are intentionally left on the default group because they run after `_async_ckpt.wait()` has drained the future, so there is no concurrent DCP collective at those points.

### Rebase note
Rebased onto `main` post-#103 merge (commit `74edfe1`). One squashed commit on top: `9fda785`. Diff vs `main`: 3 files, +147 / -15.
