### PR TITLE
Add MLflow (Databricks) logging backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ build/
 # Wandb
 wandb/
 
+# MLflow (local SQLite fallback store)
+mlflow.db
+mlruns/
+
 # OS
 .DS_Store
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MLflow logging backend** (`metrics.enable_mlflow`, Databricks-hosted or local). A third `_LoggingBackend` alongside WandB and TensorBoard: logs the same per-step metric dict, plus the flattened config as params, `host`/`slurm_job_id` tags, and optional system metrics. Credentials come from the environment (`DATABRICKS_HOST` + `DATABRICKS_TOKEN`/`DATABRICKS_API_TOKEN`); with `tracking_uri="databricks"` and no creds it disables with a warning. Opt-in at both layers — `uv sync --group mlflow` and `enable_mlflow=true`; absent or misconfigured it warns and no-ops without touching training. Default off, so existing runs are unchanged.
+  - `kempnerforge/config/metrics.py`: `enable_mlflow`, `mlflow_tracking_uri`, `mlflow_experiment`, `mlflow_run_name`, `mlflow_run_id`, `mlflow_log_system_metrics`, `mlflow_system_metrics_interval`; `__post_init__` requires an absolute experiment path on Databricks.
+  - `kempnerforge/metrics/tracker.py`: `MLflowBackend` (lazy init, run-id write-back, system metrics) + `_flatten_config_params`; selected in `_init_backends`.
+  - `scripts/train.py`: `mlflow_run_id` saved in `ckpt_extra`/`init_extra` and restored on resume, mirroring `wandb_run_id`, so a requeue reattaches to the same run (or a fresh one if the saved id was deleted, like wandb `resume="allow"`).
+  - `scripts/check_env.py`: `mlflow` preflight tag checking `DATABRICKS_HOST` + token.
+  - `pyproject.toml`: optional `mlflow` dependency group (`mlflow-skinny`, `databricks-sdk`, `psutil`, `nvidia-ml-py`).
+  - Tests: `tests/unit/test_observability.py` (backend sentinels, backend selection, config flatten, absolute-path guard).
+  - Docs: `docs/metrics-and-profiling/mlflow.md` + metrics index/tracker pages + `[metrics]` config reference.
 - **MoE router z-loss** (`moe_router_z_loss_weight`, ST-MoE style). An optional penalty on the router's pre-softmax logits — per MoE layer `mean_token(logsumexp(router_logits))²` — summed across layers and added to the training loss as `moe_router_z_loss_weight × z_loss`. It keeps router logits from growing without bound, targeting *logit-growth stability* (not load balance — that's the aux loss). Default `0.0` is off: the term is never added, so training, outputs, and gradients are unchanged. `z_loss` is a plain attribute like `aux_loss` (not a buffer/parameter), so it never enters `state_dict` — checkpoint-safe.
   - `kempnerforge/config/model.py`: `moe_router_z_loss_weight: float = 0.0` (with a non-negativity check).
   - `kempnerforge/model/router.py`: both `SoftmaxTopKRouter` and `SigmoidTopKRouter` set `self.z_loss = (logsumexp(logits, dim=-1) ** 2).mean()`.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ PyTorch-native framework for fault-tolerant distributed training of foundation m
 - DCP async checkpointing with auto-resume
 - Stateful data pipeline, multi-dataset mixing, data annealing, HuggingFace integration (eager + streaming)
 - SLURM preemption, multi-node launch, `TrainingHook` extensibility
-- NaN / GPU / NCCL health monitoring, MFU tracking, WandB / TensorBoard backends
+- NaN / GPU / NCCL health monitoring, MFU tracking, WandB / TensorBoard / MLflow backends
 
 **Interpretability**
 - Activation hooks with CPU offload for probing, CKA, SVCCA
@@ -94,7 +94,7 @@ flowchart TB
     subgraph Outputs
         direction TB
         O1[DCP checkpoints]
-        O2[MetricsTracker<br/>WandB · TB]
+        O2[MetricsTracker<br/>WandB · TB · MLflow]
         O3[torch.profiler]
     end
 ```
@@ -238,7 +238,7 @@ kempnerforge/
   training/    # optimizers, loss functions, LR schedulers, gradient utils, hooks
   checkpoint/  # DCP-based distributed checkpointing with sync/async save
   resilience/  # signal handling, NaN detection, GPU/NCCL health checks
-  metrics/     # MetricsTracker, MFU computation, WandB/TensorBoard backends
+  metrics/     # MetricsTracker, MFU computation, WandB/TensorBoard/MLflow backends
   profiling/   # torch.profiler integration, CUDA timing
 configs/       # TOML configs for training runs and model architecture presets
 scripts/       # training entry point, data validation, checkpoint conversion, SLURM launch

--- a/configs/train/debug.toml
+++ b/configs/train/debug.toml
@@ -46,3 +46,5 @@ keep_last_n = 2
 log_interval = 5
 enable_wandb = false
 enable_tensorboard = false
+# enable_mlflow = true                                    # uv sync --group mlflow; creds via env
+# mlflow_experiment = "/Users/you@example.com/kf-debug"   # absolute workspace path on Databricks

--- a/docs/configuration/config-sections.md
+++ b/docs/configuration/config-sections.md
@@ -306,6 +306,13 @@ Logging cadence and backend toggles.
 | `wandb_run_name` | `str \| None` | `None` | `None` → auto-generated |
 | `wandb_run_id` | `str` | `""` | restored from checkpoint on resume; empty = new run |
 | `tensorboard_dir` | `str` | `"tb_logs"` | TB log directory |
+| `enable_mlflow` | `bool` | `False` | turn on MLflow backend (Databricks or local) |
+| `mlflow_tracking_uri` | `str` | `"databricks"` | tracking URI; backend disables if `databricks` is set without creds |
+| `mlflow_experiment` | `str \| None` | `None` | absolute workspace path on Databricks; `None` → `$MLFLOW_EXPERIMENT`/auto |
+| `mlflow_run_name` | `str \| None` | `None` | `None` → auto-generated |
+| `mlflow_run_id` | `str` | `""` | restored from checkpoint on resume; empty = new run |
+| `mlflow_log_system_metrics` | `bool` | `True` | sample CPU/GPU/memory on a background thread |
+| `mlflow_system_metrics_interval` | `float` | `10.0` | seconds between system-metric samples |
 
 ## `[profiling]` — `ProfilingConfig`
 

--- a/docs/metrics-and-profiling/index.md
+++ b/docs/metrics-and-profiling/index.md
@@ -4,7 +4,7 @@ Everything the training loop reports about itself — throughput, MFU,
 loss smoothing, GPU memory, kernel traces. Two modules:
 
 - **`kempnerforge/metrics/`** — always-on per-step metrics with WandB /
-  TensorBoard dispatch, MFU computation, memory stats.
+  TensorBoard / MLflow dispatch, MFU computation, memory stats.
 - **`kempnerforge/profiling/`** — opt-in `torch.profiler` wrapper for
   kernel-level traces and ad-hoc CUDA event timing.
 
@@ -15,6 +15,7 @@ loss smoothing, GPU memory, kernel traces. Two modules:
 | `MetricsTracker` | always-on per-step metrics | created unconditionally in `scripts/train.py` |
 | `WandBBackend` | cloud logging | `metrics.enable_wandb = true` |
 | `TensorBoardBackend` | local event files | `metrics.enable_tensorboard = true` |
+| `MLflowBackend` | Databricks / MLflow server | `metrics.enable_mlflow = true` |
 | `compute_mfu` | per-step MFU | always-on (part of `MetricsTracker`) |
 | `get_memory_stats` | per-step GPU memory | always-on |
 | `DeviceMemoryMonitor` | interval-scoped peak tracking + snapshots | opt-in, instantiate manually |
@@ -53,6 +54,9 @@ wandb_project      = "kempnerforge"
 wandb_run_name     = ""          # auto-generated if empty
 wandb_run_id       = ""          # restored from checkpoint on resume
 tensorboard_dir    = "tb_logs"
+enable_mlflow      = false
+mlflow_experiment  = "/Experiments/my-project"   # absolute workspace path on Databricks
+mlflow_run_name    = ""                          # auto-generated if empty
 
 [profiling]
 enable     = false
@@ -72,6 +76,7 @@ for field-level notes.
 metrics-tracker
 wandb
 tensorboard
+mlflow
 mfu
 memory-monitor
 profiler

--- a/docs/metrics-and-profiling/metrics-tracker.md
+++ b/docs/metrics-and-profiling/metrics-tracker.md
@@ -134,6 +134,8 @@ if mc.enable_wandb:
     self._backends.append(WandBBackend(mc))
 if mc.enable_tensorboard:
     self._backends.append(TensorBoardBackend(mc))
+if mc.enable_mlflow:
+    self._backends.append(MLflowBackend(mc, hyperparams=_flatten_config_params(config)))
 ```
 
 Non-rank-0 workers keep `_backends` empty; their `_log_step` call iterates
