### PR TITLE
Config-driven model extensions: overridable head_dim, adapter pre-norm, warm-start exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Decoupled attention head dim, an optional adapter pre-norm, and weights-only warm-start.** Small, model-agnostic additions to core, reusable by any config:
+  - `kempnerforge/config/model.py`: `ModelConfig.head_dim` is now an overridable field (`int`, `0` → `dim // n_heads`; was a computed property), decoupling the attention width so `n_heads * head_dim` need not equal `dim`. The default preserves the `dim // n_heads` coupling; `dim % n_heads == 0` is required only when the head dim is inferred.
+  - `kempnerforge/model/adapter.py`: the `mlp_2layer` connector gains an optional `pre_norm` — a pre-projection normalization over the vision features (exposed as `ln_q`), chosen by norm-registry key (`rmsnorm` / `layernorm`). Off by default, so existing `mlp_2layer` configs are unchanged.
+  - `kempnerforge/model/cross_attention.py`, `transformer.py`: `CrossAttentionBlock` threads `head_dim` to `CrossAttention`, so cross-attention honors a decoupled head dim.
+  - `scripts/train.py`: a `load_path` warm-start now honors `checkpoint.exclude_from_loading`, so a weights-only checkpoint (no optimizer/train-state) fine-tunes cleanly; a real resume still restores full state.
+  - Tests fold into the components' existing suites (`tests/unit/test_config.py`, `test_model.py`, `test_adapter.py`, `test_cross_attention.py`).
 - **MoE router z-loss** (`moe_router_z_loss_weight`, ST-MoE style). An optional penalty on the router's pre-softmax logits — per MoE layer `mean_token(logsumexp(router_logits))²` — summed across layers and added to the training loss as `moe_router_z_loss_weight × z_loss`. It keeps router logits from growing without bound, targeting *logit-growth stability* (not load balance — that's the aux loss). Default `0.0` is off: the term is never added, so training, outputs, and gradients are unchanged. `z_loss` is a plain attribute like `aux_loss` (not a buffer/parameter), so it never enters `state_dict` — checkpoint-safe.
   - `kempnerforge/config/model.py`: `moe_router_z_loss_weight: float = 0.0` (with a non-negativity check).
   - `kempnerforge/model/router.py`: both `SoftmaxTopKRouter` and `SigmoidTopKRouter` set `self.z_loss = (logsumexp(logits, dim=-1) ** 2).mean()`.

--- a/kempnerforge/config/adapter.py
+++ b/kempnerforge/config/adapter.py
@@ -29,6 +29,10 @@ class AdapterConfig:
             ``out_dim``"; ignored by the other types.
         activation: Activation between the two MLP projections. One of
             ``"gelu"`` (default), ``"silu"``, ``"relu"``. ``mlp_2layer`` only.
+        pre_norm: Norm applied to the vision features before ``mlp_2layer``'s
+            first projection (exposed as ``ln_q``), by norm-registry key
+            (``"rmsnorm"`` / ``"layernorm"``). ``""`` (default) disables it;
+            ``mlp_2layer`` only.
         pool_window: Pooling kernel side for the pooling adapters (e.g. ``2``
             for image 2×2, ``3`` for video 3×3); ignored by projection adapters.
         pool_heads: Number of attention heads for ``attentional_pool``; must
@@ -38,6 +42,7 @@ class AdapterConfig:
     type: str = "mlp_2layer"
     hidden_dim: int = 0
     activation: str = "gelu"
+    pre_norm: str = ""
     pool_window: int = 2
     pool_heads: int = 16
 
@@ -60,6 +65,16 @@ class AdapterConfig:
             raise ValueError(
                 f"Unknown adapter.activation: {self.activation!r}. Options: 'gelu', 'silu', 'relu'."
             )
+        if self.pre_norm:
+            # Validate against the norm registry (populated by the import above),
+            # so any registered norm type is accepted; "" disables the pre-norm.
+            try:
+                registry.get("norm", self.pre_norm)
+            except KeyError as exc:
+                raise ValueError(
+                    f"Unknown adapter.pre_norm: {self.pre_norm!r}. Must be a registered norm "
+                    "type (e.g. 'rmsnorm', 'layernorm'), or '' to disable the pre-norm."
+                ) from exc
         if self.pool_window <= 0:
             raise ValueError(f"adapter.pool_window must be positive (got {self.pool_window})")
         if self.pool_heads <= 0:
