### PR TITLE
Optimize video I/O with seek decoding instead of serial decoding

### DIFF
--- a/kempnerforge/data/video_io.py
+++ b/kempnerforge/data/video_io.py
@@ -102,13 +102,10 @@ def decode_video_frames(
 
     Reading seeks to the keyframe at or before each target and decodes forward
     (``_decode_seek``), so cost scales with frames kept rather than clip
-    length. Whenever a seek cannot guarantee the same selection — a stream
-    without ``time_base``, frames without PTS, a seek landing past its target,
-    or any FFmpeg error during the attempt — the clip is reopened and decoded
-    in a single serial pass (``_decode_serial``); selection is identical on
-    either path, so seeking only ever changes speed. A clip that is corrupt
-    mid-file consequently raises from the serial retry rather than the first
-    attempt (the same error class surfaces).
+    length. If a seek cannot guarantee the same selection (see
+    ``_decode_seek``), the clip is reopened and decoded in a single serial
+    pass (``_decode_serial``) with identical selection, so seeking only ever
+    changes speed.
 
     Raises whatever ``av`` raises on a missing/corrupt file; callers that train
     over noisy data should catch and substitute an empty clip.
@@ -148,10 +145,9 @@ def _decode_seek(container: Any, stream: Any, targets: list[float]) -> list[PILI
     several targets), and targets past the last frame tail-fill with that
     frame. Raises ``_SeekUnreliableError`` whenever identical selection cannot
     be guaranteed: no ``time_base``, a frame without PTS, a seek landing past
-    its target (fuzzy-seeking container — frames may have been skipped;
-    targets near 0.0 are exempt because the landing is then the stream's first
-    frame, which is exactly what the serial pass matches), or EOF with nothing
-    decoded after a seek (the serial path defines degenerate-file behavior).
+    its target (frames may have been skipped; exempt for targets near 0.0,
+    where the landing is the stream's first frame — what serial selects too),
+    or EOF with nothing decoded after a seek.
     """
     tb = stream.time_base
     if tb is None:

--- a/kempnerforge/data/video_io.py
+++ b/kempnerforge/data/video_io.py
@@ -25,6 +25,7 @@ image preprocessing (``pil_to_tensor``) used on the single-image path.
 
 from __future__ import annotations
 
+import functools
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -44,6 +45,22 @@ _MATCH_EPS_S = 1e-3
 
 class _SeekUnreliableError(Exception):
     """Raised when seek-based decoding cannot guarantee serial-identical output."""
+
+
+@functools.cache
+def _log_fallback_once(reason: str) -> None:
+    """Log a seek-to-serial fallback once per distinct cause for this process.
+
+    On a corpus where seeking systematically fails, a per-clip log line would
+    bury the training log, so fallbacks are deduplicated by ``reason`` (the
+    exception type name): ``functools.cache`` runs the body — and thus the
+    log call — only on each cause's first occurrence.
+    """
+    logger.debug(
+        "seek decode failed (%s); falling back to serial decode "
+        "(further fallbacks with this cause are not logged)",
+        reason,
+    )
 
 
 @registry.register_sampling_policy("uniform")
@@ -129,9 +146,11 @@ def decode_video_frames(
         try:
             return _decode_seek(container, stream, targets)
         except (av.FFmpegError, _SeekUnreliableError) as e:
-            reason = f"{type(e).__name__}: {e}"
-    logger.debug("seek decode failed for %s (%s); falling back to serial decode", path, reason)
+            reason = type(e).__name__
+    _log_fallback_once(reason)
     with av.open(path) as container:
+        if not container.streams.video:
+            return []
         stream = container.streams.video[0]
         stream.thread_type = "AUTO"
         return _decode_serial(container, stream, targets)

--- a/kempnerforge/data/video_io.py
+++ b/kempnerforge/data/video_io.py
@@ -14,7 +14,10 @@ treats like a sequence of images. Two concerns live here:
    (``av``), whose manylinux wheel bundles FFmpeg, so no system FFmpeg or
    matching CUDA libraries are required (torchcodec needs both). ``av`` is
    imported lazily so this module imports cleanly without it; only actual
-   decoding requires the package.
+   decoding requires the package. Frames are read by seeking to the keyframe
+   before each sampled timestamp instead of decoding the whole clip, so cost
+   scales with frames kept rather than clip length; containers that cannot
+   seek reliably fall back to a single serial pass with identical selection.
 
 Returned frames are ``PIL.Image`` objects so the caller can reuse the exact
 image preprocessing (``pil_to_tensor``) used on the single-image path.
@@ -22,6 +25,7 @@ image preprocessing (``pil_to_tensor``) used on the single-image path.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 from kempnerforge.config.registry import registry
@@ -29,8 +33,17 @@ from kempnerforge.config.registry import registry
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from PIL.Image import Image as PILImage
 
+logger = logging.getLogger(__name__)
+
 # AV_TIME_BASE: container.duration is expressed in microseconds.
 _AV_TIME_BASE = 1_000_000.0
+
+# Slack (seconds) when matching a decoded frame's timestamp against a target.
+_MATCH_EPS_S = 1e-3
+
+
+class _SeekUnreliableError(Exception):
+    """Raised when seek-based decoding cannot guarantee serial-identical output."""
 
 
 @registry.register_sampling_policy("uniform")
@@ -80,12 +93,22 @@ def decode_video_frames(
     """Decode a clip into a list of sampled ``PIL.Image`` frames (RGB).
 
     Frames are chosen by the registered ``sampling_policy`` (default
-    ``"uniform"`` = ``sample_timestamps``) and read in a single decode pass: each
-    target timestamp is mapped to the first decoded frame at or after it
-    (timestamps past the last frame map to the last frame, so the final frame is
-    always returned). The returned list has length equal to the number of sampled
-    timestamps (``<= max_frames``), or is empty when the file has no decodable
-    video stream.
+    ``"uniform"`` = ``sample_timestamps``): each target timestamp is mapped to
+    the first decoded frame at or after it (timestamps past the last frame map
+    to the last frame, so the final frame is always returned). The returned
+    list has length equal to the number of sampled timestamps
+    (``<= max_frames``), or is empty when the file has no decodable video
+    stream.
+
+    Reading seeks to the keyframe at or before each target and decodes forward
+    (``_decode_seek``), so cost scales with frames kept rather than clip
+    length. Whenever a seek cannot guarantee the same selection — a stream
+    without ``time_base``, frames without PTS, a seek landing past its target,
+    or any FFmpeg error during the attempt — the clip is reopened and decoded
+    in a single serial pass (``_decode_serial``); selection is identical on
+    either path, so seeking only ever changes speed. A clip that is corrupt
+    mid-file consequently raises from the serial retry rather than the first
+    attempt (the same error class surfaces).
 
     Raises whatever ``av`` raises on a missing/corrupt file; callers that train
     over noisy data should catch and substitute an empty clip.
@@ -99,29 +122,93 @@ def decode_video_frames(
         ) from e
 
     sample = registry.get_sampling_policy(sampling_policy)
-    images: list[PILImage] = []
     with av.open(path) as container:
         if not container.streams.video:
-            return images
+            return []
         stream = container.streams.video[0]
         stream.thread_type = "AUTO"
         duration_s = _video_duration_seconds(stream, container)
         targets = sample(duration_s, fps, min_frames, max_frames)
+        try:
+            return _decode_seek(container, stream, targets)
+        except (av.FFmpegError, _SeekUnreliableError) as e:
+            reason = f"{type(e).__name__}: {e}"
+    logger.debug("seek decode failed for %s (%s); falling back to serial decode", path, reason)
+    with av.open(path) as container:
+        stream = container.streams.video[0]
+        stream.thread_type = "AUTO"
+        return _decode_serial(container, stream, targets)
 
-        j = 0
-        eps = 1e-3
-        last_frame = None
-        for frame in container.decode(stream):
-            t = float(frame.time) if frame.time is not None else 0.0
-            while j < len(targets) and t + eps >= targets[j]:
-                images.append(frame.to_image())
-                j += 1
-            last_frame = frame
-            if j >= len(targets):
+
+def _decode_seek(container: Any, stream: Any, targets: list[float]) -> list[PILImage]:
+    """Seek to the keyframe at or before each target, then decode forward to it.
+
+    Selection matches ``_decode_serial`` byte-for-byte: each target takes the
+    first frame with ``time + _MATCH_EPS_S >= target`` (one frame may satisfy
+    several targets), and targets past the last frame tail-fill with that
+    frame. Raises ``_SeekUnreliableError`` whenever identical selection cannot
+    be guaranteed: no ``time_base``, a frame without PTS, a seek landing past
+    its target (fuzzy-seeking container — frames may have been skipped;
+    targets near 0.0 are exempt because the landing is then the stream's first
+    frame, which is exactly what the serial pass matches), or EOF with nothing
+    decoded after a seek (the serial path defines degenerate-file behavior).
+    """
+    tb = stream.time_base
+    if tb is None:
+        raise _SeekUnreliableError("stream has no time_base")
+    images: list[PILImage] = []
+    j = 0
+    while j < len(targets):
+        tgt = targets[j]
+        container.seek(int(tgt / tb), stream=stream, backward=True, any_frame=False)
+        last = None
+        matched = False
+        first = True
+        for frame in container.decode(stream):  # fresh generator after every seek
+            if frame.time is None:
+                raise _SeekUnreliableError("frame without pts")
+            t = frame.time
+            if first:
+                first = False
+                if t > tgt + _MATCH_EPS_S and tgt > _MATCH_EPS_S:
+                    raise _SeekUnreliableError(f"seek to {tgt:.3f}s landed at {t:.3f}s")
+            if t + _MATCH_EPS_S >= tgt:
+                img = frame.to_image()
+                while j < len(targets) and t + _MATCH_EPS_S >= targets[j]:
+                    images.append(img)
+                    j += 1
+                matched = True
                 break
-        # Trailing targets (e.g. the final ``duration_s`` timestamp, which sits
-        # just past the last frame's PTS) map to the last decoded frame.
-        if j < len(targets) and last_frame is not None:
-            tail = last_frame.to_image()
+            last = frame
+        if not matched:  # EOF: the remaining targets sit past the last frame
+            if last is None:
+                raise _SeekUnreliableError(f"no frames decodable at or after {tgt:.3f}s")
+            tail = last.to_image()
             images.extend(tail for _ in range(len(targets) - j))
+            j = len(targets)
+    return images
+
+
+def _decode_serial(container: Any, stream: Any, targets: list[float]) -> list[PILImage]:
+    """Single decode pass over the whole file; the frame-selection reference.
+
+    Kept as the fallback for containers where seeking is unavailable or
+    unreliable; ``_decode_seek`` must match its selection byte-for-byte.
+    """
+    images: list[PILImage] = []
+    j = 0
+    last_frame = None
+    for frame in container.decode(stream):
+        t = float(frame.time) if frame.time is not None else 0.0
+        while j < len(targets) and t + _MATCH_EPS_S >= targets[j]:
+            images.append(frame.to_image())
+            j += 1
+        last_frame = frame
+        if j >= len(targets):
+            break
+    # Trailing targets (e.g. the final ``duration_s`` timestamp, which sits
+    # just past the last frame's PTS) map to the last decoded frame.
+    if j < len(targets) and last_frame is not None:
+        tail = last_frame.to_image()
+        images.extend(tail for _ in range(len(targets) - j))
     return images

--- a/tests/unit/test_video_io.py
+++ b/tests/unit/test_video_io.py
@@ -450,6 +450,7 @@ class TestSeekFallback:
             raise video_io._SeekUnreliableError("test")
 
         monkeypatch.setattr(video_io, "_decode_seek", _raise)
+        monkeypatch.setattr(logging.getLogger("kempnerforge"), "propagate", True)
         video_io._log_fallback_once.cache_clear()
         with caplog.at_level(logging.DEBUG, logger="kempnerforge.data.video_io"):
             for _ in range(3):

--- a/tests/unit/test_video_io.py
+++ b/tests/unit/test_video_io.py
@@ -106,8 +106,14 @@ class TestDecodeVideoFramesIntegration:
             decode_video_frames("/no/such/video.mp4", fps=2.0, min_frames=4, max_frames=8)
 
 
-def _write_mp4(path, n_frames: int, size: int = 32, fps: int = 10) -> None:
-    """Encode a tiny solid-color clip with PyAV (av is a hard dependency)."""
+def _write_mp4(
+    path, n_frames: int, size: int = 32, fps: int = 10, gop_size: int | None = None
+) -> None:
+    """Encode a tiny solid-color clip with PyAV (av is a hard dependency).
+
+    ``gop_size`` pins the keyframe cadence (frame 0, then every ``gop_size``
+    frames), which the seek tests rely on; ``None`` keeps encoder defaults.
+    """
     import av
     import numpy as np
 
@@ -116,6 +122,11 @@ def _write_mp4(path, n_frames: int, size: int = 32, fps: int = 10) -> None:
         stream.width = size
         stream.height = size
         stream.pix_fmt = "yuv420p"
+        if gop_size is not None:
+            # Scene-change detection must be suppressed alongside gop_size:
+            # the changing gray otherwise promotes every frame to a keyframe.
+            stream.codec_context.gop_size = gop_size
+            stream.codec_context.options = {"sc_threshold": "1000000000"}
         for i in range(n_frames):
             arr = np.full((size, size, 3), (i * 17) % 256, dtype=np.uint8)
             frame = av.VideoFrame.from_ndarray(arr, format="rgb24")
@@ -123,6 +134,38 @@ def _write_mp4(path, n_frames: int, size: int = 32, fps: int = 10) -> None:
                 container.mux(packet)
         for packet in stream.encode():  # flush
             container.mux(packet)
+
+
+def _write_shifted_mp4(src, dst, offset_s: float = 5.0) -> None:
+    """Remux ``src`` with every packet timestamp shifted forward by ``offset_s``."""
+    import av
+
+    with av.open(str(src)) as ic, av.open(str(dst), mode="w") as oc:
+        istream = ic.streams.video[0]
+        ostream = oc.add_stream_from_template(istream)
+        shift = int(offset_s / istream.time_base)
+        for packet in ic.demux(istream):
+            if packet.pts is None:
+                continue
+            packet.pts += shift
+            if packet.dts is not None:
+                packet.dts += shift
+            packet.stream = ostream
+            oc.mux(packet)
+
+
+def _serial_reference(path, fps: float, min_frames: int, max_frames: int) -> list:
+    """Ground-truth frames via the serial reference pass (bypasses seeking)."""
+    import av
+
+    from kempnerforge.data.video_io import _decode_serial, _video_duration_seconds
+
+    with av.open(str(path)) as container:
+        stream = container.streams.video[0]
+        stream.thread_type = "AUTO"
+        duration_s = _video_duration_seconds(stream, container)
+        targets = sample_timestamps(duration_s, fps, min_frames, max_frames)
+        return _decode_serial(container, stream, targets)
 
 
 @pytest.mark.skipif(not _AV_AVAILABLE, reason="requires the 'av' package")
@@ -155,6 +198,129 @@ class TestDecodeSynthetic:
         _write_mp4(path, n_frames=3, fps=10)  # shorter than min_frames request
         frames = decode_video_frames(str(path), fps=2.0, min_frames=4, max_frames=8)
         assert len(frames) >= 1
+
+
+# ---------------------------------------------------------------------------
+# seek-based decoding (parity with the serial reference, guards, fallback)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _AV_AVAILABLE, reason="requires the 'av' package")
+class TestKeyframeFixture:
+    """gop_size must actually control the fixture's keyframe cadence."""
+
+    def test_gop_size_controls_keyframe_cadence(self, tmp_path):
+        import av
+
+        path = tmp_path / "gop.mp4"
+        _write_mp4(path, n_frames=40, gop_size=12)
+        with av.open(str(path)) as container:
+            stream = container.streams.video[0]
+            packets = [p for p in container.demux(stream) if p.pts is not None]
+        assert [i for i, p in enumerate(packets) if p.is_keyframe] == [0, 12, 24, 36]
+
+
+@pytest.mark.skipif(not _AV_AVAILABLE, reason="requires the 'av' package")
+class TestSeekMatchesSerial:
+    """The seek path must select byte-identical frames to the serial pass."""
+
+    def _assert_parity(self, path, *, fps, min_frames, max_frames):
+        from kempnerforge.data.video_io import decode_video_frames
+
+        expected = _serial_reference(path, fps, min_frames, max_frames)
+        got = decode_video_frames(str(path), fps=fps, min_frames=min_frames, max_frames=max_frames)
+        assert len(got) == len(expected)
+        # Compare bytes, not identity: the seek path reuses one PIL object for
+        # an eps-group of duplicate targets where serial makes distinct copies.
+        assert [f.tobytes() for f in got] == [f.tobytes() for f in expected]
+
+    def test_sparse_targets_long_clip(self, tmp_path):
+        path = tmp_path / "clip.mp4"
+        _write_mp4(path, n_frames=200, gop_size=12)  # 20s, 17 GOPs
+        self._assert_parity(path, fps=2.0, min_frames=1, max_frames=4)
+
+    def test_dense_targets_min_eq_max(self, tmp_path):
+        path = tmp_path / "clip.mp4"
+        _write_mp4(path, n_frames=40, gop_size=12)  # 4s
+        self._assert_parity(path, fps=8.0, min_frames=16, max_frames=16)
+
+    def test_duplicate_targets_dense_short_clip(self, tmp_path):
+        path = tmp_path / "clip.mp4"
+        _write_mp4(path, n_frames=10, gop_size=5)  # 1s; 16 targets over 10 frames
+        self._assert_parity(path, fps=2.0, min_frames=16, max_frames=16)
+
+    def test_single_keyframe_clip(self, tmp_path):
+        path = tmp_path / "clip.mp4"
+        _write_mp4(path, n_frames=60, gop_size=999)  # every seek lands on frame 0
+        self._assert_parity(path, fps=2.0, min_frames=4, max_frames=8)
+
+    def test_short_clip_tail_fill(self, tmp_path):
+        path = tmp_path / "short.mp4"
+        _write_mp4(path, n_frames=3)  # shorter than min_frames -> tail-fill
+        self._assert_parity(path, fps=2.0, min_frames=4, max_frames=8)
+
+    def test_start_time_shifted_clip(self, tmp_path):
+        src = tmp_path / "src.mp4"
+        dst = tmp_path / "shifted.mp4"
+        _write_mp4(src, n_frames=20, gop_size=5)
+        _write_shifted_mp4(src, dst, offset_s=5.0)
+        self._assert_parity(dst, fps=2.0, min_frames=4, max_frames=8)
+
+
+@pytest.mark.skipif(not _AV_AVAILABLE, reason="requires the 'av' package")
+class TestSeekFrameIdentity:
+    """Targets must map to the expected source frames, not just the right count."""
+
+    def test_picks_expected_source_frames(self, tmp_path):
+        import numpy as np
+
+        from kempnerforge.data.video_io import decode_video_frames
+
+        path = tmp_path / "clip.mp4"
+        _write_mp4(path, n_frames=20, fps=10)  # 2s; frame i is solid (i*17)%256 gray
+        frames = decode_video_frames(str(path), fps=2.0, min_frames=4, max_frames=4)
+        assert len(frames) == 4
+        # Targets [0, 2/3, 4/3, 2.0] -> first frame at/after each: 0, 7, 14;
+        # the final target sits past the last PTS -> tail-fills with frame 19.
+        expected = [0, 7 * 17, 14 * 17, (19 * 17) % 256]
+        means = [float(np.asarray(f.convert("L")).mean()) for f in frames]
+        for got, want in zip(means, expected, strict=True):
+            assert abs(got - want) <= 4.0  # mpeg4 roundtrip error, measured 2.0
+
+
+@pytest.mark.skipif(not _AV_AVAILABLE, reason="requires the 'av' package")
+class TestSeekFallback:
+    """Unreliable seeks must degrade to the serial pass, never to wrong frames."""
+
+    def test_falls_back_to_serial_on_unreliable_seek(self, tmp_path, monkeypatch):
+        import kempnerforge.data.video_io as video_io
+
+        path = tmp_path / "clip.mp4"
+        _write_mp4(path, n_frames=40, gop_size=12)
+        expected = _serial_reference(path, 2.0, 4, 8)
+
+        def _raise(container, stream, targets):
+            raise video_io._SeekUnreliableError("test")
+
+        monkeypatch.setattr(video_io, "_decode_seek", _raise)
+        got = video_io.decode_video_frames(str(path), fps=2.0, min_frames=4, max_frames=8)
+        assert [f.tobytes() for f in got] == [f.tobytes() for f in expected]
+
+    def test_landing_check_raises_on_shifted_stream(self, tmp_path):
+        import av
+
+        from kempnerforge.data.video_io import _decode_seek, _SeekUnreliableError
+
+        src = tmp_path / "src.mp4"
+        dst = tmp_path / "shifted.mp4"
+        _write_mp4(src, n_frames=20, gop_size=5)
+        _write_shifted_mp4(src, dst, offset_s=5.0)
+        with av.open(str(dst)) as container:
+            stream = container.streams.video[0]
+            # Target 2.0s precedes the shifted stream's first keyframe (5.0s):
+            # the seek must land past its target and be flagged unreliable.
+            with pytest.raises(_SeekUnreliableError, match="landed"):
+                _decode_seek(container, stream, [2.0])
 
 
 class TestSamplingPolicyRegistry:

--- a/tests/unit/test_video_io.py
+++ b/tests/unit/test_video_io.py
@@ -153,11 +153,10 @@ def _write_h264_mp4(
 ) -> None:
     """Encode an H.264 clip with B-frames (and optionally open GOPs).
 
-    The real datasets (WebVid/MLVU/Molmo2) are H.264, whose presentation
-    reordering (pts != dts) and — with ``open_gop`` — cross-GOP leading
-    B-frames the mpeg4 fixture cannot produce, so this is the codec shape the
-    seek/serial parity claim must hold on. ``b-adapt=0`` forces a fixed
-    B-frame pattern and a moving stripe gives the encoder real motion.
+    Produces the codec features the mpeg4 fixture cannot: presentation
+    reordering (pts != dts) and, with ``open_gop``, leading B-frames that
+    reference across GOP boundaries. ``b-adapt=0`` forces a fixed B-frame
+    pattern and a moving stripe gives the encoder real motion.
     """
     import av
     import numpy as np
@@ -316,19 +315,16 @@ class TestSeekMatchesSerial:
     not _H264_AVAILABLE, reason="requires a PyAV build with the libx264 encoder"
 )
 class TestSeekMatchesSerialH264:
-    """Parity on the real datasets' codec shape: H.264 with B-frames.
+    """Parity on the codec shape of real data: H.264 with B-frames.
 
-    The mpeg4 fixtures above are closed-GOP with no B-frames, so they never
-    exercise presentation reordering — but WebVid/MLVU/Molmo2 clips are H.264,
-    where it always occurs. ``open_gop`` additionally produces leading
-    B-frames that reference across the GOP boundary and are dropped when a
-    mid-stream seek decodes from the boundary keyframe.
+    The mpeg4 fixtures above never exercise presentation reordering; real
+    clips (e.g. WebVid) are H.264, where it always occurs. ``open_gop`` adds
+    leading B-frames that are dropped after a mid-stream seek.
     """
 
     def _assert_parity_seek_ran(self, path, *, fps, min_frames, max_frames, monkeypatch):
-        # Same parity assertion as TestSeekMatchesSerial, plus a spy proving
-        # the seek path actually ran: a silent serial fallback would make
-        # parity trivially true and hide a seek path broken on H.264.
+        # Parity as in TestSeekMatchesSerial, plus a spy proving the seek path
+        # actually ran: a silent serial fallback would make parity trivially true.
         import kempnerforge.data.video_io as video_io
 
         expected = _serial_reference(path, fps, min_frames, max_frames)
@@ -424,7 +420,7 @@ class TestSeekFrameIdentity:
         expected = [0, 7 * 17, 14 * 17, (19 * 17) % 256]
         means = [float(np.asarray(f.convert("L")).mean()) for f in frames]
         for got, want in zip(means, expected, strict=True):
-            assert abs(got - want) <= 4.0  # mpeg4 roundtrip error, measured 2.0
+            assert abs(got - want) <= 4.0  # mpeg4 encode/decode roundtrip tolerance
 
 
 @pytest.mark.skipif(not _AV_AVAILABLE, reason="requires the 'av' package")

--- a/tests/unit/test_video_io.py
+++ b/tests/unit/test_video_io.py
@@ -18,6 +18,18 @@ _WEBVID_CLIP = (
 _AV_AVAILABLE = importlib.util.find_spec("av") is not None
 
 
+def _libx264_available() -> bool:
+    """Whether this PyAV build bundles the libx264 encoder (H.264 fixtures)."""
+    if not _AV_AVAILABLE:
+        return False
+    import av
+
+    return "libx264" in av.codecs_available
+
+
+_H264_AVAILABLE = _libx264_available()
+
+
 # ---------------------------------------------------------------------------
 # sample_timestamps (pure policy, no decoder)
 # ---------------------------------------------------------------------------
@@ -129,6 +141,39 @@ def _write_mp4(
             stream.codec_context.options = {"sc_threshold": "1000000000"}
         for i in range(n_frames):
             arr = np.full((size, size, 3), (i * 17) % 256, dtype=np.uint8)
+            frame = av.VideoFrame.from_ndarray(arr, format="rgb24")
+            for packet in stream.encode(frame):
+                container.mux(packet)
+        for packet in stream.encode():  # flush
+            container.mux(packet)
+
+
+def _write_h264_mp4(
+    path, n_frames: int, size: int = 64, fps: int = 10, gop_size: int = 12, open_gop: bool = False
+) -> None:
+    """Encode an H.264 clip with B-frames (and optionally open GOPs).
+
+    The real datasets (WebVid/MLVU/Molmo2) are H.264, whose presentation
+    reordering (pts != dts) and — with ``open_gop`` — cross-GOP leading
+    B-frames the mpeg4 fixture cannot produce, so this is the codec shape the
+    seek/serial parity claim must hold on. ``b-adapt=0`` forces a fixed
+    B-frame pattern and a moving stripe gives the encoder real motion.
+    """
+    import av
+    import numpy as np
+
+    params = f"keyint={gop_size}:min-keyint={gop_size}:scenecut=0:bframes=2:b-adapt=0"
+    if open_gop:
+        params += ":open-gop=1"
+    with av.open(str(path), mode="w") as container:
+        stream = container.add_stream("libx264", rate=fps)
+        stream.width = size
+        stream.height = size
+        stream.pix_fmt = "yuv420p"
+        stream.codec_context.options = {"x264-params": params}
+        for i in range(n_frames):
+            arr = np.full((size, size, 3), (i * 7) % 200, dtype=np.uint8)
+            arr[:, (i * 5) % size] = 255  # moving stripe: motion for B-frames
             frame = av.VideoFrame.from_ndarray(arr, format="rgb24")
             for packet in stream.encode(frame):
                 container.mux(packet)
@@ -265,6 +310,100 @@ class TestSeekMatchesSerial:
         _write_mp4(src, n_frames=20, gop_size=5)
         _write_shifted_mp4(src, dst, offset_s=5.0)
         self._assert_parity(dst, fps=2.0, min_frames=4, max_frames=8)
+
+
+@pytest.mark.skipif(
+    not _H264_AVAILABLE, reason="requires a PyAV build with the libx264 encoder"
+)
+class TestSeekMatchesSerialH264:
+    """Parity on the real datasets' codec shape: H.264 with B-frames.
+
+    The mpeg4 fixtures above are closed-GOP with no B-frames, so they never
+    exercise presentation reordering — but WebVid/MLVU/Molmo2 clips are H.264,
+    where it always occurs. ``open_gop`` additionally produces leading
+    B-frames that reference across the GOP boundary and are dropped when a
+    mid-stream seek decodes from the boundary keyframe.
+    """
+
+    def _assert_parity_seek_ran(self, path, *, fps, min_frames, max_frames, monkeypatch):
+        # Same parity assertion as TestSeekMatchesSerial, plus a spy proving
+        # the seek path actually ran: a silent serial fallback would make
+        # parity trivially true and hide a seek path broken on H.264.
+        import kempnerforge.data.video_io as video_io
+
+        expected = _serial_reference(path, fps, min_frames, max_frames)
+        fell_back = []
+        original = video_io._decode_serial
+
+        def _spy(*args, **kwargs):
+            fell_back.append(True)
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(video_io, "_decode_serial", _spy)
+        got = video_io.decode_video_frames(
+            str(path), fps=fps, min_frames=min_frames, max_frames=max_frames
+        )
+        assert not fell_back, "seek path unexpectedly fell back to serial decode"
+        assert len(got) == len(expected)
+        assert [f.tobytes() for f in got] == [f.tobytes() for f in expected]
+
+    def test_fixture_has_b_frames_and_reordering(self, tmp_path):
+        import av
+        from av.video.frame import PictureType
+
+        path = tmp_path / "h264.mp4"
+        _write_h264_mp4(path, n_frames=60, open_gop=True)
+        with av.open(str(path)) as container:
+            stream = container.streams.video[0]
+            packets = [p for p in container.demux(stream) if p.pts is not None]
+        # B-frames are stored out of presentation order: dts != pts somewhere.
+        assert any(p.dts is not None and p.dts != p.pts for p in packets)
+        with av.open(str(path)) as container:
+            types = {
+                PictureType(int(f.pict_type)).name
+                for f in container.decode(container.streams.video[0])
+            }
+        assert "B" in types
+
+    @pytest.mark.parametrize("open_gop", [False, True])
+    def test_sparse_targets_long_clip(self, tmp_path, monkeypatch, open_gop):
+        path = tmp_path / "clip.mp4"
+        _write_h264_mp4(path, n_frames=200, open_gop=open_gop)  # 20s, 1.2s GOPs
+        self._assert_parity_seek_ran(
+            path, fps=2.0, min_frames=1, max_frames=4, monkeypatch=monkeypatch
+        )
+
+    @pytest.mark.parametrize("open_gop", [False, True])
+    def test_dense_targets_min_eq_max(self, tmp_path, monkeypatch, open_gop):
+        path = tmp_path / "clip.mp4"
+        _write_h264_mp4(path, n_frames=60, open_gop=open_gop)  # 6s
+        self._assert_parity_seek_ran(
+            path, fps=8.0, min_frames=16, max_frames=16, monkeypatch=monkeypatch
+        )
+
+    @pytest.mark.parametrize("open_gop", [False, True])
+    def test_explicit_targets_straddle_gop_boundaries(self, tmp_path, open_gop):
+        # Targets just after each keyframe time (keyint=12 @ 10fps -> 1.2s
+        # GOPs), where open-GOP leading B-frames sit; drives _decode_seek
+        # directly so a serial fallback cannot mask a divergence.
+        import av
+
+        from kempnerforge.data.video_io import _decode_seek, _decode_serial
+
+        path = tmp_path / "clip.mp4"
+        _write_h264_mp4(path, n_frames=120, open_gop=open_gop)
+        targets = [0.05, 2.45, 4.85, 7.25, 9.65, 11.9]
+
+        def _run(fn):
+            with av.open(str(path)) as container:
+                stream = container.streams.video[0]
+                stream.thread_type = "AUTO"
+                return fn(container, stream, list(targets))
+
+        got = _run(_decode_seek)
+        expected = _run(_decode_serial)
+        assert len(got) == len(expected)
+        assert [f.tobytes() for f in got] == [f.tobytes() for f in expected]
 
 
 @pytest.mark.skipif(not _AV_AVAILABLE, reason="requires the 'av' package")

--- a/tests/unit/test_video_io.py
+++ b/tests/unit/test_video_io.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import logging
 import os
 
 import pytest
@@ -311,9 +312,7 @@ class TestSeekMatchesSerial:
         self._assert_parity(dst, fps=2.0, min_frames=4, max_frames=8)
 
 
-@pytest.mark.skipif(
-    not _H264_AVAILABLE, reason="requires a PyAV build with the libx264 encoder"
-)
+@pytest.mark.skipif(not _H264_AVAILABLE, reason="requires a PyAV build with the libx264 encoder")
 class TestSeekMatchesSerialH264:
     """Parity on the codec shape of real data: H.264 with B-frames.
 