@@ -172,8 +174,8 @@ def close(self) -> None:
         backend.close()
 ```
 
-Called at the end of `scripts/train.py`. WandB closes the run; TensorBoard
-flushes the event file.
+Called at the end of `scripts/train.py`. WandB and MLflow close the run;
+TensorBoard flushes the event file.
 
 ## Logger: `get_logger`, `format_metrics`
 
@@ -198,6 +200,8 @@ only takes effect on the very first call.
 ## See also
 
 - [WandB](wandb.md) — how `WandBBackend` initializes and what it logs.
+- [MLflow](mlflow.md) — Databricks-hosted tracking with the same metric
+  dict and run-id-resume pattern.
 - [TensorBoard](tensorboard.md) — `TensorBoardBackend` specifics and
   where event files land.
 - [MFU](mfu.md) — what the `mfu` field is computed from.

--- a/docs/metrics-and-profiling/mlflow.md
+++ b/docs/metrics-and-profiling/mlflow.md
@@ -1,0 +1,137 @@
+# MLflow backend
+
+[`MLflowBackend`](https://github.com/KempnerInstitute/KempnerForge/blob/main/kempnerforge/metrics/tracker.py)
+logs metrics, params, and system utilization to a Databricks-hosted MLflow, so we
+don't run a tracking server ourselves. It is opt-in and can run alongside WandB.
+
+```toml
+[metrics]
+enable_mlflow     = true
+mlflow_experiment = "/Experiments/my-project"   # absolute workspace path on Databricks
+mlflow_run_name   = "7b-debug"                  # optional — MLflow auto-generates one
+```
+
+Credentials come from the environment, never from config:
+
+```bash
+export DATABRICKS_HOST="https://<workspace>.cloud.databricks.com"
+export DATABRICKS_API_TOKEN="dapi..."           # or DATABRICKS_TOKEN
+```
+
+The backend is constructed by `MetricsTracker._init_backends` on rank 0 only;
+other ranks never touch MLflow.
+
+## Tracking URI and experiment
+
+`mlflow_tracking_uri` defaults to `"databricks"`, which reads `DATABRICKS_HOST` +
+a token from the environment. If it is `"databricks"` but no credentials are set,
+the backend logs a warning and disables itself — it does not invent a local store.
+Point `mlflow_tracking_uri` at an MLflow server (`http(s)://…`) to log elsewhere.
+
+The client is `mlflow-skinny` (tracking-only; no server or database backends). To
+log to a local SQLite store instead, install full `mlflow` and set
+`mlflow_tracking_uri = "sqlite:///mlflow.db"`.
+
+The experiment name resolves in order: `mlflow_experiment` → `$MLFLOW_EXPERIMENT`
+→ auto. On Databricks the name **must be an absolute workspace path**
+(`/Users/you@example.com/proj` or `/Experiments/proj`); a bare name fails, so
+`MetricsConfig.__post_init__` rejects a non-absolute `mlflow_experiment` at
+config-load time. When none is set, auto derives
+`/Users/<databricks-username>/<wandb_project>` via the Databricks SDK.
+
+## Init is lazy
+
+`__init__` just stashes the config — no network I/O. The first call to `log()`
+runs `_ensure_init`, which sets the tracking URI + experiment and calls
+`mlflow.start_run(...)`:
+
+```python
+# kempnerforge/metrics/tracker.py
+run = mlflow.start_run(
+    run_id=self._config.mlflow_run_id or None,   # resume if set
+    run_name=self._config.mlflow_run_name,
+    log_system_metrics=self._config.mlflow_log_system_metrics,
+)
+self._config.mlflow_run_id = run.info.run_id     # write back for checkpoint
+```
+
+Same two reasons as WandB: distributed setup and checkpoint resume finish before
+the first step logs, and constructing a tracker never touches the network in
+CI/tests.
+
+## Run ID and resume
+
+Mirrors [WandB](wandb.md#run-id-and-resume). On a fresh run, `start_run()` with
+no `run_id` mints a new one; it is written back to `MetricsConfig` and the
+training loop persists it in `ckpt_extra`:
+
+```python
+# scripts/train.py
+if config.metrics.mlflow_run_id:
+    ckpt_extra["mlflow_run_id"] = config.metrics.mlflow_run_id
+```
+
+On resume it is restored right after `ckpt_mgr.load(...)`:
+
+```python
+if ckpt_extra_loaded.get("mlflow_run_id"):
+    config.metrics.mlflow_run_id = ckpt_extra_loaded["mlflow_run_id"]
+```
+
+`start_run(run_id=...)` then reattaches to the same run, so metrics continue on
+one curve across Slurm restarts. If that run id no longer exists (e.g. it was
+deleted), the backend falls back to a fresh run instead of erroring — matching
+wandb's `resume="allow"`.
+
+## What gets logged
+
+- **Metrics** — the same backend dict as WandB/TensorBoard (`train/*`, `gpu/*`,
+  `smoothed/*`), plus everything passed to `tracker.log_eval`, via
+  `mlflow.log_metrics(dict, step=step)`.
+- **Params** — the full `JobConfig` flattened to dotted keys (`model.dim`,
+  `optimizer.lr`, …) once at run start, via `mlflow.log_params`. Cheap searchable
+  metadata, not artifacts.
+- **Tags** — `host` and `slurm_job_id`.
+- **System metrics** — CPU / GPU / memory under `system/`, sampled on a
+  background thread when `mlflow_log_system_metrics = true` (default). Lower
+  `mlflow_system_metrics_interval` (seconds) for short test runs.
+
+No checkpoints are uploaded as artifacts — they stay on the filesystem (artifacts
+are the main MLflow storage cost).
+
+## Failure modes
+
+`_ensure_init` wraps setup in try/except and sets `self._active = False` on any
+failure:
+
+```python
+except ImportError:
+    logger.warning("mlflow not installed — disabling MLflow backend (uv sync --group mlflow)")
+    self._active = False
+except Exception as e:     # network, auth, experiment-path, etc.
+    logger.warning(f"MLflow init failed: {e}")
+    self._active = False
+```
+
+Subsequent `log()` calls no-op — a flaky network or expired token loses logs but
+never crashes training. Param/tag logging is separately guarded so a metadata
+error doesn't disable metric logging.
+
+MLflow is an optional dependency: install with `uv sync --group mlflow` (pulls
+`mlflow-skinny` + `databricks-sdk`). Without it, `enable_mlflow = true` logs a
+warning and no-ops.
+
+## `close()`
+
+Called from `tracker.close()` at the end of training; runs `mlflow.end_run()`.
+No-op unless the run is live.
+
+## See also
+
+- [Metrics tracker](metrics-tracker.md) — where backends are constructed.
+- [WandB](wandb.md) — the sibling backend with the same metric dict and
+  run-id-resume pattern.
+- [Checkpointing § Train state](../checkpointing/train-state.md) — how
+  `mlflow_run_id` travels with the checkpoint.
+- [Configuration § `[metrics]`](../configuration/config-sections.md) — per-field
+  reference for `MetricsConfig`.

--- a/docs/metrics-and-profiling/mlflow.md
+++ b/docs/metrics-and-profiling/mlflow.md
@@ -34,9 +34,9 @@ log to a local SQLite store instead, install full `mlflow` and set
 
 The experiment name resolves in order: `mlflow_experiment` → `$MLFLOW_EXPERIMENT`
 → auto. On Databricks the name **must be an absolute workspace path**
-(`/Users/you@example.com/proj` or `/Experiments/proj`); a bare name fails, so
-`MetricsConfig.__post_init__` rejects a non-absolute `mlflow_experiment` at
-config-load time. When none is set, auto derives
+(`/Users/you@example.com/proj` or `/Experiments/proj`); a bare name fails, so a
+non-absolute experiment is rejected — `MetricsConfig.__post_init__` for the config
+field at load time, and at runtime for `$MLFLOW_EXPERIMENT`. When none is set, auto derives
 `/Users/<databricks-username>/<wandb_project>` via the Databricks SDK.
 
 ## Init is lazy
@@ -113,9 +113,9 @@ except Exception as e:     # network, auth, experiment-path, etc.
     self._active = False
 ```
 
-Subsequent `log()` calls no-op — a flaky network or expired token loses logs but
-never crashes training. Param/tag logging is separately guarded so a metadata
-error doesn't disable metric logging.
+`log()` and `close()` are guarded too: a network/token failure there is caught,
+warns, disables the backend, and never propagates — a mid-run outage loses logs
+but never crashes training. Param/tag logging is separately guarded as well.
 
 MLflow is an optional dependency: install with `uv sync --group mlflow` (pulls
 `mlflow-skinny` + `databricks-sdk`). Without it, `enable_mlflow = true` logs a

--- a/docs/metrics-and-profiling/mlflow.md
+++ b/docs/metrics-and-profiling/mlflow.md
@@ -35,8 +35,9 @@ log to a local SQLite store instead, install full `mlflow` and set
 The experiment name resolves in order: `mlflow_experiment` → `$MLFLOW_EXPERIMENT`
 → auto. On Databricks the name **must be an absolute workspace path**
 (`/Users/you@example.com/proj` or `/Experiments/proj`); a bare name fails, so a
-non-absolute experiment is rejected — `MetricsConfig.__post_init__` for the config
-field at load time, and at runtime for `$MLFLOW_EXPERIMENT`. When none is set, auto derives
+non-absolute experiment is rejected — `MetricsConfig.__post_init__` aborts at config-load
+time for the config field, and the backend disables with a clear message if
+`$MLFLOW_EXPERIMENT` is not absolute at runtime. When none is set, auto derives
 `/Users/<databricks-username>/<wandb_project>` via the Databricks SDK.
 
 ## Init is lazy
@@ -81,7 +82,9 @@ if ckpt_extra_loaded.get("mlflow_run_id"):
 `start_run(run_id=...)` then reattaches to the same run, so metrics continue on
 one curve across Slurm restarts. If that run id no longer exists (e.g. it was
 deleted), the backend falls back to a fresh run instead of erroring — matching
-wandb's `resume="allow"`.
+wandb's `resume="allow"`. On resume it also skips re-logging any step the run already
+recorded, so re-executing the steps between the last checkpoint and the crash does not
+duplicate metric points.
 
 ## What gets logged
 
@@ -113,9 +116,10 @@ except Exception as e:     # network, auth, experiment-path, etc.
     self._active = False
 ```
 
-`log()` and `close()` are guarded too: a network/token failure there is caught,
-warns, disables the backend, and never propagates — a mid-run outage loses logs
-but never crashes training. Param/tag logging is separately guarded as well.
+`log()` never propagates and does not disable the backend on a transient error: it
+warns once and keeps retrying, so logging recovers after a blip. `close()` always ends
+the run (even if logging was disabled) and swallows teardown errors. Param/tag logging
+is separately guarded as well.
 
 MLflow is an optional dependency: install with `uv sync --group mlflow` (pulls
 `mlflow-skinny` + `databricks-sdk`). Without it, `enable_mlflow = true` logs a

--- a/kempnerforge/config/metrics.py
+++ b/kempnerforge/config/metrics.py
@@ -12,11 +12,31 @@ class MetricsConfig:
     log_interval: int = 10  # Log every N steps
     enable_wandb: bool = False
     enable_tensorboard: bool = False
+    enable_mlflow: bool = False
     wandb_project: str = "kempnerforge"
     wandb_run_name: str | None = None  # None -> auto-generated
     wandb_run_id: str = ""  # Restored from checkpoint on resume; empty = new run
     tensorboard_dir: str = "tb_logs"
 
+    # MLflow (Databricks-hosted or local); credentials come from the env, not config.
+    mlflow_tracking_uri: str = "databricks"  # or an http(s):// MLflow server
+    mlflow_experiment: str | None = None  # absolute workspace path on Databricks; None -> env/auto
+    mlflow_run_name: str | None = None  # None -> auto-generated
+    mlflow_run_id: str = ""  # Restored from checkpoint on resume; empty = new run
+    mlflow_log_system_metrics: bool = True  # CPU/GPU/memory sampled on a background thread
+    mlflow_system_metrics_interval: float = 10.0  # seconds between samples
+
     def __post_init__(self) -> None:
         if self.log_interval <= 0:
             raise ValueError("log_interval must be positive")
+        # Databricks requires an absolute workspace path; fail fast at config load.
+        if (
+            self.enable_mlflow
+            and self.mlflow_tracking_uri.startswith("databricks")
+            and self.mlflow_experiment is not None
+            and not self.mlflow_experiment.startswith("/")
+        ):
+            raise ValueError(
+                "mlflow_experiment must be an absolute workspace path on Databricks "
+                f"(e.g. '/Users/you@example.com/proj'); got {self.mlflow_experiment!r}"
+            )

--- a/kempnerforge/metrics/tracker.py
+++ b/kempnerforge/metrics/tracker.py
@@ -1,12 +1,16 @@
+# pyright: reportMissingImports=false
+# ^ mlflow + databricks-sdk are an optional group; CI type-checks without them,
+#   so the lazy imports below would otherwise raise reportMissingImports.
 """Metrics collection, accumulation, and reporting.
 
 MetricsTracker aggregates per-step metrics (loss, grad norm, throughput,
 MFU, memory) and dispatches them to configured logging backends (stdout,
-WandB, TensorBoard) at a configurable interval.
+WandB, TensorBoard, MLflow) at a configurable interval.
 """
 
 from __future__ import annotations
 
+import os
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -88,6 +92,8 @@ class MetricsTracker:
             self._backends.append(WandBBackend(mc))
         if mc.enable_tensorboard:
             self._backends.append(TensorBoardBackend(mc))
+        if mc.enable_mlflow:
+            self._backends.append(MLflowBackend(mc, hyperparams=_flatten_config_params(config)))
 
     def start_step(self) -> None:
         """Mark the beginning of a training step."""
@@ -276,6 +282,152 @@ class WandBBackend(_LoggingBackend):
             import wandb
 
             wandb.finish()
+
+
+def _mlflow_databricks_ready() -> bool:
+    """True when Databricks credentials are present in the environment."""
+    has_token = bool(os.environ.get("DATABRICKS_TOKEN") or os.environ.get("DATABRICKS_API_TOKEN"))
+    return bool(os.environ.get("DATABRICKS_HOST")) and has_token
+
+
+def _resolve_mlflow_experiment(config: MetricsConfig, uri: str) -> str | None:
+    """Experiment name: mlflow_experiment -> $MLFLOW_EXPERIMENT -> auto
+    (/Users/<user>/<project> via the SDK on Databricks; bare name locally)."""
+    if config.mlflow_experiment:
+        return config.mlflow_experiment
+    if os.environ.get("MLFLOW_EXPERIMENT"):
+        return os.environ["MLFLOW_EXPERIMENT"]
+    project = config.wandb_project or "kempnerforge"
+    if not uri.startswith("databricks"):
+        return project
+    try:
+        from databricks.sdk import WorkspaceClient
+
+        user = WorkspaceClient().current_user.me().user_name
+        return f"/Users/{user}/{project}"
+    except Exception as e:  # SDK missing, no creds, or API error
+        logger.warning(f"Could not auto-resolve Databricks experiment path: {e}")
+        return None
+
+
+def _flatten_config_params(config: JobConfig, max_len: int = 250) -> dict[str, str]:
+    """Flatten a JobConfig to dotted string keys (model.dim, ...) for mlflow.log_params.
+
+    None is skipped; non-scalars are stringified; values truncated to max_len.
+    """
+    from dataclasses import asdict
+
+    flat: dict[str, str] = {}
+
+    def _walk(prefix: str, value: Any) -> None:
+        if value is None:
+            return
+        if isinstance(value, dict):
+            for k, v in value.items():
+                _walk(f"{prefix}.{k}" if prefix else str(k), v)
+        else:
+            flat[prefix] = str(value)[:max_len]
+
+    _walk("", asdict(config))
+    return flat
+
+
+class MLflowBackend(_LoggingBackend):
+    """MLflow logging backend (Databricks-hosted or any MLflow tracking server).
+
+    Lazy init on first log; run ID written back to config for checkpoint resume.
+    """
+
+    def __init__(self, config: MetricsConfig, hyperparams: dict[str, str] | None = None) -> None:
+        self._config = config
+        self._hyperparams = hyperparams or {}
+        self._active: bool | None = None  # None = not tried, True = live, False = failed
+
+    def _ensure_init(self) -> None:
+        if self._active is not None:
+            return
+        uri = self._config.mlflow_tracking_uri
+        if uri.startswith("databricks"):
+            if not _mlflow_databricks_ready():
+                logger.warning(
+                    "enable_mlflow with tracking_uri='databricks' but DATABRICKS_HOST/token "
+                    "not set — disabling MLflow backend"
+                )
+                self._active = False
+                return
+            # The Databricks SDK reads DATABRICKS_TOKEN; mirror the DATABRICKS_API_TOKEN
+            # name many keep in ~/.bashrc so either works.
+            if not os.environ.get("DATABRICKS_TOKEN") and os.environ.get("DATABRICKS_API_TOKEN"):
+                os.environ["DATABRICKS_TOKEN"] = os.environ["DATABRICKS_API_TOKEN"]
+        try:
+            import mlflow
+
+            mlflow.set_tracking_uri(uri)
+            experiment = _resolve_mlflow_experiment(self._config, uri)
+            if experiment:
+                mlflow.set_experiment(experiment)
+            if self._config.mlflow_log_system_metrics:
+                mlflow.set_system_metrics_sampling_interval(
+                    self._config.mlflow_system_metrics_interval
+                )
+            run, resumed = self._start_run(mlflow)
+            self._config.mlflow_run_id = run.info.run_id
+            self._active = True
+            logger.info(f"MLflow initialized: experiment={experiment} run_id={run.info.run_id}")
+            if not resumed:
+                self._log_run_metadata(mlflow)
+        except ImportError:
+            logger.warning(
+                "mlflow not installed — disabling MLflow backend (uv sync --group mlflow)"
+            )
+            self._active = False
+        except Exception as e:  # mlflow talks to a remote server: network / auth / config errors
+            logger.warning(f"MLflow init failed: {e}")
+            self._active = False
+
+    def _start_run(self, mlflow: Any) -> tuple[Any, bool]:
+        """Start a run, or resume the saved run_id. If that run_id no longer exists, fall
+        back to a fresh run (matching wandb's resume='allow'). Returns (run, resumed)."""
+        kwargs: dict[str, Any] = {
+            "run_name": self._config.mlflow_run_name,
+            "log_system_metrics": self._config.mlflow_log_system_metrics,
+        }
+        run_id = self._config.mlflow_run_id or None
+        if run_id:
+            try:
+                return mlflow.start_run(run_id=run_id, **kwargs), True
+            except Exception as e:  # saved run deleted/inaccessible — start fresh, like wandb
+                logger.warning(f"MLflow could not resume run_id={run_id} ({e}); starting a new run")
+        return mlflow.start_run(**kwargs), False
+
+    def _log_run_metadata(self, mlflow: Any) -> None:
+        """Log flattened config as params + host/slurm tags; non-fatal on error."""
+        try:
+            import socket
+
+            items = list(self._hyperparams.items())
+            # MLflow caps a single log_params batch at 100 entries.
+            for i in range(0, len(items), 100):
+                mlflow.log_params(dict(items[i : i + 100]))
+            mlflow.set_tags(
+                {"host": socket.gethostname(), "slurm_job_id": os.environ.get("SLURM_JOB_ID", "")}
+            )
+        except Exception as e:
+            logger.warning(f"MLflow metadata logging failed (continuing): {e}")
+
+    def log(self, metrics: dict[str, float], step: int) -> None:
+        self._ensure_init()
+        if self._active is not True:
+            return
+        import mlflow
+
+        mlflow.log_metrics({k: float(v) for k, v in metrics.items()}, step=step)
+
+    def close(self) -> None:
+        if self._active is True:
+            import mlflow
+
+            mlflow.end_run()
 
 
 class TensorBoardBackend(_LoggingBackend):

--- a/kempnerforge/metrics/tracker.py
+++ b/kempnerforge/metrics/tracker.py
@@ -93,7 +93,7 @@ class MetricsTracker:
         if mc.enable_tensorboard:
             self._backends.append(TensorBoardBackend(mc))
         if mc.enable_mlflow:
-            self._backends.append(MLflowBackend(mc, hyperparams=_flatten_config_params(config)))
+            self._backends.append(MLflowBackend(mc, job_config=config))
 
     def start_step(self) -> None:
         """Mark the beginning of a training step."""
@@ -294,8 +294,9 @@ def _resolve_mlflow_experiment(config: MetricsConfig, uri: str) -> str | None:
     """Experiment name: mlflow_experiment -> $MLFLOW_EXPERIMENT -> auto
     (/Users/<user>/<project> via the SDK on Databricks; bare name locally).
 
-    On Databricks a non-absolute $MLFLOW_EXPERIMENT raises, mirroring the
-    MetricsConfig.__post_init__ guard on the config field.
+    On Databricks a non-absolute $MLFLOW_EXPERIMENT raises ValueError; the backend
+    catches it and disables MLflow with a clear message (the config-field equivalent
+    is rejected at load time by MetricsConfig.__post_init__).
     """
     on_databricks = uri.startswith("databricks")
     if config.mlflow_experiment:
@@ -336,11 +337,36 @@ def _flatten_config_params(config: JobConfig, max_len: int = 250) -> dict[str, s
         if isinstance(value, dict):
             for k, v in value.items():
                 _walk(f"{prefix}.{k}" if prefix else str(k), v)
+        elif isinstance(value, (list, tuple)):
+            for i, v in enumerate(value):
+                _walk(f"{prefix}.{i}" if prefix else str(i), v)
         else:
             flat[prefix] = str(value)[:max_len]
 
     _walk("", asdict(config))
     return flat
+
+
+def _mlflow_run_gone(exc: Exception) -> bool:
+    """True if the error means the run can't be resumed (deleted / does not exist), vs a
+    transient network/server error that should NOT trigger a fresh-run fallback."""
+    code = str(getattr(exc, "error_code", "") or "")
+    if "RESOURCE_DOES_NOT_EXIST" in code or "NOT_FOUND" in code:
+        return True
+    msg = str(exc).lower()
+    return any(
+        s in msg for s in ("does not exist", "resource_does_not_exist", "not found", "deleted")
+    )
+
+
+def _mlflow_last_step(mlflow: Any, run_id: str) -> int | None:
+    """Highest step already recorded for the watermark metric, so a resumed run can skip
+    re-logging steps it already has (mlflow metric history is append-only)."""
+    try:
+        hist = mlflow.MlflowClient().get_metric_history(run_id, "train/loss")
+        return max((m.step for m in hist), default=None)
+    except Exception:
+        return None
 
 
 class MLflowBackend(_LoggingBackend):
@@ -349,10 +375,13 @@ class MLflowBackend(_LoggingBackend):
     Lazy init on first log; run ID written back to config for checkpoint resume.
     """
 
-    def __init__(self, config: MetricsConfig, hyperparams: dict[str, str] | None = None) -> None:
+    def __init__(self, config: MetricsConfig, job_config: JobConfig | None = None) -> None:
         self._config = config
-        self._hyperparams = hyperparams or {}
+        self._job_config = job_config  # flattened to params lazily, only for a fresh run
         self._active: bool | None = None  # None = not tried, True = live, False = failed
+        self._run_started = False  # a run exists that close() must end
+        self._resume_skip_below: int | None = None  # skip re-logging steps already in the run
+        self._log_failures = 0  # consecutive log failures (warn once, keep retrying)
 
     def _ensure_init(self) -> None:
         if self._active is not None:
@@ -374,7 +403,19 @@ class MLflowBackend(_LoggingBackend):
             import mlflow
 
             mlflow.set_tracking_uri(uri)
-            experiment = _resolve_mlflow_experiment(self._config, uri)
+            try:
+                experiment = _resolve_mlflow_experiment(self._config, uri)
+            except ValueError as e:  # bad $MLFLOW_EXPERIMENT: a deliberate config error
+                logger.warning(f"MLflow disabled: {e}")
+                self._active = False
+                return
+            if uri.startswith("databricks") and not experiment:
+                logger.warning(
+                    "MLflow disabled: could not resolve a Databricks experiment path "
+                    "(set mlflow_experiment or $MLFLOW_EXPERIMENT to an absolute path)"
+                )
+                self._active = False
+                return
             if experiment:
                 mlflow.set_experiment(experiment)
             if self._config.mlflow_log_system_metrics:
@@ -382,10 +423,13 @@ class MLflowBackend(_LoggingBackend):
                     self._config.mlflow_system_metrics_interval
                 )
             run, resumed = self._start_run(mlflow)
+            self._run_started = True
             self._config.mlflow_run_id = run.info.run_id
             self._active = True
             logger.info(f"MLflow initialized: experiment={experiment} run_id={run.info.run_id}")
-            if not resumed:
+            if resumed:
+                self._resume_skip_below = _mlflow_last_step(mlflow, run.info.run_id)
+            else:
                 self._log_run_metadata(mlflow)
         except ImportError:
             logger.warning(
@@ -407,8 +451,10 @@ class MLflowBackend(_LoggingBackend):
         if run_id:
             try:
                 return mlflow.start_run(run_id=run_id, **kwargs), True
-            except Exception as e:  # saved run deleted/inaccessible — start fresh, like wandb
-                logger.warning(f"MLflow could not resume run_id={run_id} ({e}); starting a new run")
+            except Exception as e:
+                if not _mlflow_run_gone(e):
+                    raise  # transient/other error — don't fork a new run; let init disable
+                logger.warning(f"MLflow run_id={run_id} is gone ({e}); starting a new run")
         return mlflow.start_run(**kwargs), False
 
     def _log_run_metadata(self, mlflow: Any) -> None:
@@ -416,7 +462,8 @@ class MLflowBackend(_LoggingBackend):
         try:
             import socket
 
-            items = list(self._hyperparams.items())
+            hyperparams = _flatten_config_params(self._job_config) if self._job_config else {}
+            items = list(hyperparams.items())
             # MLflow caps a single log_params batch at 100 entries.
             for i in range(0, len(items), 100):
                 mlflow.log_params(dict(items[i : i + 100]))
@@ -430,16 +477,20 @@ class MLflowBackend(_LoggingBackend):
         self._ensure_init()
         if self._active is not True:
             return
+        if self._resume_skip_below is not None and step <= self._resume_skip_below:
+            return  # already logged before this resume — avoid duplicate history points
         import mlflow
 
         try:
             mlflow.log_metrics({k: float(v) for k, v in metrics.items()}, step=step)
-        except Exception as e:  # a mid-run network/token failure must not crash training
-            logger.warning(f"MLflow log failed ({e}); disabling MLflow backend")
-            self._active = False
+            self._log_failures = 0
+        except Exception as e:  # transient network/token failure: warn once, keep retrying
+            self._log_failures += 1
+            if self._log_failures == 1:
+                logger.warning(f"MLflow log failed ({e}); will keep retrying, points may be lost")
 
     def close(self) -> None:
-        if self._active is not True:
+        if not self._run_started:
             return
         try:
             import mlflow
@@ -449,6 +500,7 @@ class MLflowBackend(_LoggingBackend):
             logger.warning(f"MLflow end_run failed ({e})")
         finally:
             self._active = False
+            self._run_started = False
 
 
 class TensorBoardBackend(_LoggingBackend):

--- a/kempnerforge/metrics/tracker.py
+++ b/kempnerforge/metrics/tracker.py
@@ -292,13 +292,24 @@ def _mlflow_databricks_ready() -> bool:
 
 def _resolve_mlflow_experiment(config: MetricsConfig, uri: str) -> str | None:
     """Experiment name: mlflow_experiment -> $MLFLOW_EXPERIMENT -> auto
-    (/Users/<user>/<project> via the SDK on Databricks; bare name locally)."""
+    (/Users/<user>/<project> via the SDK on Databricks; bare name locally).
+
+    On Databricks a non-absolute $MLFLOW_EXPERIMENT raises, mirroring the
+    MetricsConfig.__post_init__ guard on the config field.
+    """
+    on_databricks = uri.startswith("databricks")
     if config.mlflow_experiment:
-        return config.mlflow_experiment
-    if os.environ.get("MLFLOW_EXPERIMENT"):
-        return os.environ["MLFLOW_EXPERIMENT"]
+        return config.mlflow_experiment  # validated in MetricsConfig.__post_init__
+    env_experiment = os.environ.get("MLFLOW_EXPERIMENT")
+    if env_experiment:
+        if on_databricks and not env_experiment.startswith("/"):
+            raise ValueError(
+                "$MLFLOW_EXPERIMENT must be an absolute workspace path on Databricks "
+                f"(e.g. '/Users/you@example.com/proj'); got {env_experiment!r}"
+            )
+        return env_experiment
     project = config.wandb_project or "kempnerforge"
-    if not uri.startswith("databricks"):
+    if not on_databricks:
         return project
     try:
         from databricks.sdk import WorkspaceClient
@@ -421,13 +432,23 @@ class MLflowBackend(_LoggingBackend):
             return
         import mlflow
 
-        mlflow.log_metrics({k: float(v) for k, v in metrics.items()}, step=step)
+        try:
+            mlflow.log_metrics({k: float(v) for k, v in metrics.items()}, step=step)
+        except Exception as e:  # a mid-run network/token failure must not crash training
+            logger.warning(f"MLflow log failed ({e}); disabling MLflow backend")
+            self._active = False
 
     def close(self) -> None:
-        if self._active is True:
+        if self._active is not True:
+            return
+        try:
             import mlflow
 
             mlflow.end_run()
+        except Exception as e:  # teardown must not fail the job
+            logger.warning(f"MLflow end_run failed ({e})")
+        finally:
+            self._active = False
 
 
 class TensorBoardBackend(_LoggingBackend):

--- a/kempnerforge/metrics/tracker.py
+++ b/kempnerforge/metrics/tracker.py
@@ -360,8 +360,8 @@ def _mlflow_run_gone(exc: Exception) -> bool:
 
 
 def _mlflow_last_step(mlflow: Any, run_id: str) -> int | None:
-    """Highest step already recorded for the watermark metric, so a resumed run can skip
-    re-logging steps it already has (mlflow metric history is append-only)."""
+    """Highest step already logged for "train/loss" (the metric _log_step always emits), so a
+    resume skips steps it already has. Returns None if absent (dedup then skipped)."""
     try:
         hist = mlflow.MlflowClient().get_metric_history(run_id, "train/loss")
         return max((m.step for m in hist), default=None)
@@ -459,19 +459,22 @@ class MLflowBackend(_LoggingBackend):
 
     def _log_run_metadata(self, mlflow: Any) -> None:
         """Log flattened config as params + host/slurm tags; non-fatal on error."""
-        try:
-            import socket
+        import socket
 
-            hyperparams = _flatten_config_params(self._job_config) if self._job_config else {}
-            items = list(hyperparams.items())
-            # MLflow caps a single log_params batch at 100 entries.
-            for i in range(0, len(items), 100):
+        hyperparams = _flatten_config_params(self._job_config) if self._job_config else {}
+        items = list(hyperparams.items())
+        # log_params caps at 100 per batch; guard each so one bad batch keeps the rest.
+        for i in range(0, len(items), 100):
+            try:
                 mlflow.log_params(dict(items[i : i + 100]))
+            except Exception as e:
+                logger.warning(f"MLflow log_params batch failed (skipping): {e}")
+        try:
             mlflow.set_tags(
                 {"host": socket.gethostname(), "slurm_job_id": os.environ.get("SLURM_JOB_ID", "")}
             )
         except Exception as e:
-            logger.warning(f"MLflow metadata logging failed (continuing): {e}")
+            logger.warning(f"MLflow set_tags failed (continuing): {e}")
 
     def log(self, metrics: dict[str, float], step: int) -> None:
         self._ensure_init()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,14 @@ video = [
     # only to decode clips (lazy-imported in kempnerforge/data/video_io.py).
     "av>=17.1.0",
 ]
+mlflow = [
+    # Optional Databricks-hosted experiment tracking; lazy-imported in metrics/tracker.py.
+    # mlflow-skinny = tracking-only client (no pandas/server); psutil+nvidia-ml-py = system metrics.
+    "mlflow-skinny>=3.1",
+    "databricks-sdk>=0.20",
+    "psutil",
+    "nvidia-ml-py",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -348,10 +348,15 @@ def check_mlflow(check_credentials: bool = False) -> CheckResult:
             "(needed for metrics.enable_mlflow with tracking_uri=databricks)",
         )
     if not host:
-        return CheckResult("mlflow", WARN, "token set but DATABRICKS_HOST missing")
+        return CheckResult(
+            "mlflow", MISS, "token set but DATABRICKS_HOST missing", "export DATABRICKS_HOST=..."
+        )
     if not token:
         return CheckResult(
-            "mlflow", WARN, "DATABRICKS_HOST set but token missing (DATABRICKS_TOKEN/_API_TOKEN)"
+            "mlflow",
+            MISS,
+            "DATABRICKS_HOST set but token missing",
+            "export DATABRICKS_API_TOKEN=... (or DATABRICKS_TOKEN)",
         )
     if check_credentials:
         try:

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -359,6 +359,10 @@ def check_mlflow(check_credentials: bool = False) -> CheckResult:
             "export DATABRICKS_API_TOKEN=... (or DATABRICKS_TOKEN)",
         )
     if check_credentials:
+        # The SDK authenticates from DATABRICKS_TOKEN; mirror the DATABRICKS_API_TOKEN
+        # alias the MLflow backend applies so the probe matches runtime behavior.
+        if not os.environ.get("DATABRICKS_TOKEN") and os.environ.get("DATABRICKS_API_TOKEN"):
+            os.environ["DATABRICKS_TOKEN"] = os.environ["DATABRICKS_API_TOKEN"]
         try:
             from databricks.sdk import WorkspaceClient  # type: ignore
 

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -42,7 +42,7 @@ WARN = "WARN"
 MISS = "MISS"
 
 # Tags accepted via --requires. Baseline (uv, repo-layout) runs always.
-KNOWN_TAGS = ("gpu", "slurm", "multi-node", "wandb", "hf", "gh")
+KNOWN_TAGS = ("gpu", "slurm", "multi-node", "wandb", "mlflow", "hf", "gh")
 # Accepted for documentation symmetry but ignored (baseline always runs).
 BASELINE_ALIASES = ("uv", "repo-layout")
 
@@ -335,6 +335,35 @@ def check_wandb(check_credentials: bool = False) -> CheckResult:
     return CheckResult("wandb", OK, "WANDB_API_KEY set (not validated)")
 
 
+def check_mlflow(check_credentials: bool = False) -> CheckResult:
+    """Check Databricks credentials for MLflow; optionally validate via the SDK."""
+    host = os.environ.get("DATABRICKS_HOST")
+    token = os.environ.get("DATABRICKS_TOKEN") or os.environ.get("DATABRICKS_API_TOKEN")
+    if not host and not token:
+        return CheckResult(
+            "mlflow",
+            MISS,
+            "DATABRICKS_HOST and token not set",
+            "export DATABRICKS_HOST=... and DATABRICKS_API_TOKEN=... "
+            "(needed for metrics.enable_mlflow with tracking_uri=databricks)",
+        )
+    if not host:
+        return CheckResult("mlflow", WARN, "token set but DATABRICKS_HOST missing")
+    if not token:
+        return CheckResult(
+            "mlflow", WARN, "DATABRICKS_HOST set but token missing (DATABRICKS_TOKEN/_API_TOKEN)"
+        )
+    if check_credentials:
+        try:
+            from databricks.sdk import WorkspaceClient  # type: ignore
+
+            user = WorkspaceClient().current_user.me().user_name
+        except Exception as e:
+            return CheckResult("mlflow", WARN, f"credentials set but SDK probe failed: {e}")
+        return CheckResult("mlflow", OK, f"Databricks reachable, user={user}")
+    return CheckResult("mlflow", OK, "DATABRICKS_HOST + token set (not validated)")
+
+
 def check_hf(check_credentials: bool = False) -> CheckResult:
     """Check HF_TOKEN env var; optionally validate via API."""
     key = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
@@ -578,6 +607,8 @@ def run_checks(
             results.append(check_multi_node(config, repo_root))
         elif tag == "wandb":
             results.append(check_wandb(check_credentials))
+        elif tag == "mlflow":
+            results.append(check_mlflow(check_credentials))
         elif tag == "hf":
             results.append(check_hf(check_credentials))
         elif tag == "gh":
@@ -622,7 +653,7 @@ def build_argparser() -> argparse.ArgumentParser:
         "--requires",
         type=str,
         default="",
-        help="Comma-separated tags (gpu,slurm,multi-node,wandb,hf,gh). "
+        help="Comma-separated tags (gpu,slurm,multi-node,wandb,mlflow,hf,gh). "
         "Empty or omitted runs baseline only.",
     )
     ap.add_argument("--json", action="store_true", help="Emit JSON report.")
@@ -668,7 +699,7 @@ def build_argparser() -> argparse.ArgumentParser:
     ap.add_argument(
         "--check-credentials",
         action="store_true",
-        help="Validate WandB/HF tokens via API (slow; opt-in).",
+        help="Validate WandB/HF/Databricks tokens via API (slow; opt-in).",
     )
     return ap
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -235,6 +235,8 @@ def main() -> None:
         )
         if ckpt_extra_loaded.get("wandb_run_id"):
             config.metrics.wandb_run_id = ckpt_extra_loaded["wandb_run_id"]