@@ -75,6 +90,7 @@ class AdapterConfig:
         return {
             "hidden_dim": self.hidden_dim or None,
             "activation": self.activation,
+            "pre_norm": self.pre_norm or None,
             "pool_window": self.pool_window,
             "pool_heads": self.pool_heads,
         }

--- a/kempnerforge/config/model.py
+++ b/kempnerforge/config/model.py
@@ -26,6 +26,7 @@ class ModelConfig:
     n_layers: int = 32
     n_heads: int = 32
     n_kv_heads: int | None = None  # None -> same as n_heads (MHA)
+    head_dim: int = 0  # 0 -> dim // n_heads; set explicitly for decoupled head_dim (Qwen3)
     vocab_size: int = 32000
     ffn_dim_multiplier: float = 1.0
     ffn_hidden_dim: int | None = None  # Override computed hidden dim
@@ -69,9 +70,22 @@ class ModelConfig:
         if self.n_kv_heads <= 0:
             raise ValueError("n_kv_heads must be positive")
 
-        # Divisibility checks
-        if self.dim % self.n_heads != 0:
-            raise ValueError(f"dim ({self.dim}) must be divisible by n_heads ({self.n_heads})")
+        # Head dim: the default couples it to dim // n_heads (Llama-style). An
+        # explicit value decouples the attention width from the model dim
+        # (n_heads * head_dim need not equal dim) as in Qwen3 (dim=1024,
+        # n_heads=16, head_dim=128 -> a 2048-wide attention over a 1024-wide
+        # residual). The dim-divisible-by-n_heads requirement only applies to
+        # the inferred case.
+        if self.head_dim == 0:
+            if self.dim % self.n_heads != 0:
+                raise ValueError(
+                    f"dim ({self.dim}) must be divisible by n_heads ({self.n_heads}) "
+                    "when head_dim is not set explicitly"
+                )
+            self.head_dim = self.dim // self.n_heads
+        elif self.head_dim < 0:
+            raise ValueError(f"head_dim must be positive (got {self.head_dim})")
+
         if self.n_heads % self.n_kv_heads != 0:
             raise ValueError(
                 f"n_heads ({self.n_heads}) must be divisible by n_kv_heads ({self.n_kv_heads})"
@@ -110,10 +124,6 @@ class ModelConfig:
     def is_moe(self) -> bool:
         """Whether this config uses Mixture-of-Experts."""
         return self.num_experts > 0
-
-    @property
-    def head_dim(self) -> int:
-        return self.dim // self.n_heads
 
     @property
     def computed_ffn_hidden_dim(self) -> int:

--- a/kempnerforge/model/adapter.py
+++ b/kempnerforge/model/adapter.py
@@ -7,8 +7,9 @@ between the vision encoder and the transformer in ``VLMWrapper``.
 Two families:
 
 - **Projection adapters** keep the token count (``out_tokens == num_tokens``):
-  ``mlp_2layer`` (default, the canonical LLaVA-family 2-layer MLP) and
-  ``linear`` (single ``nn.Linear``, an ablation baseline).
+  ``mlp_2layer`` (default, the canonical LLaVA-family 2-layer MLP, with an
+  optional pre-projection norm) and ``linear`` (single ``nn.Linear``, an
+  ablation baseline).
 - **Pooling adapters** reduce the token count by pooling the square patch grid
   before projecting: ``avgpool`` (window-average, the cheapest reducer) and
   ``attentional_pool`` (Molmo2-style per-window multi-head attention with the
@@ -32,6 +33,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from kempnerforge.config.registry import registry
+from kempnerforge.model.norm import build_norm
 
 _ADAPTER_ACTIVATIONS: dict[str, type[nn.Module]] = {
     "gelu": nn.GELU,
@@ -124,11 +126,17 @@ class VisionAdapter(nn.Module):
 class MLP2LayerAdapter(VisionAdapter):
     """2-layer MLP from image-feature dim to LLM embedding dim.
 
-    Architecture: ``Linear(in_dim, hidden) -> activation -> Linear(hidden, out_dim)``.
-    ``hidden_dim=None`` defaults to ``out_dim``. Keeps the token count.
+    Architecture: ``[pre_norm] -> Linear(in_dim, hidden) -> activation ->
+    Linear(hidden, out_dim)``. ``hidden_dim=None`` defaults to ``out_dim``.
+    Keeps the token count.
+
+    ``pre_norm`` optionally inserts a pre-projection normalization over the
+    vision features (exposed as ``ln_q``), selected by norm-registry key
+    (e.g. ``"rmsnorm"`` / ``"layernorm"``); ``None``/empty disables it. This is
+    the LLaVA-family MLP, optionally with a Qwen2.5-VL-style pre-norm head.
 
     ``reset_parameters`` is provided so callers that materialize adapters
-    from meta can re-initialize weights with the standard Linear defaults.
+    from meta can re-initialize weights with the standard defaults.
     """
 
     def __init__(
@@ -137,6 +145,7 @@ class MLP2LayerAdapter(VisionAdapter):
         out_dim: int,
         hidden_dim: int | None = None,
         activation: str = "gelu",
+        pre_norm: str | None = None,
     ) -> None:
         super().__init__()
         if in_dim <= 0 or out_dim <= 0:
@@ -146,19 +155,28 @@ class MLP2LayerAdapter(VisionAdapter):
                 f"Unknown adapter activation: {activation!r}. Options: {list(_ADAPTER_ACTIVATIONS)}"
             )
         hidden = hidden_dim if hidden_dim and hidden_dim > 0 else out_dim
+        # Optional pre-projection norm over the vision features (Qwen2.5-VL's
+        # merger ``ln_q``); registry-selected so any registered norm works.
+        self.ln_q = build_norm(pre_norm, in_dim) if pre_norm else None
         self.proj1 = nn.Linear(in_dim, hidden, bias=True)
         self.act = _ADAPTER_ACTIVATIONS[activation]()
         self.proj2 = nn.Linear(hidden, out_dim, bias=True)
 
     def reset_parameters(self) -> None:
-        """Re-run ``nn.Linear`` default init on both projections.
+        """Re-init the projections (and the pre-norm, if any).
 
         Used after ``to_empty(device=...)`` on a meta-device build.
         """
+        if self.ln_q is not None:
+            # Standard norm init (weight -> 1, bias -> 0); covers RMSNorm/LayerNorm.
+            for name, param in self.ln_q.named_parameters():
+                nn.init.zeros_(param) if name.endswith("bias") else nn.init.ones_(param)
         self.proj1.reset_parameters()
         self.proj2.reset_parameters()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.ln_q is not None:
+            x = self.ln_q(x)
         return self.proj2(self.act(self.proj1(x)))
 
 
@@ -324,6 +342,7 @@ def _build_mlp_2layer(
     out_dim: int,
     hidden_dim: int | None = None,
     activation: str = "gelu",
+    pre_norm: str | None = None,
     **_: Any,
 ) -> VisionAdapter:
     return MLP2LayerAdapter(
@@ -331,6 +350,7 @@ def _build_mlp_2layer(
         out_dim=out_dim,
         hidden_dim=hidden_dim,
         activation=activation,
+        pre_norm=pre_norm,
     )
 
 

--- a/kempnerforge/model/cross_attention.py
+++ b/kempnerforge/model/cross_attention.py
@@ -131,10 +131,13 @@ class CrossAttentionBlock(nn.Module):
         ffn_hidden_dim: int,
         norm_type: str = "rmsnorm",
         activation: str = "silu",
+        head_dim: int | None = None,
     ) -> None:
         super().__init__()
         self.attn_norm = build_norm(norm_type, dim)
-        self.attn = CrossAttention(dim=dim, n_heads=n_heads, n_kv_heads=n_kv_heads)
+        self.attn = CrossAttention(
+            dim=dim, n_heads=n_heads, n_kv_heads=n_kv_heads, head_dim=head_dim
+        )
         self.mlp_norm = build_norm(norm_type, dim)
         self.mlp = build_mlp(dim=dim, hidden_dim=ffn_hidden_dim, activation=activation)
 

--- a/kempnerforge/model/transformer.py
+++ b/kempnerforge/model/transformer.py
@@ -197,6 +197,7 @@ class Transformer(nn.Module):
                     ffn_hidden_dim=config.computed_ffn_hidden_dim,
                     norm_type=config.norm_type,
                     activation=config.activation,
+                    head_dim=config.head_dim,
                 )
 
         # Final normalization. Used by the non-MoT path. MoT uses

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -228,9 +228,17 @@ def main() -> None:
             vlm_freeze_expected = canonical_freeze_meta(
                 effective_freeze(probe_step, vlm_cfg.freeze, vlm_cfg.freeze_schedule, valid_modules)
             )
+        # Warm-start (fine-tune from checkpoint.load_path, no in-place resume)
+        # honors checkpoint.exclude_from_loading so a weights-only checkpoint
+        # (e.g. a converted external model with no optimizer/train_state) loads
+        # cleanly. A real resume (resume_path present) always restores full state.
+        warm_start_exclude = (
+            (config.checkpoint.exclude_from_loading or None) if resume_path is None else None
+        )
         step, tokens_seen, ckpt_extra_loaded = ckpt_mgr.load(
             path=str(resume_path) if resume_path else None,
             scheduler=scheduler,
+            exclude_keys=warm_start_exclude,
             vlm_freeze_expected=vlm_freeze_expected,
         )
         if ckpt_extra_loaded.get("wandb_run_id"):

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -19,6 +19,7 @@ from kempnerforge.model.adapter import (
     build_adapter,
     pooled_token_count,
 )
+from kempnerforge.model.norm import RMSNorm
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -515,3 +516,82 @@ class TestBuildAdapterPooling:
         adapter = build_adapter(cfg, in_dim=32, out_dim=16)
         assert isinstance(adapter, AttentionalPoolAdapter)
         assert adapter.pool_heads == 8
+
+
+# ---------------------------------------------------------------------------
+# MLP2LayerAdapter optional pre-norm (the folded-in Qwen2.5-VL merger head)
+# ---------------------------------------------------------------------------
+
+
+class TestMLP2LayerPreNorm:
+    """``mlp_2layer`` with an optional pre-projection norm (``ln_q``).
+
+    A pre-norm over the vision features before the 2-layer MLP, selected by
+    norm-registry key. ``pre_norm=None`` keeps the plain MLP (default).
+    """
+
+    def test_no_pre_norm_has_no_ln_q(self):
+        adapter = MLP2LayerAdapter(in_dim=1152, out_dim=1024)
+        assert adapter.ln_q is None
+        assert adapter(torch.randn(2, 8, 1152)).shape == (2, 8, 1024)
+
+    def test_pre_norm_adds_rmsnorm_ln_q(self):
+        adapter = MLP2LayerAdapter(in_dim=1152, out_dim=1024, pre_norm="rmsnorm")
+        assert isinstance(adapter.ln_q, RMSNorm)
+        assert adapter.ln_q.weight.shape == (1152,)
+
+    def test_pre_norm_layernorm(self):
+        adapter = MLP2LayerAdapter(in_dim=32, out_dim=16, pre_norm="layernorm")
+        assert isinstance(adapter.ln_q, torch.nn.LayerNorm)
+        assert adapter(torch.randn(1, 4, 32)).shape == (1, 4, 16)
+
+    def test_forward_shape_preserves_tokens(self):
+        adapter = MLP2LayerAdapter(in_dim=1152, out_dim=1024, hidden_dim=1152, pre_norm="rmsnorm")
+        assert adapter(torch.randn(2, 256, 1152)).shape == (2, 256, 1024)
+
+    def test_backward_grads_flow(self):
+        adapter = MLP2LayerAdapter(in_dim=32, out_dim=16, pre_norm="rmsnorm")
+        x = torch.randn(1, 4, 32, requires_grad=True)
+        adapter(x).sum().backward()
+        for p in adapter.parameters():
+            assert p.grad is not None
+            assert torch.isfinite(p.grad).all()
+
+    def test_reset_parameters_reinitializes(self):
+        adapter = MLP2LayerAdapter(in_dim=8, out_dim=4, pre_norm="rmsnorm")
+        adapter.reset_parameters()
+        assert torch.isfinite(adapter.proj1.weight).all()
+        assert torch.allclose(adapter.ln_q.weight, torch.ones_like(adapter.ln_q.weight))
+
+    def test_built_via_config(self):
+        cfg = AdapterConfig(type="mlp_2layer", pre_norm="rmsnorm", hidden_dim=1152)
+        adapter = build_adapter(cfg, in_dim=1152, out_dim=1024)
+        assert isinstance(adapter, MLP2LayerAdapter)
+        assert isinstance(adapter.ln_q, RMSNorm)
+        assert adapter.proj1.out_features == 1152
+
+    def test_config_default_has_no_pre_norm(self):
+        adapter = build_adapter(AdapterConfig(type="mlp_2layer"), in_dim=8, out_dim=4)
+        assert adapter.ln_q is None
+
+    def test_unknown_pre_norm_raises(self):
+        with pytest.raises(ValueError, match="Unknown adapter.pre_norm"):
+            AdapterConfig(type="mlp_2layer", pre_norm="banana")
+
+    def test_matches_converted_checkpoint_keys(self):
+        # Warm-start guarantee: the converted checkpoints store the adapter as
+        # {ln_q.weight, proj1.weight, proj1.bias, proj2.weight, proj2.bias}.
+        # Building the connector the configs name must reproduce exactly those
+        # keys and shapes, or the checkpoints would stop loading.
+        cfg = AdapterConfig(type="mlp_2layer", pre_norm="rmsnorm", hidden_dim=1152)
+        sd = build_adapter(cfg, in_dim=1152, out_dim=1024).state_dict()
+        assert set(sd) == {
+            "ln_q.weight",
+            "proj1.weight",
+            "proj1.bias",
+            "proj2.weight",
+            "proj2.bias",
+        }
+        assert tuple(sd["ln_q.weight"].shape) == (1152,)
+        assert tuple(sd["proj1.weight"].shape) == (1152, 1152)
+        assert tuple(sd["proj2.weight"].shape) == (1024, 1152)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -188,6 +188,37 @@ class TestModelConfig:
             ModelConfig(sdpa_backend="fa3")
 
 
+class TestHeadDimOverride:
+    """``ModelConfig.head_dim`` decouples the attention width from ``dim``."""
+
+    def test_defaults_to_dim_over_n_heads(self):
+        assert ModelConfig(dim=256, n_heads=8).head_dim == 32
+
+    def test_explicit_decouples_from_dim(self):
+        cfg = ModelConfig(dim=1024, n_heads=16, n_kv_heads=8, head_dim=128)
+        assert cfg.head_dim == 128  # not 1024 // 16 == 64
+
+    def test_explicit_allows_dim_not_divisible_by_n_heads(self):
+        # With an explicit head_dim the attention width is decoupled, so dim
+        # need not be divisible by n_heads.
+        cfg = ModelConfig(
+            dim=100, n_heads=8, head_dim=16, vocab_size=100, n_layers=1, max_seq_len=16
+        )
+        assert cfg.head_dim == 16
+
+    def test_inferred_still_requires_divisible(self):
+        with pytest.raises(ValueError, match="divisible by n_heads"):
+            ModelConfig(dim=100, n_heads=8)
+
+    def test_zero_head_dim_infers(self):
+        # 0 is the "infer" sentinel -> dim // n_heads (same as an unset head_dim).
+        assert ModelConfig(dim=256, n_heads=8, head_dim=0).head_dim == 32
+
+    def test_rejects_negative_head_dim(self):
+        with pytest.raises(ValueError, match="head_dim must be positive"):
+            ModelConfig(dim=256, n_heads=8, head_dim=-4)
+
+
 # ---------------------------------------------------------------------------
 # TrainConfig
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cross_attention.py
+++ b/tests/unit/test_cross_attention.py
@@ -317,3 +317,19 @@ def test_cross_attention_shape_parametrize(batch, seq_len, num_image_tokens):
     out.sum().backward()
     assert x.grad is not None
     assert img.grad is not None
+
+
+class TestCrossAttentionHeadDim:
+    """``CrossAttentionBlock`` honors a decoupled ``head_dim``."""
+
+    def test_block_uses_decoupled_head_dim(self):
+        block = CrossAttentionBlock(
+            dim=1024, n_heads=16, n_kv_heads=8, ffn_hidden_dim=3072, head_dim=128
+        )
+        assert block.attn.q_proj.out_features == 16 * 128  # 2048, not 1024
+        assert block.attn.o_proj.in_features == 16 * 128
+
+    def test_block_defaults_to_coupled_head_dim(self):
+        # Without an explicit head_dim the block keeps dim // n_heads.
+        block = CrossAttentionBlock(dim=1024, n_heads=16, n_kv_heads=8, ffn_hidden_dim=3072)
+        assert block.attn.q_proj.out_features == 1024  # 16 * (1024 // 16)

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1036,3 +1036,33 @@ class TestInitWeights:
             model = Transformer(_INIT_CONFIG)
         # Should not raise even though all params are on meta device
         init_weights(model, _INIT_CONFIG)
+
+
+class TestDecoupledHeadDim:
+    """A ``ModelConfig.head_dim`` override flows into the built attention/RoPE."""
+
+    def test_attention_uses_decoupled_head_dim(self):
+        cfg = ModelConfig(
+            dim=1024, n_heads=16, n_kv_heads=8, head_dim=128, vocab_size=1000, n_layers=1
+        )
+        block = TransformerBlock(cfg, layer_idx=0)
+        assert block.attention.q_proj.out_features == 16 * 128  # 2048, decoupled
+        assert block.attention.k_proj.out_features == 8 * 128  # 1024 (GQA)
+        assert block.attention.o_proj.in_features == 16 * 128  # 2048
+        assert block.attention.o_proj.out_features == 1024  # back to residual dim
+
+    def test_rope_table_width_follows_head_dim(self):
+        # RoPE cos/sin last dim is head_dim // 2; a decoupled head_dim must flow
+        # into the precomputed table, not dim // n_heads.
+        cfg = ModelConfig(
+            dim=1024,
+            n_heads=16,
+            n_kv_heads=8,
+            head_dim=128,
+            vocab_size=64,
+            n_layers=1,
+            max_seq_len=8,
+        )
+        model = Transformer(cfg)
+        assert model._rope_cos is not None
+        assert model._rope_cos.shape[-1] == 128 // 2


### PR DESCRIPTION
## Summary
- Make `ModelConfig.head_dim` an overridable field (`int`; `0` = infer `dim // n_heads`, was a computed property) so the attention width can decouple from `dim` (`n_heads * head_dim` need not equal `dim`); default and divisibility behavior unchanged when inferred
- Add an optional `pre_norm` to the `mlp_2layer` adapter — a pre-projection norm (exposed as `ln_q`) selected by norm-registry key (`rmsnorm` / `layernorm`); off by default, so existing `mlp_2layer` configs are unchanged
- Thread an explicit `head_dim` through `CrossAttentionBlock` → `CrossAttention` so cross-attention honors a decoupled head dim
- Honor `checkpoint.exclude_from_loading` on a `load_path` warm-start in `scripts/train.py` (weights-only fine-tune skips optimizer/dataloader state); a full resume still restores everything
- Tests folded into the existing suites (`test_config`, `test_model`, `test_adapter`, `test_cross_attention`)

All additions default to prior behavior (`head_dim=0`, `pre_norm=""`, empty `exclude_from_loading`); no changes to existing configs or checkpoints.

## Testing
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors)
- [x] `uv run pytest tests/unit/ -v --timeout=60` — 1667 passed, 2 skipped. (The one miss, `test_moe.py::TestCompile::test_compile_moe_bf16`, is a pre-existing cold-`torch.compile` >60s timeout in code this PR doesn't touch — identical to `main`; passes at `--timeout=300` in 39s.)
- [ ] If distributed code changed: N/A (no `kempnerforge/distributed/` changes)
- [ ] If training loop / parallelism / optimizers changed: the `train.py` warm-start path was validated by a 4×H200 video smoke (loads a converted DCP + trains); formal `tests/e2e/` not required

ralted to #139
Refs: [KEM-571](https://linear.app/kempner/issue/KEM-571/enable-the-vlm-architecture-with-qwen3-backbone)
Example that exercises these: #140 (stacked on this PR)
