### PR TITLE
Add MoE router z-loss for training stability (ST-MoE)

### DIFF
--- a/kempnerforge/config/model.py
+++ b/kempnerforge/config/model.py
@@ -54,6 +54,7 @@ class ModelConfig:
     moe_gradient_scale: bool = False  # Per-expert gradient normalization
     moe_bias_schedule: str = "constant"  # "constant", "cosine_decay", "linear_warmup"
     moe_packed_experts: bool = False  # Pack expert weights into one tensor per projection
+    moe_router_z_loss_weight: float = 0.0  # router logit z-loss coeff (ST-MoE; 0=off)
 
     def __post_init__(self) -> None:
         if self.n_kv_heads is None:
@@ -99,6 +100,8 @@ class ModelConfig:
                     f"Unknown moe_bias_schedule: '{self.moe_bias_schedule}'. "
                     "Options: 'constant', 'cosine_decay', 'linear_warmup'"
                 )
+            if self.moe_router_z_loss_weight < 0:
+                raise ValueError("moe_router_z_loss_weight must be non-negative")
 
     @property
     def is_moe(self) -> bool:

--- a/kempnerforge/model/moe.py
+++ b/kempnerforge/model/moe.py
@@ -353,6 +353,10 @@ class MoEMLP(nn.Module):
         return self.router.aux_loss  # type: ignore[reportReturnType]
 
     @property
+    def z_loss(self) -> torch.Tensor:
+        return self.router.z_loss  # type: ignore[reportReturnType]
+
+    @property
     def expert_counts(self) -> torch.Tensor:
         return self.router.expert_counts  # type: ignore[reportReturnType]
 

--- a/kempnerforge/model/router.py
+++ b/kempnerforge/model/router.py
@@ -28,6 +28,7 @@ class SoftmaxTopKRouter(nn.Module):
         self.num_experts = num_experts
         self.top_k = top_k
         self.aux_loss = torch.tensor(0.0)
+        self.z_loss = torch.tensor(0.0)
         self.expert_counts: torch.Tensor = torch.zeros(num_experts)
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -65,6 +66,9 @@ class SoftmaxTopKRouter(nn.Module):
         p = probs.mean(dim=0)  # (E,)
 
         self.aux_loss = self.num_experts * (f * p).sum()
+        # Router z-loss (ST-MoE): penalizes large router logits. Always computed
+        # (like aux_loss); only added to the training loss when the weight > 0.
+        self.z_loss = (torch.logsumexp(logits, dim=-1) ** 2).mean()
         self.expert_counts = tokens_per_expert.detach()
 
         return weights, indices
@@ -120,6 +124,7 @@ class SigmoidTopKRouter(nn.Module):
         self.register_buffer("expert_ema", torch.ones(num_experts) / num_experts)
 
         self.aux_loss = torch.tensor(0.0)
+        self.z_loss = torch.tensor(0.0)
         self.expert_counts: torch.Tensor = torch.zeros(num_experts)
 
     def set_step(self, step: int, max_steps: int) -> None:
@@ -189,6 +194,10 @@ class SigmoidTopKRouter(nn.Module):
             self.aux_loss = self.sequence_aux_loss_weight * balance_loss
         else:
             self.aux_loss = torch.tensor(0.0, device=x.device)
+
+        # Router z-loss (ST-MoE): penalizes large router logits. Always computed
+        # (like aux_loss); only added to the training loss when the weight > 0.
+        self.z_loss = (torch.logsumexp(logits, dim=-1) ** 2).mean()
 
         return weights, indices
 

--- a/kempnerforge/model/transformer.py
+++ b/kempnerforge/model/transformer.py
@@ -263,6 +263,14 @@ class Transformer(nn.Module):
                 total = total + layer.mlp.aux_loss
         return total
 