+        if ckpt_extra_loaded.get("mlflow_run_id"):
+            config.metrics.mlflow_run_id = ckpt_extra_loaded["mlflow_run_id"]
         # MoT warm-start: translate dense TransformerBlock weights from a
         # JD/text-only checkpoint into per-modality copies inside every
         # MoTBlock. Runs once at the start of training (resume_path is
@@ -657,6 +659,8 @@ def main() -> None:
         init_extra: dict = {"phase_idx": current_phase_idx} if active_phases else {}
         if config.metrics.wandb_run_id:
             init_extra["wandb_run_id"] = config.metrics.wandb_run_id
+        if config.metrics.mlflow_run_id:
+            init_extra["mlflow_run_id"] = config.metrics.mlflow_run_id
         if is_vlm:
             assert vlm_cfg is not None
             valid_modules = set(vlm_cfg.module_patterns.keys())
@@ -1009,10 +1013,12 @@ def main() -> None:
         if prof is not None:
             prof.step()
 
-        # Checkpoint (include phase index + wandb run ID for exact resumption)
+        # Checkpoint (include phase index + wandb/mlflow run IDs for exact resumption)
         ckpt_extra: dict = {"phase_idx": current_phase_idx} if active_phases else {}
         if config.metrics.wandb_run_id:
             ckpt_extra["wandb_run_id"] = config.metrics.wandb_run_id
