### PR TITLE
 Add the missing [model] section to moe_small.toml

### DIFF
--- a/configs/model/moe_small.toml
+++ b/configs/model/moe_small.toml
@@ -1,4 +1,8 @@
-# Small MoE: ~1B active params, ~4B total (8 experts, top-2, all layers)
+# MoE reference architecture: ~2.9B active params, ~9.2B total
+# (8 experts, top-2, every layer). Used by convert_checkpoint.py for
+# DCP <-> HuggingFace conversion.
+
+[model]
 dim = 2048
 n_layers = 24
 n_heads = 16

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import random
 import sys
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -723,6 +724,23 @@ class TestTomlLoading:
         config = load_config("configs/train/7b.toml", cli_args=[])
         assert config.scheduler.name == SchedulerType.cosine
         assert isinstance(config.scheduler.name, SchedulerType)
+
+    @pytest.mark.parametrize(
+        "config_path",
+        sorted(str(p) for p in Path("configs").rglob("*.toml")),
+        ids=lambda p: str(p).replace("configs/", "").replace("/", ":"),
+    )
+    def test_shipped_config_loads(self, config_path):
+        """Every TOML under configs/ must load.
+
+        `configs/model/moe_small.toml` shipped without its `[model]` section
+        header and was unloadable from the day it was added, because no test
+        exercised the shipped presets. This sweeps all of them so the next one
+        cannot ship broken. Load only -- `validate()` needs a world size and is
+        covered separately.
+        """
+        config = load_config(config_path, cli_args=[])
+        assert config.model.dim > 0, f"{config_path} loaded but has no model dim"
 
     def test_missing_toml_raises(self):
         with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
## Summary

  - `configs/model/moe_small.toml` was missing its `[model]` header, so its 13 keys landed at the top level of `JobConfig` and were rejected with `Unknown config keys`. It is the only one of four model presets that fails to load.

## Testing
- [x] `uv run ruff check kempnerforge/ tests/` passes
- [x] `uv run ruff format --check kempnerforge/ tests/ scripts/` passes
- [x] `uv run pyright kempnerforge/` passes (0 errors)
- [x] `uv run pytest tests/unit/ -v --timeout=60` passes
- [x] If distributed code changed: `uv run torchrun --nproc_per_node=4 -m pytest tests/distributed/ -v`
- [ ] If training loop / parallelism / optimizers changed: `uv run pytest tests/e2e/ --e2e -v`
