### PR TITLE
Unskip `test_latest_only_resolves_to_durable_checkpoints` (stale skip, now passes)

### DIFF
--- a/tests/distributed/test_checkpoint.py
+++ b/tests/distributed/test_checkpoint.py
@@ -241,17 +241,6 @@ class TestAsyncCheckpointLatestSafety:
     recover from the newest durable step.
     """
 
-    @pytest.mark.skip(
-        reason="Test contains internal dist.barrier() calls between async saves "
-        "that race DCP's async-executor background collective on the "
-        "default PG. The save()-end barrier deadlock is fixed by this PR "
-        "(via _sync_barrier on a dedicated gloo group), but unskipping "
-        "additionally requires rewriting this test's intra-loop barriers "
-        "to drain the async future first or use a private gloo group. "
-        "Out of scope here; the async-save behavior is covered by "
-        "TestAsyncSaveBarrierNoDeadlock and by the deterministic unit "
-        "tests in TestAsyncLatestSymlinkSafety."
-    )
     def test_latest_only_resolves_to_durable_checkpoints(self, distributed_env, shared_tmp_dir):
         mesh = distributed_env
         ckpt_dir = shared_tmp_dir


### PR DESCRIPTION
Closes #108

Removes the stale `@pytest.mark.skip` decorator. Only change: -11 lines, no test-body edit. The skip reason described a pre-rewrite body; the current body has no inter-save collectives, and #105 (merged) fixed `save()`'s end barrier. This restores per-cycle `.metadata` durability + resume verification coverage under real 2-rank FSDP async DCP.

### Test plan
- [x] Full `tests/distributed/test_checkpoint.py` on a 2-node interactive job (`holygpu8a[11103,15503]`, 1 GPU/node) via `srun --jobid=<job> --overlap --nodes=2 --ntasks-per-node=1`: **7 passed, 0 skipped in 16.30s**, identical on both ranks (per-rank logs captured on shared netscratch and verified). The unskipped `test_latest_only_resolves_to_durable_checkpoints` passes (previously 6 passed + 1 skipped).
- [x] `uv run ruff check tests/distributed/test_checkpoint.py` and `uv run ruff format --check tests/distributed/test_checkpoint.py`: clean.
- [x] `tests/unit/test_checkpoint.py` + `tests/unit/test_checkpoint_security.py`: 71 pass (no regressions).
- Note: no CI job runs `tests/distributed/` (`unit-tests` runs only `tests/unit/`; `gpu-tests` has `if: github.event_name == 'workflow_dispatch'` and runs `tests/integration/` on `ubuntu-latest`). The 2-node manual run above is therefore the verification gate.