+        if config.metrics.mlflow_run_id:
+            ckpt_extra["mlflow_run_id"] = config.metrics.mlflow_run_id
         if is_vlm:
             assert vlm_cfg is not None
             # Use effective_freeze so the saved metadata reflects the

--- a/tests/unit/test_check_env.py
+++ b/tests/unit/test_check_env.py
@@ -323,6 +323,31 @@ class TestCheckWandb:
         assert "not validated" in r.message
 
 
+class TestCheckMlflow:
+    def test_missing_both(self, monkeypatch):
+        for v in ("DATABRICKS_HOST", "DATABRICKS_TOKEN", "DATABRICKS_API_TOKEN"):
+            monkeypatch.delenv(v, raising=False)
+        assert check_env.check_mlflow().status == check_env.MISS
+
+    def test_host_without_token_is_miss(self, monkeypatch):
+        monkeypatch.setenv("DATABRICKS_HOST", "https://x.cloud.databricks.com")
+        monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+        monkeypatch.delenv("DATABRICKS_API_TOKEN", raising=False)
+        assert check_env.check_mlflow().status == check_env.MISS
+
+    def test_token_without_host_is_miss(self, monkeypatch):
+        monkeypatch.delenv("DATABRICKS_HOST", raising=False)
+        monkeypatch.setenv("DATABRICKS_API_TOKEN", "dapi-xxx")
+        assert check_env.check_mlflow().status == check_env.MISS
+
+    def test_both_set_ok(self, monkeypatch):
+        monkeypatch.setenv("DATABRICKS_HOST", "https://x.cloud.databricks.com")
+        monkeypatch.setenv("DATABRICKS_API_TOKEN", "dapi-xxx")
+        r = check_env.check_mlflow()
+        assert r.status == check_env.OK
+        assert "not validated" in r.message
+
+
 class TestCheckHf:
     def test_missing(self, monkeypatch):
         monkeypatch.delenv("HF_TOKEN", raising=False)