@@ -440,6 +439,61 @@ class TestSeekFallback:
         monkeypatch.setattr(video_io, "_decode_seek", _raise)
         got = video_io.decode_video_frames(str(path), fps=2.0, min_frames=4, max_frames=8)
         assert [f.tobytes() for f in got] == [f.tobytes() for f in expected]
+
+    def test_fallback_logged_once_per_cause(self, tmp_path, monkeypatch, caplog):
+        import kempnerforge.data.video_io as video_io
+
+        path = tmp_path / "clip.mp4"
+        _write_mp4(path, n_frames=40, gop_size=12)
+
+        def _raise(container, stream, targets):
+            raise video_io._SeekUnreliableError("test")
+
+        monkeypatch.setattr(video_io, "_decode_seek", _raise)
+        video_io._log_fallback_once.cache_clear()
+        with caplog.at_level(logging.DEBUG, logger="kempnerforge.data.video_io"):
+            for _ in range(3):
+                video_io.decode_video_frames(str(path), fps=2.0, min_frames=4, max_frames=8)
+        fallback_lines = [r for r in caplog.records if "falling back" in r.message]
+        assert len(fallback_lines) == 1
+
+    def test_fallback_reopen_without_video_stream_returns_empty(self, tmp_path, monkeypatch):
+        import av
+
+        import kempnerforge.data.video_io as video_io
+
+        path = tmp_path / "clip.mp4"
+        _write_mp4(path, n_frames=40, gop_size=12)
+
+        def _raise(container, stream, targets):
+            raise video_io._SeekUnreliableError("test")
+
+        # The second open (the fallback reopen) yields a container whose video
+        # stream has vanished — the guard must return [] rather than crash.
+        real_open = av.open
+        opens = {"n": 0}
+
+        class _NoVideoStreams:
+            video = ()
+
+        class _NoVideoContainer:
+            streams = _NoVideoStreams()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        def _flaky_open(p, *args, **kwargs):
+            opens["n"] += 1
+            if opens["n"] == 2:
+                return _NoVideoContainer()
+            return real_open(p, *args, **kwargs)
+
+        monkeypatch.setattr(video_io, "_decode_seek", _raise)
+        monkeypatch.setattr(av, "open", _flaky_open)
+        assert video_io.decode_video_frames(str(path), fps=2.0, min_frames=4, max_frames=8) == []
 
     def test_landing_check_raises_on_shifted_stream(self, tmp_path):
         import av


