### PR TITLE
Add fine-grained MoE experts: decouple expert FFN hidden dim from dense FFN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Fine-grained MoE experts** (`moe_expert_ffn_multiplier`). Decouples each expert's FFN hidden width from the dense FFN: the per-expert hidden dim is `computed_ffn_hidden_dim × moe_expert_ffn_multiplier`, rounded to a multiple of 16. The default `1.0` is a no-op (each expert is a full dense FFN, zero behavior change); set `0.5` for fine-grained experts so top-2 routing matches the dense FFN's activated FLOPs (`2 × F/2 = F`) while adding total capacity — the DeepSeekMoE recipe. Applies to routed and shared experts wherever they are built (`build_moe` and MoMa's `ExpertChoiceMoE`).
+  - `kempnerforge/config/model.py`: `moe_expert_ffn_multiplier: float = 1.0` (with a positivity check) and a `computed_expert_ffn_hidden_dim` property; `num_params_estimate` accounts for the smaller experts.
+  - `kempnerforge/model/{moe,moma,mot,transformer}.py`: experts are built at `computed_expert_ffn_hidden_dim` instead of the dense FFN width.
+  - Tests: `tests/unit/test_config.py` (default-equals-dense, half-size, iso-FLOP top-2, rejects non-positive, param-estimate drop) plus cases in `test_moe.py`, `test_moma.py`, `test_mot.py`.
 - **VLM (Vision-Language Model) foundation + Joint-Decoder arch.** A registry-driven, discriminated-union design so future arches (Cross-Attention, Mixture-of-Transformers) can be added as small additive PRs without changes to existing call sites.
   - `kempnerforge/config/vlm.py`: `VLMConfig` base + `JointDecoderConfig(arch="joint_decoder")` registered via `@registry.register_vlm_config`. `FreezeSpec`, `FreezeStage`, and `DEFAULT_MODULE_PATTERNS` for the freeze plumbing. `_RESERVED_ARCHS = ("cross_attention", "mot")` so TOMLs aimed at future arches get a clear `NotImplementedError`.
   - `kempnerforge/config/registry.py`: `register_vision_encoder` / `register_vlm_config` / `register_modality_strategy` registries.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ PyTorch-native framework for fault-tolerant distributed training of foundation m
 
 - **Scaling law experiments**: train the same architecture from 125M to 70B by swapping a TOML config. FSDP, tensor, expert, and pipeline parallelism are automatic.
 - **Mechanistic interpretability**: activation extraction hooks at any layer with CPU offload; attention weight capture exposes raw QK^T matrices.
-- **Sparse architecture research**: switch between dense and MoE by setting `num_experts` (0 for dense, >0 for MoE). Softmax top-k or DeepSeek-V3 sigmoid routing, shared experts, configurable MoE frequency.
+- **Sparse architecture research**: switch between dense and MoE by setting `num_experts` (0 for dense, >0 for MoE). Softmax top-k or DeepSeek-V3 sigmoid routing, shared experts, fine-grained experts, configurable MoE frequency.
 - **Optimizer and scheduler comparison**: 4 optimizers (AdamW, Muon, Lion, Schedule-Free AdamW) × 6 LR schedulers, composable via config. Data annealing phases for curriculum learning.
 - **Long-running jobs on shared clusters**: SLURM preemption handling, async DCP checkpointing, auto-resume, NaN detection, GPU/NCCL health monitoring.
 - **Representation analysis for NeuroAI**: batch activation extraction via `ActivationStore` and `extract_representations()`, saved to `.npz` for downstream comparison against neural recordings.
@@ -27,7 +27,7 @@ PyTorch-native framework for fault-tolerant distributed training of foundation m
 
 **Architecture**
 - Decoder-only Transformer: RoPE, GQA, SwiGLU, RMSNorm, `torch.compile`
-- Mixture-of-Experts: softmax top-k and DeepSeek-V3 sigmoid routers, shared experts, configurable frequency
+- Mixture-of-Experts: softmax top-k and DeepSeek-V3 sigmoid routers, shared experts, fine-grained experts, configurable frequency
 
 **Parallelism**
 - FSDP2, Tensor, Expert, and Pipeline Parallelism

--- a/docs/moe/index.md
+++ b/docs/moe/index.md
@@ -37,6 +37,7 @@ the distributed mechanics (all-to-all, expert parallelism) live under
 | `moe_gradient_scale` | `false` | Per-expert output scaling by utilization |
 | `moe_sequence_aux_loss_weight` | `0.0` | Sigmoid-only: sequence-level balance penalty |
 | `moe_bias_schedule` | `"constant"` | Sigmoid-only: bias update rate schedule |
+| `moe_expert_ffn_multiplier` | `1.0` | Per-expert FFN hidden = `multiplier × dense FFN`; `0.5` = fine-grained, so top-2 matches the dense FFN's activated FLOPs |
 
 All fields live in
 [`kempnerforge/config/model.py`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/config/model.py)

--- a/kempnerforge/config/model.py
+++ b/kempnerforge/config/model.py
@@ -54,6 +54,7 @@ class ModelConfig:
     moe_gradient_scale: bool = False  # Per-expert gradient normalization
     moe_bias_schedule: str = "constant"  # "constant", "cosine_decay", "linear_warmup"
     moe_packed_experts: bool = False  # Pack expert weights into one tensor per projection
+    moe_expert_ffn_multiplier: float = 1.0  # expert FFN hidden vs dense (0.5 = fine-grained)
 
     def __post_init__(self) -> None:
         if self.n_kv_heads is None:
@@ -99,6 +100,8 @@ class ModelConfig:
                     f"Unknown moe_bias_schedule: '{self.moe_bias_schedule}'. "
                     "Options: 'constant', 'cosine_decay', 'linear_warmup'"
                 )