--- a/tests/unit/test_check_env.py
+++ b/tests/unit/test_check_env.py
@@ -347,6 +347,34 @@ class TestCheckMlflow:
         assert r.status == check_env.OK
         assert "not validated" in r.message
 
+    def test_check_credentials_applies_api_token_alias(self, monkeypatch):
+        """--check-credentials mirrors DATABRICKS_API_TOKEN->DATABRICKS_TOKEN before the SDK
+        probe (the same alias the backend applies), so it doesn't falsely WARN. (Finding #6)"""
+        import types as _types
+
+        monkeypatch.setenv("DATABRICKS_HOST", "https://x.cloud.databricks.com")
+        monkeypatch.setenv("DATABRICKS_API_TOKEN", "dapi-x")
+        monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+
+        class _WC:  # authenticates only when the SDK-native DATABRICKS_TOKEN is present
+            def __init__(self):
+                import os as _os
+
+                if not _os.environ.get("DATABRICKS_TOKEN"):
+                    raise RuntimeError("no DATABRICKS_TOKEN")
+                self.current_user = _types.SimpleNamespace(
+                    me=lambda: _types.SimpleNamespace(user_name="abbas")
+                )
+
+        fake_sdk = _types.ModuleType("databricks.sdk")
+        fake_sdk.WorkspaceClient = _WC
+        monkeypatch.setitem(sys.modules, "databricks", _types.ModuleType("databricks"))
+        monkeypatch.setitem(sys.modules, "databricks.sdk", fake_sdk)
+
+        r = check_env.check_mlflow(check_credentials=True)
+        assert r.status == check_env.OK
+        assert "abbas" in r.message
+
 
 class TestCheckHf:
     def test_missing(self, monkeypatch):

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -35,6 +35,7 @@ from kempnerforge.metrics.tracker import (
     TensorBoardBackend,
     WandBBackend,
     _flatten_config_params,
+    _resolve_mlflow_experiment,
 )
 
 # ---------------------------------------------------------------------------
@@ -415,6 +416,81 @@ class TestMLflowBackend:
         assert backend._active is True
         assert cfg.mlflow_run_id == "new-run-123"  # wrote back the new id
         assert tried == ["stale-id", None]  # tried resume, then started fresh
+
+    def test_log_failure_disables_backend(self, monkeypatch):
+        """A mid-run log_metrics failure warns and disables the backend, never raises."""
+        import types
+
+        def _boom_log(*a, **k):
+            raise RuntimeError("network down")
+
+        fake_run = types.SimpleNamespace(info=types.SimpleNamespace(run_id="r1"))
+        fake_mlflow = types.SimpleNamespace(
+            set_tracking_uri=lambda *a, **k: None,
+            set_experiment=lambda *a, **k: None,
+            set_system_metrics_sampling_interval=lambda *a, **k: None,
+            start_run=lambda *a, **k: fake_run,
+            log_params=lambda *a, **k: None,
+            set_tags=lambda *a, **k: None,
+            log_metrics=_boom_log,
+            end_run=lambda *a, **k: None,
+        )
+        monkeypatch.setitem(sys.modules, "mlflow", fake_mlflow)
+        backend = MLflowBackend(
+            MetricsConfig(
+                enable_mlflow=True,
+                mlflow_tracking_uri="http://localhost:5000",
+                mlflow_experiment="e2e",
+                mlflow_log_system_metrics=False,
+            )
+        )
+        backend.log({"train/loss": 1.0}, step=1)  # must not raise
+        assert backend._active is False
+
+    def test_close_survives_end_run_error(self, monkeypatch):
+        """A failing end_run at teardown warns but does not raise; backend marked inactive."""
+        import types
+
+        def _boom_end(*a, **k):
+            raise RuntimeError("server gone")
+
+        fake_run = types.SimpleNamespace(info=types.SimpleNamespace(run_id="r1"))
+        fake_mlflow = types.SimpleNamespace(
+            set_tracking_uri=lambda *a, **k: None,
+            set_experiment=lambda *a, **k: None,
+            set_system_metrics_sampling_interval=lambda *a, **k: None,
+            start_run=lambda *a, **k: fake_run,
+            log_params=lambda *a, **k: None,
+            set_tags=lambda *a, **k: None,
+            log_metrics=lambda *a, **k: None,
+            end_run=_boom_end,
+        )
+        monkeypatch.setitem(sys.modules, "mlflow", fake_mlflow)
+        backend = MLflowBackend(
+            MetricsConfig(
+                enable_mlflow=True,
+                mlflow_tracking_uri="http://localhost:5000",
+                mlflow_experiment="e2e",
+                mlflow_log_system_metrics=False,
+            )
+        )
+        backend.log({"train/loss": 1.0}, step=1)
+        assert backend._active is True
+        backend.close()  # must not raise
+        assert backend._active is False
+
+
+class TestResolveMlflowExperiment:
+    def test_env_experiment_must_be_absolute_on_databricks(self, monkeypatch):
+        """Non-absolute $MLFLOW_EXPERIMENT is rejected on Databricks (config-guard parity)."""
+        monkeypatch.setenv("MLFLOW_EXPERIMENT", "bare-name")
+        with pytest.raises(ValueError, match="absolute workspace path"):
+            _resolve_mlflow_experiment(MetricsConfig(enable_mlflow=True), "databricks")
+
+    def test_env_experiment_bare_ok_for_non_databricks(self, monkeypatch):
+        monkeypatch.setenv("MLFLOW_EXPERIMENT", "bare-name")
+        cfg = MetricsConfig(enable_mlflow=True, mlflow_tracking_uri="http://localhost:5000")
+        assert _resolve_mlflow_experiment(cfg, "http://localhost:5000") == "bare-name"
 
 
 class TestTensorBoardBackend:

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -7,6 +7,7 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 import torch.distributed as dist
 
@@ -29,9 +30,11 @@ from kempnerforge.metrics.memory import (
 )
 from kempnerforge.metrics.tracker import (
     MetricsTracker,
+    MLflowBackend,
     StepMetrics,
     TensorBoardBackend,
     WandBBackend,
+    _flatten_config_params,
 )
 
 # ---------------------------------------------------------------------------