+    def get_moe_router_z_loss(self) -> torch.Tensor:
+        """Collect router z-losses (ST-MoE) from all MoE layers. Returns 0 if dense."""
+        total = torch.tensor(0.0, device=next(self.parameters()).device)
+        for layer in self.layers.values():
+            if isinstance(layer.mlp, MoEMLP):
+                total = total + layer.mlp.z_loss
+        return total
+
     def get_expert_counts(self) -> dict[int, torch.Tensor]:
         """Collect per-layer expert utilization for flat MoE layers.
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -746,6 +746,9 @@ def main() -> None:
                     if mc.is_moe:
                         aux_loss = inner_transformer(model).get_moe_aux_loss()  # type: ignore[attr-defined]
                         loss = loss + mc.moe_aux_loss_weight * aux_loss
+                        if mc.moe_router_z_loss_weight > 0:
+                            z = inner_transformer(model).get_moe_router_z_loss()  # type: ignore[attr-defined]
+                            loss = loss + mc.moe_router_z_loss_weight * z
 
                     scaled_loss = loss / tc.grad_accum_steps
                     scaled_loss.backward()
@@ -810,6 +813,9 @@ def main() -> None:
                     if mc.is_moe:
                         aux_loss = inner_transformer(model).get_moe_aux_loss()  # type: ignore[attr-defined]
                         loss = loss + mc.moe_aux_loss_weight * aux_loss
+                        if mc.moe_router_z_loss_weight > 0:
+                            z = inner_transformer(model).get_moe_router_z_loss()  # type: ignore[attr-defined]
+                            loss = loss + mc.moe_router_z_loss_weight * z
 
                     scaled_loss = loss / tc.grad_accum_steps
                     scaled_loss.backward()
@@ -912,6 +918,7 @@ def main() -> None:
         if mc.is_moe and step_metrics is not None:
             _inner = inner_transformer(model)
             moe_metrics = {"moe/aux_loss": _inner.get_moe_aux_loss().item()}  # type: ignore[attr-defined]
+            moe_metrics["moe/router_z_loss"] = _inner.get_moe_router_z_loss().item()  # type: ignore[attr-defined]
             expert_counts = _inner.get_expert_counts()  # type: ignore[attr-defined]
             if expert_counts:
                 all_counts = torch.stack(list(expert_counts.values())).float()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -104,6 +104,14 @@ class TestModelConfig:
         assert m.is_moe is True
         assert m.moe_top_k == 2
 
+    def test_router_z_loss_weight_default(self):
+        m = ModelConfig(num_experts=4, moe_top_k=2)
+        assert m.moe_router_z_loss_weight == 0.0
+
+    def test_router_z_loss_weight_rejects_negative(self):
+        with pytest.raises(ValueError, match="moe_router_z_loss_weight must be non-negative"):
+            ModelConfig(num_experts=4, moe_top_k=2, moe_router_z_loss_weight=-1.0)
+
     def test_moe_rejects_top_k_greater_than_experts(self):
         with pytest.raises(ValueError, match="moe_top_k.*must be <= num_experts"):
             ModelConfig(num_experts=8, moe_top_k=16)

--- a/tests/unit/test_moe.py
+++ b/tests/unit/test_moe.py
@@ -51,6 +51,23 @@ class TestMoEMLP:
         assert torch.isfinite(moe.aux_loss)
         assert moe.aux_loss.item() > 0
 
+    def test_z_loss_accessible(self):
+        router = SoftmaxTopKRouter(dim=64, num_experts=8, top_k=2)
+        experts = torch.nn.ModuleList([SwiGLUMLP(64, 128) for _ in range(8)])
+        moe = MoEMLP(router, experts)
+        x = torch.randn(2, 16, 64)
+        moe(x)
+        assert torch.isfinite(moe.z_loss)
+        assert moe.z_loss.item() > 0
+
+    def test_z_loss_matches_logsumexp_formula(self):
+        torch.manual_seed(0)
+        router = SoftmaxTopKRouter(dim=64, num_experts=8, top_k=2)
+        x = torch.randn(32, 64)
+        router(x)
+        expected = (torch.logsumexp(router.gate(x), dim=-1) ** 2).mean()
+        assert torch.allclose(router.z_loss, expected, atol=1e-5)
+
     def test_expert_counts_accessible(self):
         router = SoftmaxTopKRouter(dim=64, num_experts=8, top_k=2)
         experts = torch.nn.ModuleList([SwiGLUMLP(64, 128) for _ in range(8)])
@@ -173,6 +190,30 @@ class TestMoETransformer:
             model(tokens)
         assert model.get_moe_aux_loss().item() == 0.0
 
+    def test_get_moe_router_z_loss(self):
+        config = ModelConfig(**_SMALL, num_experts=4, moe_top_k=2)
+        model = Transformer(config).to(DEVICE)
+        tokens = torch.randint(0, 1000, (2, 32), device=DEVICE)
+        with torch.no_grad():
+            model(tokens)
+        z = model.get_moe_router_z_loss()
+        assert torch.isfinite(z)
+        assert z.item() > 0
+
+    def test_get_moe_router_z_loss_dense_returns_zero(self):
+        config = ModelConfig(**_SMALL)
+        model = Transformer(config).to(DEVICE)
+        tokens = torch.randint(0, 1000, (2, 32), device=DEVICE)
+        with torch.no_grad():
+            model(tokens)
+        assert model.get_moe_router_z_loss().item() == 0.0
+
+    def test_z_loss_not_in_state_dict(self):
+        """z_loss is a transient attribute (like aux_loss), not a checkpointed buffer."""
+        config = ModelConfig(**_SMALL, num_experts=4, moe_top_k=2)
+        model = Transformer(config)
+        assert not any("z_loss" in k for k in model.state_dict())
+
     def test_get_expert_counts(self):
         config = ModelConfig(**_SMALL, num_experts=4, moe_top_k=2)
         model = Transformer(config).to(DEVICE)
@@ -231,6 +272,14 @@ class TestSigmoidTopKRouter:
         x = torch.randn(32, 64)
         router(x)
         assert router.aux_loss.item() == 0.0
+
+    def test_z_loss_computed(self):
+        """Sigmoid router computes router z-loss from gate logits."""
+        router = SigmoidTopKRouter(dim=64, num_experts=8, top_k=2)
+        x = torch.randn(32, 64)
+        router(x)
+        assert torch.isfinite(router.z_loss)
+        assert router.z_loss.item() > 0
 
     def test_weights_sum_to_one(self):
         """Routing weights are normalized to sum to 1 per token."""


### PR DESCRIPTION
## Summary
- Add `ModelConfig.moe_router_z_loss_weight` (default `0.0` = off): the ST-MoE router z-loss `mean_token (logsumexp(router_logits))²`, which penalizes router-logit growth.
- Compute `z_loss` in both routers (`SoftmaxTopKRouter`, `SigmoidTopKRouter`), expose via `MoEMLP.z_loss`, aggregate via `Transformer.get_moe_router_z_loss()` (mirrors `aux_loss` / `get_moe_aux_loss`), and add `weight × z_loss` to the loss in `scripts/train.py` (both forward paths), gated on `weight > 0`; log `moe/router_z_loss`.
- Default `0.0` ⇒ z-loss never added ⇒ training/outputs/grads unchanged. `z_loss` is a plain attribute (like `aux_loss`), not a buffer/param ⇒ not in `state_dict` (checkpoint-safe).
- Verified end-to-end: with `weight=1e-3`, router z-loss is held bounded (~2–3 vs 14→24 when off) at identical LM loss — stabilizes router logits at negligible cost. (Note: z-loss targets logit-growth stability, not load balance)
    
## Testing
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors; parity with `main`)
- [x] `uv run pytest tests/unit/ -v --timeout=60` passes (1376 passed, 2 skipped; +8 new tests in test_config / test_moe)
- [ ] distributed: n/a (no parallelism code changed)
- [x] training loop changed → ran `tests/e2e --e2e`: 25 passed, 5 failed. The 5 failures (checkpoint-resume / pipeline-parallel / SIGTERM) are **pre-existing on `main`** and unrelated to this PR — PR1, which doesn't touch `train.py`, fails the identical 5.

Closes #117 
