### PR TITLE
Forward zero_grad to Muon's inner AdamW

### DIFF
--- a/kempnerforge/training/optimizer.py
+++ b/kempnerforge/training/optimizer.py
@@ -412,6 +412,16 @@ class Muon(torch.optim.Optimizer):
         if adam_state is not None and self._adam is not None:
             self._adam.load_state_dict(adam_state)
 
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        """Zero both Muon's own parameters and the inner AdamW's.
+
+        Only the Muon half is registered with the base class, so the inherited
+        ``zero_grad`` would leave every delegated parameter accumulating.
+        """
+        super().zero_grad(set_to_none=set_to_none)
+        if self._adam is not None:
+            self._adam.zero_grad(set_to_none=set_to_none)
+
     @torch.no_grad()
     def step(self, closure=None):
         loss = None

--- a/tests/unit/test_optimizer.py
+++ b/tests/unit/test_optimizer.py
@@ -305,6 +305,38 @@ class TestMuon:
         assert embedding.grad is not None, "set_to_none=False must keep the tensor"
         assert embedding.grad.abs().sum().item() == 0.0
 
+    def test_zero_grad_without_delegated_params(self):
+        """A model whose parameters are all Muon-eligible leaves _adam as None."""
+        torch.manual_seed(0)
+        model = nn.Linear(32, 32, bias=False)  # single 2D param, aspect ratio 1.0
+        optimizer = build_optimizer(model, OptimizerConfig(name="muon", lr=0.01))
+        assert optimizer._adam is None
+
+        model(torch.randn(4, 32)).sum().backward()
+        assert model.weight.grad is not None
+
+        optimizer.zero_grad()
+        assert model.weight.grad is None
+
+    def test_no_delegated_params_step_and_roundtrip(self):
+        """step/state_dict/load_state_dict must tolerate _adam being None."""
+        torch.manual_seed(0)
+        model = nn.Linear(32, 32, bias=False)
+        optimizer = build_optimizer(model, OptimizerConfig(name="muon", lr=0.01))
+        assert optimizer._adam is None
+
+        optimizer.zero_grad()
+        model(torch.randn(4, 32)).sum().backward()
+        optimizer.step()
+
+        sd = optimizer.state_dict()
+        assert "_adam_state" not in sd
+
+        model2 = nn.Linear(32, 32, bias=False)
+        optimizer2 = build_optimizer(model2, OptimizerConfig(name="muon", lr=0.01))
+        optimizer2.load_state_dict(sd)
+        assert optimizer2._adam is None
+
 
 class TestAdamW:
     def test_build_adamw(self):

--- a/tests/unit/test_optimizer.py
+++ b/tests/unit/test_optimizer.py
@@ -240,6 +240,71 @@ class TestMuon:
         adam_states = [s for s in optimizer2._adam.state.values() if s]
         assert len(adam_states) > 0, "Internal AdamW state was not restored"
 
+    def test_zero_grad_clears_delegated_params(self):
+        """Params routed to the inner AdamW must be zeroed too.
+
+        Only Muon's half is registered with the base class, so the inherited
+        zero_grad leaves everything delegated to _adam accumulating. The shape
+        matters: at an aspect ratio under 10 the embedding stays on Muon's side
+        and this passes even when the delegation is missing.
+        """
+        torch.manual_seed(0)
+        model = nn.Sequential(
+            nn.Embedding(32000, 64),  # aspect ratio 500:1 -> inner AdamW
+            nn.Linear(64, 64),
+        )
+        # lr tiny and no decay, so parameters barely move and the per-step
+        # gradient is constant unless it is accumulating.
+        config = OptimizerConfig(name="muon", lr=1e-12, weight_decay=0.0)
+        optimizer = build_optimizer(model, config)
+        embedding = model[0].weight
+        assert any(p is embedding for g in optimizer._adam.param_groups for p in g["params"]), (
+            "test needs the embedding on the AdamW side"
+        )
+
+        x = torch.randint(0, 32000, (8, 16))
+        grad_sums = []
+        for _ in range(3):
+            optimizer.zero_grad()
+            model(x).square().sum().backward()
+            grad_sums.append(embedding.grad.abs().sum().item())
+            optimizer.step()
+
+        torch.testing.assert_close(grad_sums[1], grad_sums[0], rtol=1e-5, atol=0.0)
+        torch.testing.assert_close(grad_sums[2], grad_sums[0], rtol=1e-5, atol=0.0)
+
+    def test_zero_grad_still_clears_muon_params(self):
+        """Regression guard: the Muon half must keep being zeroed."""
+        torch.manual_seed(0)
+        model = self._make_model()
+        optimizer = build_optimizer(model, OptimizerConfig(name="muon", lr=0.01))
+
+        x = torch.randn(8, 32)
+        nn.functional.cross_entropy(model(x), torch.randint(0, 10, (8,))).backward()
+        muon_params = [p for g in optimizer.param_groups for p in g["params"]]
+        assert all(p.grad is not None for p in muon_params)
+
+        optimizer.zero_grad()
+        assert all(p.grad is None for p in muon_params)
+
+    def test_zero_grad_forwards_set_to_none_false(self):
+        """set_to_none=False has to reach the inner AdamW, not just Muon."""
+        torch.manual_seed(0)
+        model = nn.Sequential(
+            nn.Embedding(32000, 64),
+            nn.Linear(64, 64),
+        )
+        optimizer = build_optimizer(model, OptimizerConfig(name="muon", lr=0.01))
+        embedding = model[0].weight
+
+        x = torch.randint(0, 32000, (8, 16))
+        model(x).square().sum().backward()
+        assert embedding.grad is not None
+
+        optimizer.zero_grad(set_to_none=False)
+        assert embedding.grad is not None, "set_to_none=False must keep the tensor"
+        assert embedding.grad.abs().sum().item() == 0.0
+
 
 class TestAdamW:
     def test_build_adamw(self):


### PR DESCRIPTION
## Summary

  `Muon` registers only its own half of the parameters with the base class
  (`optimizer.py:395`), so the inherited `zero_grad` never reached anything
  delegated to the inner AdamW and those gradients accumulated for the entire run,
  measured at 1x, 2x, 3x across three steps with the learning rate held near zero.
  The routing rule sends embeddings and output heads to AdamW on an aspect ratio
  above 10, so at the `configs/train/7b_16gpu_muon.toml` shape 1,050,939,392
  parameters were affected, roughly 13% of the model including its two largest
  tensors, silently and with no warning. `state_dict`, `load_state_dict` and `step`
  already delegate to `self._adam`; this adds the one missing forward plus three
  tests. The routing is shape-dependent, so the tests use a vocab-to-dim ratio
  above 10, because at a lower ratio the embedding stays on Muon's side and they
  pass on the unfixed tree.

## Testing
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors)
- [x] `uv run pytest tests/unit/ -v --timeout=60` passes
- [ ] If distributed code changed: `uv run torchrun --nproc_per_node=4 -m pytest tests/distributed/ -v`
- [x] If training loop / parallelism / optimizers changed: `uv run pytest tests/e2e/ --e2e -v`

Closes #182 