@@ -115,6 +118,17 @@ class TestMetricsTracker:
         config = JobConfig(
             model=ModelConfig(dim=128, n_layers=2, n_heads=2, vocab_size=256),
             metrics=MetricsConfig(enable_tensorboard=True),
+        )
+        tracker = MetricsTracker(config, num_gpus=1)
+        tracker.init_backends(config)
+        assert len(tracker._backends) == 1
+
+    def test_init_backends_rank_zero_appends_mlflow(self, monkeypatch):
+        """When rank-0 and enable_mlflow=True, init_backends appends an MLflowBackend."""
+        monkeypatch.setattr(tracker_mod, "MLflowBackend", MagicMock(name="FakeMLflow"))
+        config = JobConfig(
+            model=ModelConfig(dim=128, n_layers=2, n_heads=2, vocab_size=256),
+            metrics=MetricsConfig(enable_mlflow=True),
         )
         tracker = MetricsTracker(config, num_gpus=1)
         tracker.init_backends(config)
@@ -329,6 +343,80 @@ class TestWandBBackend:
         assert backend._run is False
 
 
+class TestMLflowBackend:
+    def test_init_no_crash(self):
+        backend = MLflowBackend(MetricsConfig(enable_mlflow=True))
+        assert backend._active is None
+
+    def test_disabled_without_databricks_creds(self, monkeypatch):
+        """tracking_uri=databricks with no creds disables the backend before importing mlflow."""
+        for var in ("DATABRICKS_HOST", "DATABRICKS_TOKEN", "DATABRICKS_API_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        backend = MLflowBackend(MetricsConfig(enable_mlflow=True))  # default uri = databricks
+        backend.log({"train/loss": 1.0}, step=1)
+        assert backend._active is False
+
+    def test_mlflow_handles_import_error(self, monkeypatch):
+        """ImportError inside _ensure_init flips _active to the False sentinel."""
+        monkeypatch.setitem(sys.modules, "mlflow", None)
+        # Non-databricks URI so the readiness gate is skipped and the import is attempted.
+        backend = MLflowBackend(
+            MetricsConfig(enable_mlflow=True, mlflow_tracking_uri="http://localhost:5000")
+        )
+        backend.log({"train/loss": 1.0}, step=1)
+        assert backend._active is False
+
+    def test_mlflow_handles_init_exception(self, monkeypatch):
+        """A non-ImportError from mlflow (e.g. tracking/auth) flips _active = False."""
+        mlflow = pytest.importorskip("mlflow")
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated tracking failure")
+
+        monkeypatch.setattr(mlflow, "set_tracking_uri", _boom)
+        backend = MLflowBackend(
+            MetricsConfig(enable_mlflow=True, mlflow_tracking_uri="sqlite:///x.db")
+        )
+        backend.log({"train/loss": 1.0}, step=1)
+        assert backend._active is False
+
+    def test_resume_falls_back_to_new_run_when_id_missing(self, monkeypatch):
+        """A stale saved run_id (run deleted) starts a fresh run, like wandb resume='allow'."""
+        import types
+
+        tried: list = []
+        fake_run = types.SimpleNamespace(info=types.SimpleNamespace(run_id="new-run-123"))
+
+        def fake_start_run(run_id=None, run_name=None, log_system_metrics=False):
+            tried.append(run_id)
+            if run_id is not None:
+                raise RuntimeError("RESOURCE_DOES_NOT_EXIST")
+            return fake_run
+
+        fake_mlflow = types.SimpleNamespace(
+            set_tracking_uri=lambda *a, **k: None,
+            set_experiment=lambda *a, **k: None,
+            set_system_metrics_sampling_interval=lambda *a, **k: None,
+            start_run=fake_start_run,
+            log_params=lambda *a, **k: None,
+            set_tags=lambda *a, **k: None,
+            log_metrics=lambda *a, **k: None,
+            end_run=lambda *a, **k: None,
+        )
+        monkeypatch.setitem(sys.modules, "mlflow", fake_mlflow)
+        cfg = MetricsConfig(
+            enable_mlflow=True,
+            mlflow_tracking_uri="http://localhost:5000",  # skip the databricks readiness gate
+            mlflow_run_id="stale-id",
+            mlflow_log_system_metrics=False,
+        )
+        backend = MLflowBackend(cfg)
+        backend.log({"train/loss": 1.0}, step=1)
+        assert backend._active is True
+        assert cfg.mlflow_run_id == "new-run-123"  # wrote back the new id
+        assert tried == ["stale-id", None]  # tried resume, then started fresh
+
+
 class TestTensorBoardBackend:
     def test_init_no_crash(self):
         config = MetricsConfig(enable_tensorboard=True)
@@ -349,6 +437,44 @@ class TestTensorBoardBackend:
         backend = TensorBoardBackend(MetricsConfig(enable_tensorboard=True))
         backend.log({"loss": 1.0}, step=1)
         assert backend._writer is False
+
+
+class TestFlattenConfigParams:
+    def test_flatten_produces_dotted_scalar_string_keys(self):
+        config = JobConfig(
+            model=ModelConfig(dim=128, n_layers=2, n_heads=2, vocab_size=256),
+            metrics=MetricsConfig(log_interval=7),
+        )
+        params = _flatten_config_params(config)
+        assert params["model.dim"] == "128"
+        assert params["metrics.log_interval"] == "7"
+        # mlflow.log_params requires string values.
+        assert all(isinstance(v, str) for v in params.values())
+        # Optional None sub-configs (vlm, adapter, vision_encoder) are skipped.
+        assert not any(k.startswith("vlm") for k in params)
+
+    def test_flatten_truncates_long_values(self):
+        config = JobConfig(model=ModelConfig(dim=128, n_layers=2, n_heads=2, vocab_size=256))
+        params = _flatten_config_params(config, max_len=4)
+        assert all(len(v) <= 4 for v in params.values())
+
+
+class TestMetricsConfigMLflow:
+    def test_databricks_requires_absolute_experiment_path(self):
+        with pytest.raises(ValueError, match="absolute workspace path"):
+            MetricsConfig(enable_mlflow=True, mlflow_experiment="bare-name")
+
+    def test_absolute_experiment_path_ok(self):
+        cfg = MetricsConfig(enable_mlflow=True, mlflow_experiment="/Users/me/proj")
+        assert cfg.mlflow_experiment == "/Users/me/proj"
+
+    def test_bare_name_ok_for_local_uri(self):
+        cfg = MetricsConfig(
+            enable_mlflow=True,
+            mlflow_tracking_uri="sqlite:///mlflow.db",
+            mlflow_experiment="bare-name",
+        )
+        assert cfg.mlflow_experiment == "bare-name"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -585,6 +585,23 @@ class TestMLflowBackend:
         backend.log({"train/loss": 1.0}, step=1)
         backend.close()  # must not raise
 
+    def test_databricks_token_mirror_and_metadata(self, monkeypatch):
+        """DATABRICKS_API_TOKEN is mirrored to DATABRICKS_TOKEN, the system-metrics interval
+        is set when enabled, and a fresh run logs flattened params + tags."""
+        monkeypatch.setenv("DATABRICKS_HOST", "https://x.cloud.databricks.com")
+        monkeypatch.setenv("DATABRICKS_API_TOKEN", "dapi-x")
+        monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+        monkeypatch.setattr(tracker_mod, "_resolve_mlflow_experiment", lambda c, u: "/Users/me/p")
+        fm = _FakeMlflow()
+        monkeypatch.setitem(sys.modules, "mlflow", fm)
+        cfg = MetricsConfig(enable_mlflow=True, mlflow_log_system_metrics=True)  # uri = databricks
+        job = JobConfig(model=ModelConfig(dim=128, n_layers=2, n_heads=2, vocab_size=256))
+        backend = MLflowBackend(cfg, job_config=job)
+        backend.log({"train/loss": 1.0}, step=1)
+        assert backend._active is True
+        assert os.environ["DATABRICKS_TOKEN"] == "dapi-x"  # mirrored from API_TOKEN
+        assert fm.logged_params and fm.logged_tags  # fresh-run metadata (params + tags) logged
+
 
 class TestResolveMlflowExperiment:
     def test_env_experiment_must_be_absolute_on_databricks(self, monkeypatch):
@@ -597,6 +614,65 @@ class TestResolveMlflowExperiment:
         monkeypatch.setenv("MLFLOW_EXPERIMENT", "bare-name")
         cfg = MetricsConfig(enable_mlflow=True, mlflow_tracking_uri="http://localhost:5000")
         assert _resolve_mlflow_experiment(cfg, "http://localhost:5000") == "bare-name"
+
+    def test_auto_resolves_databricks_user_path(self, monkeypatch):
+        """With no experiment set on Databricks, derive /Users/<sdk-user>/<project>."""
+        monkeypatch.delenv("MLFLOW_EXPERIMENT", raising=False)
+
+        class _WC:
+            def __init__(self):
+                self.current_user = types.SimpleNamespace(
+                    me=lambda: types.SimpleNamespace(user_name="abbas")
+                )
+
+        fake_sdk = types.ModuleType("databricks.sdk")
+        fake_sdk.WorkspaceClient = _WC
+        monkeypatch.setitem(sys.modules, "databricks", types.ModuleType("databricks"))
+        monkeypatch.setitem(sys.modules, "databricks.sdk", fake_sdk)
+        cfg = MetricsConfig(enable_mlflow=True, wandb_project="proj")
+        assert _resolve_mlflow_experiment(cfg, "databricks") == "/Users/abbas/proj"
+
+    def test_auto_resolve_failure_returns_none(self, monkeypatch):
+        """If the SDK lookup fails, auto-resolution returns None (backend then disables)."""
+        monkeypatch.delenv("MLFLOW_EXPERIMENT", raising=False)
+
+        class _WC:
+            def __init__(self):
+                raise RuntimeError("no sdk creds")
+
+        fake_sdk = types.ModuleType("databricks.sdk")
+        fake_sdk.WorkspaceClient = _WC
+        monkeypatch.setitem(sys.modules, "databricks", types.ModuleType("databricks"))
+        monkeypatch.setitem(sys.modules, "databricks.sdk", fake_sdk)
+        assert _resolve_mlflow_experiment(MetricsConfig(enable_mlflow=True), "databricks") is None
+
+
+class TestMlflowHelpers:
+    def test_run_gone_by_error_code(self):
+        e = RuntimeError("boom")
+        e.error_code = "RESOURCE_DOES_NOT_EXIST"
+        assert tracker_mod._mlflow_run_gone(e) is True
+
+    def test_run_gone_by_message(self):
+        assert tracker_mod._mlflow_run_gone(RuntimeError("run is in the deleted state")) is True
+
+    def test_transient_error_is_not_gone(self):
+        assert tracker_mod._mlflow_run_gone(RuntimeError("503 Service Unavailable")) is False
+
+    def test_last_step_from_history(self):
+        fm = _FakeMlflow()
+        fm.history_steps = [2, 7, 5]
+        assert tracker_mod._mlflow_last_step(fm, "rid") == 7
+
+    def test_last_step_empty_history(self):
+        assert tracker_mod._mlflow_last_step(_FakeMlflow(), "rid") is None
+
+    def test_last_step_handles_error(self):
+        class _M:
+            def MlflowClient(self):
+                raise RuntimeError("no client")
+
+        assert tracker_mod._mlflow_last_step(_M(), "rid") is None
 
 
 class TestTensorBoardBackend:

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,7 +14,13 @@ import torch.distributed as dist
 
 import kempnerforge.metrics.logger as log_mod
 import kempnerforge.metrics.tracker as tracker_mod
-from kempnerforge.config.schema import JobConfig, MetricsConfig, ModelConfig
+from kempnerforge.config.schema import (
+    DataConfig,
+    DatasetSource,
+    JobConfig,
+    MetricsConfig,
+    ModelConfig,
+)
 from kempnerforge.metrics.logger import (
     _format_number,
     _RankFilter,
@@ -344,6 +351,59 @@ class TestWandBBackend:
         assert backend._run is False
 
 
+class _FakeMlflow:
+    """Stand-in `mlflow` module for MLflowBackend tests (no real tracking server)."""
+
+    def __init__(self):
+        self._run = types.SimpleNamespace(info=types.SimpleNamespace(run_id="run-xyz"))
+        self.log_steps: list = []
+        self.start_run_ids: list = []
+        self.end_run_calls = 0
+        self.logged_params: list = []
+        self.logged_tags: list = []
+        self.history_steps: list = []  # steps returned by MlflowClient().get_metric_history
+
+    def set_tracking_uri(self, *a, **k):
+        pass
+
+    def set_experiment(self, *a, **k):
+        pass
+
+    def set_system_metrics_sampling_interval(self, *a, **k):
+        pass
+
+    def start_run(self, run_id=None, run_name=None, log_system_metrics=False):
+        self.start_run_ids.append(run_id)
+        return self._run
+
+    def log_metrics(self, metrics, step=None):
+        self.log_steps.append(step)
+
+    def log_params(self, params):
+        self.logged_params.append(params)
+
+    def set_tags(self, tags):
+        self.logged_tags.append(tags)
+
+    def end_run(self):
+        self.end_run_calls += 1
+
+    def MlflowClient(self, *a, **k):
+        steps = [types.SimpleNamespace(step=s) for s in self.history_steps]
+        return types.SimpleNamespace(get_metric_history=lambda run_id, key: steps)
+
+
+def _mlflow_cfg(**kw):
+    base = dict(
+        enable_mlflow=True,
+        mlflow_tracking_uri="http://localhost:5000",  # non-databricks: skip readiness gate
+        mlflow_experiment="exp",
+        mlflow_log_system_metrics=False,
+    )
+    base.update(kw)
+    return MetricsConfig(**base)
+
+
 class TestMLflowBackend:
     def test_init_no_crash(self):
         backend = MLflowBackend(MetricsConfig(enable_mlflow=True))
@@ -417,67 +477,113 @@ class TestMLflowBackend:
         assert cfg.mlflow_run_id == "new-run-123"  # wrote back the new id
         assert tried == ["stale-id", None]  # tried resume, then started fresh
 
-    def test_log_failure_disables_backend(self, monkeypatch):
-        """A mid-run log_metrics failure warns and disables the backend, never raises."""
-        import types
+    def test_log_retries_after_transient_failure(self, monkeypatch):
+        """A transient log error is swallowed (warned) but does NOT disable the backend;
+        the next step retries and succeeds. (Finding #1)"""
+        fm = _FakeMlflow()
+        state = {"n": 0}
 
-        def _boom_log(*a, **k):
-            raise RuntimeError("network down")
+        def flaky_log(metrics, step=None):
+            state["n"] += 1
+            if state["n"] == 1:
+                raise RuntimeError("transient network blip")
+            fm.log_steps.append(step)
 
-        fake_run = types.SimpleNamespace(info=types.SimpleNamespace(run_id="r1"))
-        fake_mlflow = types.SimpleNamespace(
-            set_tracking_uri=lambda *a, **k: None,
-            set_experiment=lambda *a, **k: None,
-            set_system_metrics_sampling_interval=lambda *a, **k: None,
-            start_run=lambda *a, **k: fake_run,
-            log_params=lambda *a, **k: None,
-            set_tags=lambda *a, **k: None,
-            log_metrics=_boom_log,
-            end_run=lambda *a, **k: None,
+        fm.log_metrics = flaky_log
+        monkeypatch.setitem(sys.modules, "mlflow", fm)
+        backend = MLflowBackend(_mlflow_cfg())
+        backend.log({"train/loss": 2.0}, step=1)  # fails internally, swallowed
+        backend.log({"train/loss": 1.5}, step=2)  # must retry, not stay disabled
+        assert backend._active is True
+        assert state["n"] == 2  # second call actually attempted (no permanent disable)
+        assert fm.log_steps == [2]
+
+    def test_resume_skips_already_logged_steps(self, monkeypatch):
+        """On resume, steps already recorded in the run are not re-logged. (Finding #2)"""
+        fm = _FakeMlflow()
+        fm.history_steps = [1, 2, 3, 4]  # run already has metrics up to step 4
+        monkeypatch.setitem(sys.modules, "mlflow", fm)
+        backend = MLflowBackend(_mlflow_cfg(mlflow_run_id="existing-run"))
+        backend.log({"train/loss": 1.2}, step=3)  # already logged -> skip
+        backend.log({"train/loss": 1.0}, step=4)  # already logged -> skip
+        backend.log({"train/loss": 0.8}, step=5)  # new -> log
+        assert fm.log_steps == [5]
+
+    def test_bad_env_experiment_disables_with_clear_message(self, monkeypatch):
+        """Non-absolute $MLFLOW_EXPERIMENT on Databricks disables with a specific message,
+        not the generic 'MLflow init failed'. (Finding #3)"""
+        monkeypatch.setenv("DATABRICKS_HOST", "https://x.cloud.databricks.com")
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-x")
+        monkeypatch.setenv("MLFLOW_EXPERIMENT", "bare-name")  # not absolute
+        warnings_seen: list = []
+        monkeypatch.setattr(
+            tracker_mod.logger, "warning", lambda msg, *a, **k: warnings_seen.append(str(msg))
         )
-        monkeypatch.setitem(sys.modules, "mlflow", fake_mlflow)
-        backend = MLflowBackend(
-            MetricsConfig(
-                enable_mlflow=True,
-                mlflow_tracking_uri="http://localhost:5000",
-                mlflow_experiment="e2e",
-                mlflow_log_system_metrics=False,
-            )
-        )
-        backend.log({"train/loss": 1.0}, step=1)  # must not raise
+        fm = _FakeMlflow()
+        monkeypatch.setitem(sys.modules, "mlflow", fm)
+        backend = MLflowBackend(MetricsConfig(enable_mlflow=True))  # default uri = databricks
+        backend.log({"train/loss": 1.0}, step=1)
         assert backend._active is False
+        assert fm.start_run_ids == []  # never started a run
+        text = " ".join(warnings_seen).lower()
+        assert "absolute" in text and "disabled" in text
+        assert "init failed" not in text  # a deliberate config error, not an unexpected failure
+
+    def test_null_experiment_disables_on_databricks(self, monkeypatch):
+        """On Databricks, an unresolvable experiment (None) disables the backend instead of
+        logging into the default experiment. (Finding #7)"""
+        monkeypatch.setenv("DATABRICKS_HOST", "https://x.cloud.databricks.com")
+        monkeypatch.setenv("DATABRICKS_TOKEN", "dapi-x")
+        monkeypatch.delenv("MLFLOW_EXPERIMENT", raising=False)
+        monkeypatch.setattr(tracker_mod, "_resolve_mlflow_experiment", lambda cfg, uri: None)
+        fm = _FakeMlflow()
+        monkeypatch.setitem(sys.modules, "mlflow", fm)
+        backend = MLflowBackend(MetricsConfig(enable_mlflow=True))  # uri = databricks
+        backend.log({"train/loss": 1.0}, step=1)
+        assert backend._active is False
+        assert fm.start_run_ids == []  # never started a run in the default experiment
+
+    def test_resume_transient_error_does_not_fork(self, monkeypatch):
+        """A transient error resuming a still-valid run must NOT fork a new run; it disables
+        instead so history isn't split. (Finding #8)"""
+        fm = _FakeMlflow()
+
+        def start_run(run_id=None, run_name=None, log_system_metrics=False):
+            fm.start_run_ids.append(run_id)
+            if run_id is not None:
+                raise RuntimeError("503 Service Unavailable")  # transient; run still exists
+            return fm._run
+
+        fm.start_run = start_run
+        monkeypatch.setitem(sys.modules, "mlflow", fm)
+        backend = MLflowBackend(_mlflow_cfg(mlflow_run_id="live-run"))
+        backend.log({"train/loss": 1.0}, step=1)
+        assert backend._active is False  # disabled, not forked
+        assert fm.start_run_ids == ["live-run"]  # only the resume attempt, no fresh start_run()
+
+    def test_close_ends_run_even_when_inactive(self, monkeypatch):
+        """Once a run is started, close() ends it even if the backend was later marked
+        inactive, so the run isn't left RUNNING. (Finding #11)"""
+        fm = _FakeMlflow()
+        monkeypatch.setitem(sys.modules, "mlflow", fm)
+        backend = MLflowBackend(_mlflow_cfg())
+        backend.log({"train/loss": 1.0}, step=1)  # starts the run
+        backend._active = False  # simulate a later disable
+        backend.close()
+        assert fm.end_run_calls == 1
 
     def test_close_survives_end_run_error(self, monkeypatch):
-        """A failing end_run at teardown warns but does not raise; backend marked inactive."""
-        import types
+        """A failing end_run at teardown warns but does not raise."""
+        fm = _FakeMlflow()
 
-        def _boom_end(*a, **k):
+        def boom_end():
             raise RuntimeError("server gone")
 
-        fake_run = types.SimpleNamespace(info=types.SimpleNamespace(run_id="r1"))
-        fake_mlflow = types.SimpleNamespace(
-            set_tracking_uri=lambda *a, **k: None,
-            set_experiment=lambda *a, **k: None,
-            set_system_metrics_sampling_interval=lambda *a, **k: None,
-            start_run=lambda *a, **k: fake_run,
-            log_params=lambda *a, **k: None,
-            set_tags=lambda *a, **k: None,
-            log_metrics=lambda *a, **k: None,
-            end_run=_boom_end,
-        )
-        monkeypatch.setitem(sys.modules, "mlflow", fake_mlflow)
-        backend = MLflowBackend(
-            MetricsConfig(
-                enable_mlflow=True,
-                mlflow_tracking_uri="http://localhost:5000",
-                mlflow_experiment="e2e",
-                mlflow_log_system_metrics=False,
-            )
-        )
+        fm.end_run = boom_end
+        monkeypatch.setitem(sys.modules, "mlflow", fm)
+        backend = MLflowBackend(_mlflow_cfg())
         backend.log({"train/loss": 1.0}, step=1)
-        assert backend._active is True
         backend.close()  # must not raise
-        assert backend._active is False
 
 
 class TestResolveMlflowExperiment:
@@ -533,6 +639,24 @@ class TestFlattenConfigParams:
         config = JobConfig(model=ModelConfig(dim=128, n_layers=2, n_heads=2, vocab_size=256))
         params = _flatten_config_params(config, max_len=4)
         assert all(len(v) <= 4 for v in params.values())
+
+    def test_flatten_recurses_into_lists(self):
+        """list-of-dataclass config (data.datasets) expands into indexed dotted keys,
+        not one truncated str(). (Finding #5)"""
+        config = JobConfig(
+            model=ModelConfig(dim=128, n_layers=2, n_heads=2, vocab_size=256),
+            data=DataConfig(
+                datasets=[
+                    DatasetSource(path="/d/a", name="ds_a", weight=0.7),
+                    DatasetSource(path="/d/b", name="ds_b", weight=0.3),
+                ]
+            ),
+        )
+        params = _flatten_config_params(config)
+        assert params["data.datasets.0.name"] == "ds_a"
+        assert params["data.datasets.1.name"] == "ds_b"
+        assert params["data.datasets.0.path"] == "/d/a"
+        assert "data.datasets" not in params  # not collapsed into one opaque key
 
 
 class TestMetricsConfigMLflow:

--- a/uv.lock
+++ b/uv.lock
@@ -276,6 +276,15 @@ css = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -424,6 +433,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
 ]
 
 [[package]]
@@ -595,6 +613,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "12.9.6"
 source = { registry = "https://pypi.org/simple" }
@@ -672,6 +740,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "databricks-sdk"
+version = "0.122.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "protobuf" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/7d/e3e34005d835c88df348187414837e34981d8eaec29bf91abd36a6f5e39f/databricks_sdk-0.122.0.tar.gz", hash = "sha256:eb11be13f0c02fc4ffc6e2672ad47478ce26ac4b310bd26916af8ba56e374e98", size = 1024752, upload-time = "2026-07-21T09:24:15.952Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/95/f17887b43ac4dcc09079e5fb0e93374762d85d593c8e5114dbc6f82b6c52/databricks_sdk-0.122.0-py3-none-any.whl", hash = "sha256:7d998ec47f580be6be1cfe066be78038054767575b7437af5e4f76b67dde49c2", size = 969097, upload-time = "2026-07-21T09:24:14.32Z" },
 ]
 
 [[package]]