+            if self.moe_expert_ffn_multiplier <= 0:
+                raise ValueError("moe_expert_ffn_multiplier must be positive")
 
     @property
     def is_moe(self) -> bool:
@@ -119,6 +122,19 @@ class ModelConfig:
         return 256 * math.ceil(raw / 256)
 
     @property
+    def computed_expert_ffn_hidden_dim(self) -> int:
+        """Per-expert FFN hidden dim = ``computed_ffn_hidden_dim`` * ``moe_expert_ffn_multiplier``.
+
+        Rounded to a multiple of 16 for tensor-core alignment. With the default
+        multiplier 1.0 this equals ``computed_ffn_hidden_dim`` (zero behavior
+        change); set 0.5 for fine-grained experts so top-2 routing matches the
+        dense FFN's activated FLOPs (2 * F/2 = F). Applies to routed and shared
+        experts wherever they are built (build_moe and MoMa's ExpertChoiceMoE).
+        """
+        raw = int(self.computed_ffn_hidden_dim * self.moe_expert_ffn_multiplier)
+        return max(16, 16 * round(raw / 16))
+
+    @property
     def num_params_estimate(self) -> int:
         """Rough total parameter count estimate (excluding embedding if tied).
 
@@ -134,11 +150,13 @@ class ModelConfig:
         norm = 2 * d  # 2 norms per layer
 
         if self.is_moe:
+            he = self.computed_expert_ffn_hidden_dim  # may be fine-grained (< h)
+            expert_mlp = d * he + d * he + he * d
             n_moe = sum(1 for i in range(self.n_layers) if (i + 1) % self.moe_frequency == 0)
             n_dense = self.n_layers - n_moe
             router = d * self.num_experts  # gate linear per MoE layer
-            shared_mlp = self.moe_shared_experts * mlp
-            moe_per_layer = attn + self.num_experts * mlp + router + shared_mlp + norm
+            shared_mlp = self.moe_shared_experts * expert_mlp
+            moe_per_layer = attn + self.num_experts * expert_mlp + router + shared_mlp + norm
             dense_per_layer = attn + mlp + norm
             layer_params = n_moe * moe_per_layer + n_dense * dense_per_layer
         else:

--- a/kempnerforge/model/moma.py
+++ b/kempnerforge/model/moma.py
@@ -289,7 +289,7 @@ class MoMaFFN(nn.Module):
             {
                 m: ExpertChoiceMoE(
                     dim=config.dim,
-                    hidden_dim=config.computed_ffn_hidden_dim,
+                    hidden_dim=config.computed_expert_ffn_hidden_dim,
                     num_experts=experts_per_modality[m],
                     capacity_factor=capacity_factor_per_modality[m],
                     activation=config.activation,

--- a/kempnerforge/model/mot.py
+++ b/kempnerforge/model/mot.py
@@ -253,7 +253,7 @@ class MoTBlock(nn.Module):
                 {
                     m: build_moe(
                         dim=config.dim,
-                        hidden_dim=config.computed_ffn_hidden_dim,
+                        hidden_dim=config.computed_expert_ffn_hidden_dim,
                         num_experts=config.num_experts,
                         top_k=config.moe_top_k,
                         activation=config.activation,

--- a/kempnerforge/model/transformer.py
+++ b/kempnerforge/model/transformer.py
@@ -60,7 +60,7 @@ class TransformerBlock(nn.Module):
         if use_moe:
             self.mlp = build_moe(
                 dim=config.dim,
-                hidden_dim=config.computed_ffn_hidden_dim,
+                hidden_dim=config.computed_expert_ffn_hidden_dim,
                 num_experts=config.num_experts,
                 top_k=config.moe_top_k,
                 activation=config.activation,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -104,6 +104,35 @@ class TestModelConfig:
         assert m.is_moe is True
         assert m.moe_top_k == 2
 
+    def test_expert_ffn_multiplier_default_matches_dense(self):
+        m = ModelConfig(dim=1024, n_heads=16, num_experts=4, moe_top_k=2)
+        assert m.moe_expert_ffn_multiplier == 1.0
+        assert m.computed_expert_ffn_hidden_dim == m.computed_ffn_hidden_dim
+
+    def test_expert_ffn_multiplier_half(self):
+        m = ModelConfig(
+            dim=1024, n_heads=16, num_experts=4, moe_top_k=2, moe_expert_ffn_multiplier=0.5
+        )
+        assert m.computed_expert_ffn_hidden_dim == m.computed_ffn_hidden_dim // 2
+
+    def test_expert_ffn_isoflop_top2(self):
+        # top-2 with half-size experts matches the dense FFN's activated FLOPs (2 * F/2 = F)
+        m = ModelConfig(
+            dim=1024, n_heads=16, num_experts=4, moe_top_k=2, moe_expert_ffn_multiplier=0.5
+        )
+        assert m.moe_top_k * m.computed_expert_ffn_hidden_dim == m.computed_ffn_hidden_dim
+
+    def test_expert_ffn_multiplier_rejects_nonpositive(self):
+        with pytest.raises(ValueError, match="moe_expert_ffn_multiplier must be positive"):
+            ModelConfig(num_experts=4, moe_top_k=2, moe_expert_ffn_multiplier=0.0)
+
+    def test_finegrained_reduces_param_estimate(self):
+        common = dict(dim=512, n_layers=2, n_heads=8, vocab_size=1000, num_experts=4, moe_top_k=2)
+        assert (
+            ModelConfig(**common, moe_expert_ffn_multiplier=0.5).num_params_estimate
+            < ModelConfig(**common).num_params_estimate
+        )
+
     def test_moe_rejects_top_k_greater_than_experts(self):
         with pytest.raises(ValueError, match="moe_top_k.*must be <= num_experts"):
             ModelConfig(num_experts=8, moe_top_k=16)

--- a/tests/unit/test_moe.py
+++ b/tests/unit/test_moe.py
@@ -211,6 +211,26 @@ class TestMoETransformer:
         actual = sum(p.numel() for p in model.parameters())
         assert actual == config.num_params_estimate
 
+    def test_finegrained_experts_built_smaller(self):
+        """moe_expert_ffn_multiplier=0.5 -> experts have F/2 hidden; dense layers unchanged."""
+        config = ModelConfig(
+            **_SMALL, num_experts=4, moe_top_k=2, moe_frequency=2, moe_expert_ffn_multiplier=0.5
+        )
+        f = config.computed_ffn_hidden_dim
+        model = Transformer(config)
+        for _name, layer in model.layers.items():
+            if isinstance(layer.mlp, MoEMLP):  # layers 1, 3
+                assert layer.mlp.experts[0].gate_proj.weight.shape[0] == f // 2
+            else:  # dense layers 0, 2
+                assert layer.mlp.gate_proj.weight.shape[0] == f
+
+    def test_finegrained_param_count_matches(self):
+        """num_params_estimate matches actual params for a fine-grained MoE model."""
+        config = ModelConfig(**_SMALL, num_experts=4, moe_top_k=2, moe_expert_ffn_multiplier=0.5)
+        model = Transformer(config)
+        actual = sum(p.numel() for p in model.parameters())
+        assert actual == config.num_params_estimate
+
 
 # ---------------------------------------------------------------------------
 # SigmoidTopKRouter (DeepSeek-V3 style)

--- a/tests/unit/test_moma.py
+++ b/tests/unit/test_moma.py
@@ -66,6 +66,21 @@ def _config(
     )
 
 
+def test_moma_finegrained_experts():
+    """MoMa expert-choice MoE experts honor moe_expert_ffn_multiplier (fine-grained)."""
+    cfg = ModelConfig(
+        dim=64, n_layers=2, n_heads=4, vocab_size=128, max_seq_len=64, moe_expert_ffn_multiplier=0.5
+    )
+    ffn = MoMaFFN(
+        cfg,
+        modalities=("image", "text"),
+        experts_per_modality={"image": 4, "text": 4},
+        capacity_factor_per_modality={"image": 1.0, "text": 1.0},
+    )
+    expert = ffn.experts["text"].experts[0]
+    assert expert.gate_proj.weight.shape[0] == cfg.computed_ffn_hidden_dim // 2
+
+
 # ---------------------------------------------------------------------------
 # MoMaConfig
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mot.py
+++ b/tests/unit/test_mot.py
@@ -54,6 +54,27 @@ def _config(
     )
 
 
+def test_mot_finegrained_experts():
+    """MoT MoE experts honor moe_expert_ffn_multiplier (fine-grained)."""
+    from kempnerforge.model.moe import MoEMLP
+
+    cfg = ModelConfig(
+        dim=64,
+        n_layers=2,
+        n_heads=4,
+        vocab_size=128,
+        max_seq_len=64,
+        num_experts=4,
+        moe_top_k=2,
+        moe_frequency=1,
+        moe_expert_ffn_multiplier=0.5,
+    )
+    block = MoTBlock(cfg, modalities=("image", "text"), layer_idx=0)
+    moe = block.mlp["text"]
+    assert isinstance(moe, MoEMLP)
+    assert moe.experts[0].gate_proj.weight.shape[0] == cfg.computed_ffn_hidden_dim // 2
+
+
 # ---------------------------------------------------------------------------
 # MoTAttention — structural
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `ModelConfig.moe_expert_ffn_multiplier` (default `1.0`) + a `computed_expert_ffn_hidden_dim` property: expert FFN hidden = `computed_ffn_hidden_dim × multiplier`, rounded to a multiple of 16.
- Thread the expert hidden dim into every expert-construction site: `transformer.py` (standard `build_moe`), `mot.py` (MoT per-modality `build_moe`), `moma.py` (`ExpertChoiceMoE`).
- Update `num_params_estimate` to count experts at the (possibly smaller) expert hidden dim.
- Enables DeepSeek-style fine-grained experts and **activated-FLOP-matched** MoE↔dense comparisons: with top-`k`, set `multiplier = 1/k` so `k × (F/k) = F` (e.g. top-2 + `0.5` → MoE activates the same FFN compute as dense). Verified: 70M backbone, top-2/`0.5` → 1536 activated = dense (1.0×).

Default `1.0` reproduces current behavior exactly (expert hidden == dense FFN); dense and existing MoE configs are unchanged.

 ## Testing
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors; parity with `main`)
- [x] `uv run pytest tests/unit/ -v --timeout=60` passes (1377 passed, 2 skipped; +9 new tests in test_config / test_moe / test_mot / test_moma)
- [ ] distributed: n/a (no distributed code changed)
- [ ] e2e: n/a (no training-loop/parallelism/optimizer change). Ran `tests/e2e --e2e` anyway: 25 passed, 5 pre-existing failures (checkpoint-resume / pipeline-parallel / SIGTERM), identical on `main`.

Closes #116 