### PR TITLE
Add configurable data_seed independent of training seed

### DIFF
--- a/kempnerforge/config/training.py
+++ b/kempnerforge/config/training.py
@@ -25,7 +25,8 @@ class TrainConfig:
     max_steps: int = 100000
     grad_accum_steps: int = 1
     grad_clip_norm: float = 1.0
-    seed: int = 42
+    seed: int = 42  # Seeds parameter init, dropout, and (by default) data order
+    data_seed: int | None = None  # Overrides data/batch order only; None falls back to seed
     compile_model: bool = True
     mixed_precision: Literal["bf16", "fp16", "fp32", "fp8"] = "bf16"
     activation_checkpointing: ActivationCheckpointing = ActivationCheckpointing.none
@@ -67,3 +68,15 @@ class TrainConfig:
     def is_fp8(self) -> bool:
         """Whether FP8 mixed precision is enabled."""
         return self.mixed_precision == "fp8"
+
+    @property
+    def effective_data_seed(self) -> int:
+        """Seed for data shuffling / batch composition.
+
+        Falls back to ``seed`` when ``data_seed`` is unset, so existing configs
+        reproduce their current trajectory. Kept independent from ``seed``
+        (parameter init) so stability studies can vary batch order while holding
+        initialization fixed. Must stay identical across data-parallel ranks so
+        the global shuffle is consistent before rank partitioning.
+        """
+        return self.data_seed if self.data_seed is not None else self.seed

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -319,7 +319,7 @@ def main() -> None:
             _pad_id = _tok.eos_token_id if _tok.eos_token_id is not None else 0
         collator = VLMCollator(pad_id=int(_pad_id), max_text_len=vlm_cfg.max_text_len)
         sampler = DistributedSampler(
-            dataset, num_replicas=dp_size, rank=dp_rank, shuffle=True, seed=tc.seed
+            dataset, num_replicas=dp_size, rank=dp_rank, shuffle=True, seed=tc.effective_data_seed
         )
         dataloader = StatefulDataLoader(
             dataset,
@@ -373,7 +373,7 @@ def main() -> None:
             num_replicas=dp_size,
             rank=dp_rank,
             shuffle=True,
-            seed=tc.seed,
+            seed=tc.effective_data_seed,
             temperature=config.data.mix_temperature,
         )
         dataloader = StatefulDataLoader(
@@ -401,7 +401,7 @@ def main() -> None:
             num_replicas=dp_size,
             rank=dp_rank,
             shuffle=True,
-            seed=tc.seed,
+            seed=tc.effective_data_seed,
         )
         dataloader = StatefulDataLoader(
             dataset,
@@ -429,7 +429,7 @@ def main() -> None:
                 dataset_config=config.data.hf_dataset_config,
                 rank=dp_rank,
                 world_size=dp_size,
-                seed=tc.seed,
+                seed=tc.effective_data_seed,
                 pack_sequences=config.data.pack_sequences,
             )
             dataloader = TorchDataLoader(
@@ -463,7 +463,7 @@ def main() -> None:
                 num_replicas=dp_size,
                 rank=dp_rank,
                 shuffle=True,
-                seed=tc.seed,
+                seed=tc.effective_data_seed,
             )
             dataloader = StatefulDataLoader(
                 dataset,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -169,6 +169,18 @@ class TestTrainConfig:
         with pytest.raises(ValueError, match="grad_accum_steps must be positive"):
             TrainConfig(grad_accum_steps=0)
 
+    def test_data_seed_defaults_to_none(self):
+        assert TrainConfig().data_seed is None
+
+    def test_effective_data_seed_falls_back_to_seed(self):
+        t = TrainConfig(seed=123)
+        assert t.effective_data_seed == 123
+
+    def test_effective_data_seed_overrides_when_set(self):
+        t = TrainConfig(seed=123, data_seed=456)
+        assert t.effective_data_seed == 456
+        assert t.seed == 123  # init seed stays independent
+
 
 # ---------------------------------------------------------------------------
 # OptimizerConfig


### PR DESCRIPTION
## Summary
- Add `TrainConfig.data_seed` (`int | None`, default `None`) so the data-shuffling seed can be set independently of the parameter-init `seed`.
- Add `TrainConfig.effective_data_seed` property — returns `data_seed` when set, else falls back to `seed`, so existing configs reproduce their current trajectory byte-for-byte (willing to remove the backward compatibility).
- Route the five training-data sampler/dataset sites in `scripts/train.py` (VLM, mixture, mmap, HF-streaming, HF-eager) through `effective_data_seed`. Eval samplers keep using `seed`.
- The data seed is passed identically to all data-parallel ranks (unchanged: a consistent global shuffle is partitioned per rank; unlike the init seed in `_set_seed`, it is deliberately not rank-offset).
- Add unit tests for the fallback and override semantics.
  
Enables independently varying parameter initialization and data order, while keeping single-seed runs identical.

## Testing
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors)
- [x] `uv run pytest tests/unit/ -v --timeout=60` passes
- [x] If distributed code changed: `uv run torchrun --nproc_per_node=4 -m pytest tests/distributed/ -v`
- [x] If training loop / parallelism / optimizers changed: `uv run pytest tests/e2e/ --e2e -v`

Closes #110 