@@ -762,6 +845,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.139.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/95/d3f0ae10836324a2eab98a52b61210ac609f08200bf4bb0dc8132d32f78a/fastapi-0.139.2.tar.gz", hash = "sha256:333145a6891e9b5b3cfceb69baf817e8240cde4d4588ae5a10bf56ffacb6255e", size = 423428, upload-time = "2026-07-16T15:06:17.912Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/c7/cb03251d9dfb177246a9809a76f189d21df32dbd4a845951881d11323b7f/fastapi-0.139.2-py3-none-any.whl", hash = "sha256:b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c", size = 130234, upload-time = "2026-07-16T15:06:19.557Z" },
 ]
 
 [[package]]
@@ -967,6 +1066,19 @@ wheels = [
 ]
 
 [[package]]
+name = "google-auth"
+version = "2.56.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/33/dbc946a407401b975f0719658f18e664ece2109f79ffd1ff3bf226c205f4/google_auth-2.56.2.tar.gz", hash = "sha256:e28f103ca8091fb7012b99c44243d7366c29863713b8e34a220c3322b7a07051", size = 365820, upload-time = "2026-07-21T21:53:28.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/63/50636aae68c9bf17c891c7eb18b49baa9bd6b31d2a97b8de4813a9fc8d1c/google_auth-2.56.2-py3-none-any.whl", hash = "sha256:c8270ea95b2697b74e3d8438ae9c5b898e38b623b915c7b5c5635921e7de68a6", size = 258588, upload-time = "2026-07-21T21:53:26.399Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1112,6 +1224,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
 ]
 
 [[package]]