### PR DESCRIPTION
## Summary

`decode_video_frames` previously decoded every frame of a clip serially to extract $N$ sampled frames. It now seeks to the keyframe at or before each target timestamp and decodes forward only to that frame, so decode cost scales with frames *kept* rather than clip length. Any seek that cannot guarantee identical selection (no `time_base`, missing PTS, seek landing past its target, FFmpeg error) falls back to a single serial pass — the retained reference implementation — so seeking only ever changes speed, never output.

---

### Benchmarks

Frame-selection parity is byte-identical to serial in all cases below. Decode counts via an instrumented container; times single-threaded.

| Clip | serial | seek | speedup |
|---|---|---|---|
| Real WebVid H.264 clip (11.3s, 8 targets) | 282 frames / 128ms | 18 frames / 53ms | **15.7× fewer decodes** |
| Synthetic, 0.4s GOPs (WebVid-like), 8 tgts/12s | 120 | 20 | 6× |
| Synthetic, 3s GOPs (MLVU-like), 8 tgts/30s | 300 | 127 | 2.4× |
| MLVU end-to-end (prior measurement) | — | — | 11–22× |

**Known tradeoff:** dense sampling inside long GOPs re-decodes the GOP prefix per target (e.g. 5s GOPs with 16 targets/30s: 465 vs 300 serial). Real workloads sample sparsely relative to GOP size, so this doesn't occur there; if it shows up in profiling, the fix is a demux-pass keyframe planner, not a heuristic (a stateful-cursor variant was prototyped, benchmarked at zero gain on sparse workloads, and rejected).

## Testing
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run pyright kempnerforge/` passes
- [x] `uv run pytest tests/unit/ -v` passes (N tests, 0 failures)

Closes #171 