@@ -1305,6 +1429,12 @@ docs = [
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-copybutton" },
 ]
+mlflow = [
+    { name = "databricks-sdk" },
+    { name = "mlflow-skinny" },
+    { name = "nvidia-ml-py" },
+    { name = "psutil" },
+]
 video = [
     { name = "av" },
 ]
@@ -1341,6 +1471,12 @@ docs = [
     { name = "sphinx-autobuild", specifier = ">=2024.4" },
     { name = "sphinx-autodoc-typehints", specifier = ">=2.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5" },
+]
+mlflow = [
+    { name = "databricks-sdk", specifier = ">=0.20" },
+    { name = "mlflow-skinny", specifier = ">=3.1" },
+    { name = "nvidia-ml-py" },
+    { name = "psutil" },
 ]
 video = [{ name = "av", specifier = ">=17.1.0" }]
 
@@ -1620,6 +1756,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/55/d01f0c4b45ade6536c51170b9043db8b2ec6ddf4a35c7ea3f5f559ac935b/mistune-3.2.0.tar.gz", hash = "sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a", size = 95467, upload-time = "2025-12-23T11:36:34.994Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl", hash = "sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1", size = 53598, upload-time = "2025-12-23T11:36:33.211Z" },
+]
+
+[[package]]
+name = "mlflow-skinny"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "cloudpickle" },
+    { name = "databricks-sdk" },
+    { name = "fastapi" },
+    { name = "gitpython" },
+    { name = "importlib-metadata" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlparse" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/4f/a054cd8860590e4e942aee1aab3c94307878159f945fa844acc9ea787721/mlflow_skinny-3.14.0.tar.gz", hash = "sha256:e50f4506422c7737157ae6643c165122af7898345f2e828fa93c4f10128653cf", size = 2901772, upload-time = "2026-06-17T07:57:44.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/e7/b80f76ce689b9d6f21cdb84abb2b02148a1149e63a6428dd2c629cefd061/mlflow_skinny-3.14.0-py3-none-any.whl", hash = "sha256:a4880e086365871ef9d78e727a34ea5fb1ce615689579998d48e8c65ee1665a9", size = 3462788, upload-time = "2026-06-17T07:57:42.583Z" },
 ]
 
 [[package]]
@@ -2048,6 +2215,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-ml-py"
+version = "13.610.43"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b5/a8fbc356f768fa5c9cfd646668fd7d34bf55bdd1c6e20754642a64d930d4/nvidia_ml_py-13.610.43.tar.gz", hash = "sha256:65437eb73d68d0c62c931ca4d45038472faff03bd0b8729abba4b899f70d60f2", size = 52109, upload-time = "2026-06-01T18:54:08.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/45/caa600acfab94560807a20a64b5830d2cd3c3202b7f1328644d70b7d6bd8/nvidia_ml_py-13.610.43-py3-none-any.whl", hash = "sha256:f13c72698edef492f985cc225f14faafe68ae065a2e407f45bdf6f4b9b43fde8", size = 53163, upload-time = "2026-06-01T18:54:07.704Z" },
+]
+
+[[package]]
 name = "nvidia-nccl-cu12"
 version = "2.28.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2081,6 +2257,57 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
     { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
@@ -2356,16 +2583,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "4.25.9"
+version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d9/8e/d08c41a8c004e1d437ef467e7c4f9c3295cd784eba48ed5d1d01f94b1dad/protobuf-4.25.9.tar.gz", hash = "sha256:b0dc7e7c68de8b1ce831dacb12fb407e838edbb8b6cc0dc3a2a6b4cbf6de9cff", size = 381040, upload-time = "2026-03-25T23:09:36.423Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/e9/59435bd04bdd46cb38c42a336b22f9843e8e586ff83c35a5423f8b14704e/protobuf-4.25.9-cp310-abi3-win32.whl", hash = "sha256:bde396f568b0b46fc8fbfe9f02facf25b6755b2578a3b8ac61e74b9d69499e03", size = 392879, upload-time = "2026-03-25T23:09:21.32Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/16/42a5c7f1001783d2b5bfcecde10127f09010f78982c86ae409122ce3ece6/protobuf-4.25.9-cp310-abi3-win_amd64.whl", hash = "sha256:3683c05154252206f7cb2d371626514b3708199d9bcf683b503dabf3a2e38e06", size = 413900, upload-time = "2026-03-25T23:09:23.589Z" },
-    { url = "https://files.pythonhosted.org/packages/56/5b/0074a0a9eb01f3d1c4648ca5e81b22090c811b210b61df9018ac6d6c5cda/protobuf-4.25.9-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:9560813560e6ee72c11ca8873878bdb7ee003c96a57ebb013245fe84e2540904", size = 394826, upload-time = "2026-03-25T23:09:25.194Z" },
-    { url = "https://files.pythonhosted.org/packages/54/aa/b2dba856f64c36b2a06c67be1472de98cca07a2322d0f0cbf03279a40e5b/protobuf-4.25.9-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:999146ef02e7fa6a692477badd1528bcd7268df211852a3df2d834ba2b480791", size = 294191, upload-time = "2026-03-25T23:09:26.613Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/5c/53f18822017b8bda6bd8bb4e02048e911fdc79a3dafdc83ab994fe922a84/protobuf-4.25.9-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:438c636de8fb706a0de94a12a268ef1ae8f5ba5ae655a7671fcda5968ba3c9be", size = 295178, upload-time = "2026-03-25T23:09:27.839Z" },
-    { url = "https://files.pythonhosted.org/packages/16/28/d5065b212685875d3924bcdb3201cbf467cb4d58a18aa19a8dfd99ea80a9/protobuf-4.25.9-py3-none-any.whl", hash = "sha256:d49b615e7c935194ac161f0965699ac84df6112c378e05ec53da65d2e4cbb6d4", size = 156822, upload-time = "2026-03-25T23:09:34.957Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -2455,6 +2683,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
     { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
     { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -2640,6 +2889,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -3198,6 +3456,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "sqlparse"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
 ]
 
 [[package]]
@@ -3873,4 +4140,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
     { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Summary
- Adds `MLflowBackend`, a third `_LoggingBackend` alongside WandB/TensorBoard, enabled via `metrics.enable_mlflow`. Logs the same per-step and eval metric dict (`train/*`, `gpu/*`, `smoothed/*`, `eval/*`, `moe/*`) to Databricks-hosted MLflow (or any MLflow server).
- Also logs the flattened `JobConfig` as params + `host`/`slurm_job_id` tags + optional system metrics. No artifacts — checkpoints stay on disk.
- Resume: `mlflow_run_id` is saved in the checkpoint and restored on resume (mirrors `wandb_run_id`), so a requeue reattaches to the same run — or starts a fresh run if the saved id was deleted (parity with wandb `resume="allow"`).
- Credentials are env-only (`DATABRICKS_HOST` + `DATABRICKS_TOKEN`/`DATABRICKS_API_TOKEN`); experiment resolves `mlflow_experiment` → `$MLFLOW_EXPERIMENT` → auto.
- Optional dep group `mlflow` (`mlflow-skinny` + `databricks-sdk`) keeps the base install lean and avoids a pandas downgrade; adds a `check_env --requires mlflow` preflight tag and `docs/metrics-and-profiling/mlflow.md`.
- Default off; degrades to a warning if the dep/creds are absent. In-training eval logs automatically via `log_eval`; the standalone eval pipeline is unchanged (no backend — same as WandB/TB).

## Testing
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors)
- [x] `uv run pytest tests/unit/ --timeout=60` passes (1658 passed, 3 skipped)
- [ ] Distributed — N/A (no distributed code changed)
- [x] E2E — not run (no GPU). The `scripts/train.py` change is a 3-line additive mirror of the existing `wandb_run_id` checkpoint handling. Separately verified live: real logging to Databricks MLflow, plus resume / delete→new-run / system metrics via an end-to-end run against real MLflow.

Closes #158 